### PR TITLE
Issue formatting guide for Guideline Form

### DIFF
--- a/docs/issue-formatting-guide.md
+++ b/docs/issue-formatting-guide.md
@@ -1,7 +1,9 @@
 # Issue Formatting Guide
 
 ## Purpose
-This guide outlines our team's Markdown standards for writing issues and pull requests. We follow these rules to ensure our content converts cleanly from Markdown to reStructuredText (.rst) using the [m2r](https://pypi.org/project/m2r/) converter, which is then fed into Sphinx for documentation.
+This guide outlines Markdown standards when submitting a [Coding Guideline issue template](https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/new?template=CODING-GUIDELINE.yml).
+
+We follow these rules to ensure our content converts cleanly from Markdown to reStructuredText (.rst) when an Issue converted to a Pull Request. During that process the [m2r](https://pypi.org/project/m2r/) converter is used, which is then fed into Sphinx for documentation.
 
 ---
 


### PR DESCRIPTION
# Issue formatting guide for Guideline Form

You can also refer to https://pypi.org/project/m2r/ which is used to covert markdown to .rst, but note that "some" features will conflict with Sphinx.

Please let me know if anything is missing.

Closes #166