### PR TITLE
[Sphinx Extension] Include PDF build from Sphinx LaTeX

### DIFF
--- a/builder/build_cli.py
+++ b/builder/build_cli.py
@@ -21,6 +21,8 @@ SPEC_CHECKSUM_URL = "https://spec.ferrocene.dev/paragraph-ids.json"
 SPEC_LOCKFILE = "spec.lock"
 
 def build_docs(root, builder, clear, serve, debug, spec_lock_consistency_check):
+    if builder == "pdf":
+        builder = "latex"
     dest = root / "build"
 
     args = ["-b", builder, "-d", dest / "doctrees"]
@@ -67,6 +69,12 @@ def build_docs(root, builder, clear, serve, debug, spec_lock_consistency_check):
             ],
             check=True,
         )
+        if builder == "latex":
+            subprocess.run(
+                ["make", "-C", str(dest / "latex"), "all-pdf"],
+                check=True
+            )
+            print(f"PDF generated at: {dest/'latex'}")
     except KeyboardInterrupt:
         exit(1)
     except subprocess.CalledProcessError:
@@ -132,7 +140,12 @@ def main(root):
         "--check-links", help="Check whether all links are valid", action="store_true"
     )
     group.add_argument(
-        "--xml", help="Generate Sphinx XML rather than HTML", action="store_true"
+        "--output",
+        help="select output format: html, xml, or pdf",
+        choices=["html", "xml", "pdf"],  
+        default="html",
+        metavar="FORMAT", 
+        required=False,   
     )
     group.add_argument(
         "--debug",
@@ -145,6 +158,6 @@ def main(root):
         update_spec_lockfile(SPEC_CHECKSUM_URL, root / "src" / SPEC_LOCKFILE)
 
     rendered = build_docs(
-        root, "xml" if args.xml else "html", args.clear, args.serve, args.debug, not args.ignore_spec_lock_diff
+        root, args.output, args.clear, args.serve, args.debug, not args.ignore_spec_lock_diff
     )
 

--- a/exts/coding_guidelines/__init__.py
+++ b/exts/coding_guidelines/__init__.py
@@ -6,10 +6,9 @@ from . import write_guidelines_ids
 from . import std_role
 from . import fls_linking
 
-from sphinx_needs.api import add_dynamic_function
 from sphinx.errors import SphinxError
 from sphinx.domains import Domain
-
+from docutils import nodes
 import logging
 
 # Get the Sphinx logger
@@ -33,8 +32,9 @@ class CodingGuidelinesDomain(Domain):
         pass  # No domain data to merge
 
 def setup(app):
-    
+
     app.add_domain(CodingGuidelinesDomain)
+    app.connect('env-check-consistency', fls_checks.check_fls)
     app.add_config_value(
         name="spec_std_docs_url",
         default="https://doc.rust-lang.org/stable/std",
@@ -48,7 +48,6 @@ def setup(app):
                          default=True,
                          rebuild='env')
 
-    app.connect('env-check-consistency', fls_checks.check_fls)
     app.connect('build-finished', write_guidelines_ids.build_finished)
     app.connect('build-finished', fls_linking.build_finished)
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -14,6 +14,7 @@ project = 'Safety-Critical Rust Coding Guidelines'
 copyright = '2025, Contributors to Coding Guidelines Subcommittee'
 author = 'Contributors to Coding Guidelines Subcommittee'
 release = '0.1'
+language = 'en'
 
 # -- General configuration ---------------------------------------------------
 
@@ -127,3 +128,24 @@ needs_extra_options = ["category", "recommendation", "fls", "decidability", "sco
 # Configure the theme
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
+
+# -- Options for LaTex output -------------------------------------------------
+latex_engine = 'xelatex'  # or 'pdflatex', 'lualatex'
+#latex_documents = [
+#    ('index', 'YourProject.tex', 'Your Project Title', 'Your Name', 'manual'),
+#]
+
+latex_toplevel_sectioning = 'section'
+latex_show_urls = 'footnote'  # or 'inline', 'no'
+latex_elements = {
+    'classoptions': ',openany,oneside',
+    'preamble': r'''
+    \usepackage[most]{tcolorbox}
+    \usepackage{xcolor}
+    \let\cleardoublepage\clearpage
+''',
+    'fontpkg': r'''
+\setmainfont{DejaVu Serif}
+''',
+    'figure_align': 'H',
+}


### PR DESCRIPTION
This is experimental at the moment, 
to generate PDFs from .rst files through Sphinx there are two approaches 
- First `rst2pdf`, it's more convinient but your control is very limited and often require direct modification to .rst files
- Second approach is the beloved LaTex, fine grained control.
the issue with customising the pdf through sphinx is the lack of documentation, learning curve, even the documentation itself is quite extensive, they really abused the word 'documentation', 
