### PR TITLE
Add CNAME to deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ jobs:
           ls build
           ls build/html
 
+      - name: Add CNAME to be able to be seen at coding-guidelines.arewesafetycriticalyet.org
+        run: |
+          echo "coding-guidelines.arewesafetycriticalyet.org" >> ./build/html/CNAME
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
So that the coding guidelines can be seen at coding-guidelines.arewesafetycriticalyet.org