### PR TITLE
[CI/auto-pr] Fix quote heredoc to prevent shell expansion

### DIFF
--- a/.github/workflows/auto-pr-on-issue.yml
+++ b/.github/workflows/auto-pr-on-issue.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Python script to generate guideline file
         run: |
-          cat <<EOF | uv run python scripts/auto-pr-helper.py --save
+          cat <<'EOF' | uv run python scripts/auto-pr-helper.py --save
           ${{ toJson(github.event.issue) }}
           EOF
 


### PR DESCRIPTION
This PR fixes an issue with improper quote escaping in the CI workflow that caused unexpected parsing behavior when passing the GitHub event issue payload to the Python script.
Before:
```bash
  cat <<EOF | uv run python scripts/auto-pr-helper.py --save
  ${{ toJson(github.event.issue) }}
  EOF
```
This version failed when the payload contained special characters or quotes.

 After:
  ```bash
cat <<'EOF' | uv run python scripts/auto-pr-helper.py --save
  ${{ toJson(github.event.issue) }}
  EOF
```
By quoting the here-document delimiter with single quotes (<<'EOF'), we ensure the payload is passed literally to the script, preserving all quote characters safely.

### Origin:

This was noticed in PR #159, it was missing the code section.

https://github.com/x0rw/safety-critical-rust-coding-guidelines/actions/runs/16647842314/job/47112691866

fixes #161 