### PR TITLE
Ignore '*.egg-info' directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 build/
+*.egg-info/


### PR DESCRIPTION
When I build the docs, my `uv` installation creates a `builder/builder.egg-info` directory that needs to be ignored.