### PR TITLE
Add read the docs PR build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  jobs:
+    create_environment:
+      # uv config from https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv
+       - asdf plugin add uv
+       - asdf install uv latest
+       - asdf global uv latest
+       - uv venv $READTHEDOCS_VIRTUALENV_PATH
+    install:
+       - uv sync
+    build:
+      html:
+        - uv run python make.py
+        - mkdir -p $READTHEDOCS_OUTPUT/html/
+        - cp -r build/html/* $READTHEDOCS_OUTPUT/html/
+


### PR DESCRIPTION
Hey @plaindocs -- FYI this is the PR you asked me open to the main repo.

@JoelMarcey --

The steps to follow are outlined on @plaindocs PR [over here](https://github.com/plaindocs/safety-critical-rust-coding-guidelines/pull/1) to get this repo setup for Read The Docs PR previews. Figured we'd want this to be done under the umbrella of credentials you'd own at the Rust Foundation.