### PR TITLE
Fix typo in conf.py

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -102,8 +102,8 @@ needs_tags = [
     dict(name="undefined-behavior", description="Numerics-related guideline"),
     dict(name="stack-overflow", description="Stack-overflow-related guideline"),
 
-    dict(name="defect", description="Guideline associated with the language-subset profile"),
-    dict(name="subset", description="Guideline associated with the defect-prevention profile"),
+    dict(name="subset", description="Guideline associated with the language-subset profile"),
+    dict(name="defect", description="Guideline associated with the defect-prevention profile"),
 ]
 
 needs_categories = [


### PR DESCRIPTION
The `subset` and `defect` tags had their descriptions swapped with one another. Now they're all good :)