### PR TITLE
replaced integer overflow rule with strong typing rule

### DIFF
--- a/src/coding-guidelines/types-and-traits.rst
+++ b/src/coding-guidelines/types-and-traits.rst
@@ -65,8 +65,8 @@ Types and Traits
          }
 
          fn main() {
-            let d: u32 = 100_u32;
-            let t: u32 = 10_u32;
+            let d = 100;
+            let t = = 10;
             let _result = travel(t, d);  // Compiles, but semantically incorrect
          }
 


### PR DESCRIPTION
Integer overflow rule is obsolete as it was replaced by by this merged https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/pull/220 

Strong typing rule has been added