### PR TITLE
Scaffolding: add function-like macros section in the guidelines

### DIFF
--- a/src/coding-guidelines/macros.rst
+++ b/src/coding-guidelines/macros.rst
@@ -90,6 +90,48 @@ Macros
             // Compliant implementation
         }
 
+.. guideline:: Shall not use Function-like Macros
+   :id: gui_WJlWqgIxmE8P
+   :category: mandatory
+   :status: draft
+   :release: todo
+   :fls: fls_utd3zqczix
+   :decidability: decidable
+   :scope: system
+   :tags: reduce-human-error
+
+   Description of the guideline goes here.
+
+   .. rationale::
+      :id: rat_C8RRidiVzhRj
+      :status: draft
+
+      Explanation of why this guideline is important.
+
+   .. non_compliant_example::
+      :id: non_compl_ex_TjRiRkmBY6wG
+      :status: draft
+
+      Explanation of code example.
+
+      .. code-block:: rust
+
+        fn example_function() {
+            // Non-compliant implementation
+        }
+
+   .. compliant_example::
+      :id: compl_ex_AEKEOYhBWPMl
+      :status: draft
+
+      Explanation of code example.
+
+      .. code-block:: rust
+
+        fn example_function() {
+            // Compliant implementation
+        }
+
 .. guideline:: Shall not invoke macros
    :id: gui_a1mHfjgKk4Xr
    :category: mandatory


### PR DESCRIPTION
Discussed in today's Coding Guidelines Subcommittee meeting. I took inspiration from #61.