### PR TITLE
Use a local venv to allow self-modifying package installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 build/
+.venv

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+create = true
+in-project = true


### PR DESCRIPTION
Several of the python packages "self-modify" their own install(s), and when poetry uses a user-global-but-possibly-shared installation, that's not allowed.

The solution is to use a local `.venv` so local packages can go crazy with their installs.