### PR TITLE
Install typos GHA and fix typos

### DIFF
--- a/.github/workflows/build-guidelines.yml
+++ b/.github/workflows/build-guidelines.yml
@@ -76,3 +76,13 @@ jobs:
           path: build
           retention-days: 7
           compression-level: 6  # Default compression level for a good balance of speed and size
+  check_typos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install typos
+        run: cargo install typos-cli
+      - name: Check for typos
+        run: typos
+  

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,6 @@
+[default]
+extend-ignore-identifiers-re = [
+  # Ignore things that look like gui_xztNdXA2oFNB
+  "gui_.*",
+]
+

--- a/exts/coding_guidelines/README.rst
+++ b/exts/coding_guidelines/README.rst
@@ -18,13 +18,13 @@ Ferrocene Language Specification Conformance
 Various checks are performed against the ``:fls:`` option present in ``guideline`` directives to
 ensure they are valid.
 
-Coverage of the coding guidlines over the FLS is calculated.
+Coverage of the coding guidelines over the FLS is calculated.
 
 Each coding guideline has its ``:fls:`` option turned into a hyperlink to the corresponding element
 within the FLS to be able to navigate there directly.
 
 Further an ``spec.lock`` file located at ``root/src/spec.lock`` is validated against the currently
-deployed version of the Ferrocene Language Spec and the build is failed if there is discrepency.
+deployed version of the Ferrocene Language Spec and the build is failed if there is discrepancy.
 
 Links to the Rust standard library
 ==================================

--- a/src/coding-guidelines/macros.rst
+++ b/src/coding-guidelines/macros.rst
@@ -456,7 +456,7 @@ Macros
 
       The following is a macro which shows referring to a vector entity using a non-global path. Depending on
       where the macro is used a different `Vec` could be used than is intended. If scope where this is used
-      defines a struct `Vec` which is not preset at the macro defintion, the macro user might be intending to
+      defines a struct `Vec` which is not preset at the macro definition, the macro user might be intending to
       use that in the macro.
 
       .. code-block:: rust

--- a/src/process/style-guideline.rst
+++ b/src/process/style-guideline.rst
@@ -214,7 +214,7 @@ appropriate ``category``.
 
 These are guidelines for which no enforcement is expected and any non-compliance **MAY** be disregarded.
 
-*Note*: The ``retired`` ``status`` supercedes any ``category`` assigned a guideline, effectively
+*Note*: The ``retired`` ``status`` supersedes any ``category`` assigned a guideline, effectively
 conferring upon the guideline the ``category`` of ``disapplied`` with no ability to recategorize it
 to ``mandatory``, ``required``, or ``advisory``. The ``category`` assigned the guideline at the time
 it is retired is kept.


### PR DESCRIPTION
Chipping away at #34 here is a GitHub action which adds a [typo checker](https://github.com/crate-ci/typos) workflow in parallel, adds some minor configuration to avoid false positives, and finally fixes the few typos found.