### PR TITLE
[fix] remove build step at the end of auto-pr workflow

### DIFF
--- a/.github/workflows/auto-pr-on-issue.yml
+++ b/.github/workflows/auto-pr-on-issue.yml
@@ -50,6 +50,3 @@ jobs:
             **Authored by:** @${{ github.event.issue.user.login }}
 
             Closes #${{ github.event.issue.number }}.
-
-  build:
-    uses: ./.github/workflows/build-guidelines.yml


### PR DESCRIPTION
This wasn't the right way to fix the issue of the build workflow not being run.

See this issue for more on the right way and for follow-up: https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/164
