### PR TITLE
Add macOS to build docs; resolves #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you still need to install `uv` you can follow the [steps outlined](https://do
 
 You can build the rendered version by running:
 
-On Linux-like systems:
+On Linux-like and macOS systems:
 
 ```shell
    ./make.py


### PR DESCRIPTION
Adds macOS to the build instructions in README.md. I tested locally (M1 mac running macOS 15.6.1) and the `./make.py` command syntax worked as expected.

Addresses: https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/47