### PR TITLE
Poetry's resolver fails due to overly-broad constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "safety-critical-rust-coding-guidelines"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<4"
 dependencies = [
     "builder",
     "sphinx>=8.2.3",


### PR DESCRIPTION
Ubuntu 24.04 (amd64), package poetry 2.1.1, installed using Python 3.12.3

On a fresh checkout, `poetry update` gives:

```
poetry update
Updating dependencies
Resolving dependencies... (2.0s)

The current project's supported Python range (>=3.12) is not compatible with some of the required packages Python requirement:
  - sphinx-needs requires Python <4,>=3.9, so it will not be installable for Python >=4

Because no versions of sphinx-needs match >5.1.0
 and sphinx-needs (5.1.0) requires Python <4,>=3.9, sphinx-needs is forbidden.
So, because safety-critical-rust-coding-guidelines depends on sphinx-needs (>=5.1.0), version solving failed.

  * Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties

    For sphinx-needs, a possible solution would be to set the `python` property to ">=3.12,<4"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers

```

It's silly, but this PR fixes it.