### PR TITLE
Fix typo in src/coding-guidelines/macros.rst (second attempt, now in-tree)

### DIFF
--- a/src/coding-guidelines/macros.rst
+++ b/src/coding-guidelines/macros.rst
@@ -479,7 +479,7 @@ Macros
       :status: draft
 
       The following is a macro refers to Vec using a global path. Even if there is a different struct called
-      `Vec` defined in the scope of the macro usage, this macro will unambigiously use the `Vec` from the
+      `Vec` defined in the scope of the macro usage, this macro will unambiguously use the `Vec` from the
       Standard Library.
 
       .. code-block:: rust


### PR DESCRIPTION
CC @plaindocs so that you can cherrypick