### PR TITLE
Update spec.lock, 3 guidelines related but not affected

### DIFF
--- a/src/spec.lock
+++ b/src/spec.lock
@@ -1,122 +1,227 @@
 {
     "documents": [
         {
+            "informational": true,
+            "link": "changelog.html",
+            "sections": [],
+            "title": "Changelog"
+        },
+        {
             "informational": false,
-            "link": "exceptions-and-errors.html",
+            "link": "concurrency.html",
             "sections": [
                 {
-                    "id": "fls_dzq9cdz4ibsz",
+                    "id": "fls_3v733mnewssy",
                     "informational": false,
-                    "link": "exceptions-and-errors.html",
-                    "number": "16",
+                    "link": "concurrency.html",
+                    "number": "17",
                     "paragraphs": [
                         {
-                            "checksum": "d0dadbee084de3030e81aaf2325ea8878e99a72e77800a2662c1fe290bbc9d62",
-                            "id": "fls_vsk4vhnuiyyz",
-                            "link": "exceptions-and-errors.html#fls_vsk4vhnuiyyz",
-                            "number": "16:1"
+                            "checksum": "58e23287dc1c3ffbe6b2c4672501d222916a129910befc8fadc364de5171c351",
+                            "id": "fls_opt7v0mopxc8",
+                            "link": "concurrency.html#fls_opt7v0mopxc8",
+                            "number": "17:1"
                         },
                         {
-                            "checksum": "f2e56f24b5565d180411f7693f63a3b70001ae9c0e4e605e1bd11ea5c207f968",
-                            "id": "fls_ebangxc36t74",
-                            "link": "exceptions-and-errors.html#fls_ebangxc36t74",
-                            "number": "16:2"
+                            "checksum": "60786d66db9926333e9768b0cc8aa490ff764f600fdbdb389912f9e85add0678",
+                            "id": "fls_tx4b8r6i93n4",
+                            "link": "concurrency.html#fls_tx4b8r6i93n4",
+                            "number": "17:2"
                         },
                         {
-                            "checksum": "1fd314e20308ba8d525a721f6a9bf050a337f71186510503044dc84efe09173e",
-                            "id": "fls_ckeitwiv326r",
-                            "link": "exceptions-and-errors.html#fls_ckeitwiv326r",
-                            "number": "16:3"
-                        },
-                        {
-                            "checksum": "b346390e8119d57549b96dcb345a29235552cdc69a61d7d2c8c883cf6d34ae61",
-                            "id": "fls_eg0orgibg98m",
-                            "link": "exceptions-and-errors.html#fls_eg0orgibg98m",
-                            "number": "16:4"
-                        },
-                        {
-                            "checksum": "83c2582339039d863409873a919aa3040ed86f444b3a5f5729e9fe0d65313c5e",
-                            "id": "fls_ko1x0gp9e7y3",
-                            "link": "exceptions-and-errors.html#fls_ko1x0gp9e7y3",
-                            "number": "16:5"
-                        },
-                        {
-                            "checksum": "475f3e3082b2760a32589c7540d5123f0459abea622ba1ae15aa53068c337d7b",
-                            "id": "fls_gwu4cn4ziabe",
-                            "link": "exceptions-and-errors.html#fls_gwu4cn4ziabe",
-                            "number": "16:6"
+                            "checksum": "5a06090908c3a726a0df6203b3e9f7c460c35609c758b6db09cf2d5c5c753c8e",
+                            "id": "fls_isypweqewe78",
+                            "link": "concurrency.html#fls_isypweqewe78",
+                            "number": "17:3"
                         }
                     ],
-                    "title": "Exceptions and Errors"
+                    "title": "Concurrency"
                 },
                 {
-                    "id": "fls_k02nt1m5fq1z",
+                    "id": "fls_eiw4by8z75di",
                     "informational": false,
-                    "link": "exceptions-and-errors.html#panic",
-                    "number": "16.1",
+                    "link": "concurrency.html#send-and-sync",
+                    "number": "17.1",
                     "paragraphs": [
                         {
-                            "checksum": "f4d500cf3ddd573cf21ec19b03d0e534bb8caa50bdf5d11eecd095eeaae539f2",
-                            "id": "fls_a554v4n0khye",
-                            "link": "exceptions-and-errors.html#fls_a554v4n0khye",
-                            "number": "16.1:1"
+                            "checksum": "18cfbb89a43fe476f2c0e5f3299b552fe8abafac2b759f081654338c7597f688",
+                            "id": "fls_n5l17mlglq11",
+                            "link": "concurrency.html#fls_n5l17mlglq11",
+                            "number": "17.1:1"
                         },
                         {
-                            "checksum": "d0ec8ad699ff1c4778bd35b0577f2de16559c4f7a8a67503e9d8b5ffb3feefe0",
-                            "id": "fls_i9njhpte5l0t",
-                            "link": "exceptions-and-errors.html#fls_i9njhpte5l0t",
-                            "number": "16.1:2"
+                            "checksum": "2c6d410f6594c15bcbb289be0b5a44ae8b19c478583342e5405aef3abbdb8951",
+                            "id": "fls_2jujsujpjp3w",
+                            "link": "concurrency.html#fls_2jujsujpjp3w",
+                            "number": "17.1:2"
                         },
                         {
-                            "checksum": "df2cd62113f2dc6ca452da3c12891fd958bc64f17397066b0a128c09a0fef520",
-                            "id": "fls_n6q7bksyn1m",
-                            "link": "exceptions-and-errors.html#fls_n6q7bksyn1m",
-                            "number": "16.1:3"
+                            "checksum": "11baae79e2b2bec1ba1dccff05f08bedf2b603f0b2748f345dafa59243aab72f",
+                            "id": "fls_cax6fe4em23k",
+                            "link": "concurrency.html#fls_cax6fe4em23k",
+                            "number": "17.1:3"
                         },
                         {
-                            "checksum": "7ce748762310bab19fffad785d50307098ea7d0e69ac336f7218ce22e6205dfa",
-                            "id": "fls_xmtt04lw517w",
-                            "link": "exceptions-and-errors.html#fls_xmtt04lw517w",
-                            "number": "16.1:4"
+                            "checksum": "14b867fe8baaef726910084c46d92291fffbfe3b462586c4a7ecd134f8152d96",
+                            "id": "fls_4ypqdehn7b0v",
+                            "link": "concurrency.html#fls_4ypqdehn7b0v",
+                            "number": "17.1:4"
+                        },
+                        {
+                            "checksum": "3e1f608593a27c63b70db641f71e71a331b116739b77b1bc9ce207481f0dd8be",
+                            "id": "fls_dekskhk4g895",
+                            "link": "concurrency.html#fls_dekskhk4g895",
+                            "number": "17.1:5"
+                        },
+                        {
+                            "checksum": "37c5ee82be489b2f1bd2eb9efdd02a9e9734ac2867c6bfc04f37f9877a9ab760",
+                            "id": "fls_y0iqr5ibnbfe",
+                            "link": "concurrency.html#fls_y0iqr5ibnbfe",
+                            "number": "17.1:6"
+                        },
+                        {
+                            "checksum": "a206190ea6bc9a6672886ed000599cd972f4abec22f754db4c4d9acbc6754a4c",
+                            "id": "fls_zgemofbs5q2x",
+                            "link": "concurrency.html#fls_zgemofbs5q2x",
+                            "number": "17.1:7"
                         }
                     ],
-                    "title": "Panic"
+                    "title": "Send and Sync"
                 },
                 {
-                    "id": "fls_hi1iz0gbnksi",
+                    "id": "fls_vyc9vcuamlph",
                     "informational": false,
-                    "link": "exceptions-and-errors.html#abort",
-                    "number": "16.2",
+                    "link": "concurrency.html#atomics",
+                    "number": "17.2",
                     "paragraphs": [
                         {
-                            "checksum": "7a15948904b2de411b7c6338a4b97095cd8046a23ef8462801fa784b9b75ba03",
-                            "id": "fls_9a1izu3omkbn",
-                            "link": "exceptions-and-errors.html#fls_9a1izu3omkbn",
-                            "number": "16.2:1"
+                            "checksum": "aca31f1758bf227f88cdd68e64370874768f51dd10e9211ec344537b1d7ba6cd",
+                            "id": "fls_3pjla9s93mhd",
+                            "link": "concurrency.html#fls_3pjla9s93mhd",
+                            "number": "17.2:1"
                         },
                         {
-                            "checksum": "890c034f6aea73b0142607337332d673a009ec8f47e288cd2cfdab3f5c91cee4",
-                            "id": "fls_iq6olct3rw4u",
-                            "link": "exceptions-and-errors.html#fls_iq6olct3rw4u",
-                            "number": "16.2:2"
+                            "checksum": "ce72ccfc2f3e59228fae42edd3521e8333bddb6951896be2347ec2387355262a",
+                            "id": "fls_wn4ynaio8u47",
+                            "link": "concurrency.html#fls_wn4ynaio8u47",
+                            "number": "17.2:2"
                         },
                         {
-                            "checksum": "77bbb6c647c37714e1fa9e1f81b3f63485155de50d4d371608e8f006a638a216",
-                            "id": "fls_wd2q6ft9yzrg",
-                            "link": "exceptions-and-errors.html#fls_wd2q6ft9yzrg",
-                            "number": "16.2:3"
+                            "checksum": "f04e33b2cedb200500a0733c23e46638bb219c9422ea4796905e57f57c0bc457",
+                            "id": "fls_q7mn6pdd8bix",
+                            "link": "concurrency.html#fls_q7mn6pdd8bix",
+                            "number": "17.2:3"
                         },
                         {
-                            "checksum": "b5c6b6bfc6de8e05e13b1fa486c385523fa6472c257f7c8c4b2b86ec91d6664f",
-                            "id": "fls_7bnrbjb0pq5n",
-                            "link": "exceptions-and-errors.html#fls_7bnrbjb0pq5n",
-                            "number": "16.2:4"
+                            "checksum": "fa9d632297e07c71321455d7ac82181279f4349b2878ed60e0088fb76453fa21",
+                            "id": "fls_jx0784jzxy00",
+                            "link": "concurrency.html#fls_jx0784jzxy00",
+                            "number": "17.2:4"
+                        },
+                        {
+                            "checksum": "17b8684e84e891ce119a119dcdf3b5cc1df0bd9132fc39002ef445333a7386cf",
+                            "id": "fls_vzuwnpx7mt08",
+                            "link": "concurrency.html#fls_vzuwnpx7mt08",
+                            "number": "17.2:5"
+                        },
+                        {
+                            "checksum": "3df9c673e62071885a6938566ce59609242470b1c63272f358bf5f999f2324fe",
+                            "id": "fls_cpcd0vexfbhj",
+                            "link": "concurrency.html#fls_cpcd0vexfbhj",
+                            "number": "17.2:6"
+                        },
+                        {
+                            "checksum": "9c9a349252f3cb141e008067381e5a19c45f3b1738132bfebc02583b25c36873",
+                            "id": "fls_jt7rfq9atbiv",
+                            "link": "concurrency.html#fls_jt7rfq9atbiv",
+                            "number": "17.2:7"
+                        },
+                        {
+                            "checksum": "72763ab828f9c57a7ba7ae57c095d30f4ef5bb34e5319df45f176f6570588e00",
+                            "id": "fls_2hqmfwswc6k",
+                            "link": "concurrency.html#fls_2hqmfwswc6k",
+                            "number": "17.2:8"
+                        },
+                        {
+                            "checksum": "051b06b8e012ef9e9c02369b0cb8074a99acd99781938a746c9de16fa2ce4dcd",
+                            "id": "fls_5ab2sw3gwmt3",
+                            "link": "concurrency.html#fls_5ab2sw3gwmt3",
+                            "number": "17.2:9"
+                        },
+                        {
+                            "checksum": "a8ab421b6894b056917c74396d9ac843c73dad27e12268a43fad03a877c8009c",
+                            "id": "fls_w2mw833g28eb",
+                            "link": "concurrency.html#fls_w2mw833g28eb",
+                            "number": "17.2:10"
+                        },
+                        {
+                            "checksum": "f182e5451b68bf0b4094178052d33c3a59b7d40c5282e4bf77de423b44b77f8d",
+                            "id": "fls_mjq1l1y0vmz4",
+                            "link": "concurrency.html#fls_mjq1l1y0vmz4",
+                            "number": "17.2:11"
+                        },
+                        {
+                            "checksum": "3b07334d52a95685b653abaecb58f071b99276e911b0f4bc4ab80cda4ef4ff1f",
+                            "id": "fls_906978wtss6n",
+                            "link": "concurrency.html#fls_906978wtss6n",
+                            "number": "17.2:12"
+                        },
+                        {
+                            "checksum": "5b5d7f2d72de32a5c8c9e36b4111885655abad9b351cd2bdd65dac06dcdf6660",
+                            "id": "fls_4urmnh4mfehl",
+                            "link": "concurrency.html#fls_4urmnh4mfehl",
+                            "number": "17.2:13"
+                        },
+                        {
+                            "checksum": "b14552f886fa68d1904ccff6320f2d395f90fee027a70f30588a9ba68a53b172",
+                            "id": "fls_2qkrcd5eovpe",
+                            "link": "concurrency.html#fls_2qkrcd5eovpe",
+                            "number": "17.2:14"
+                        },
+                        {
+                            "checksum": "1bf7e1661a0f7e7762a5549fe82988a4afbe4436720588214b9ad3857ecc02a7",
+                            "id": "fls_cry1e78gp19q",
+                            "link": "concurrency.html#fls_cry1e78gp19q",
+                            "number": "17.2:15"
                         }
                     ],
-                    "title": "Abort"
+                    "title": "Atomics"
+                },
+                {
+                    "id": "fls_mtuwzinpfvkl",
+                    "informational": false,
+                    "link": "concurrency.html#asynchronous-computation",
+                    "number": "17.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "dfbc3bd3bcdae5a3f76ab60f5c1fbcb25458c3975778746db7eea952015a2f79",
+                            "id": "fls_g40xp4andj5g",
+                            "link": "concurrency.html#fls_g40xp4andj5g",
+                            "number": "17.3:1"
+                        },
+                        {
+                            "checksum": "0a94602025c891b37d5f98e1ccd525f0cd66c06df02df85b06336668d0711cbe",
+                            "id": "fls_fte085hi1yqj",
+                            "link": "concurrency.html#fls_fte085hi1yqj",
+                            "number": "17.3:2"
+                        },
+                        {
+                            "checksum": "306a3b2eabc2ff31f77f6446060185578f9427fcc497d1588cb51a4c94ae4819",
+                            "id": "fls_7muubin2wn1v",
+                            "link": "concurrency.html#fls_7muubin2wn1v",
+                            "number": "17.3:3"
+                        },
+                        {
+                            "checksum": "d6389f23a8eff8343451429941d835b9e1b00fa45cf260112041467021172752",
+                            "id": "fls_ftzey2156ha",
+                            "link": "concurrency.html#fls_ftzey2156ha",
+                            "number": "17.3:4"
+                        }
+                    ],
+                    "title": "Asynchronous Computation"
                 }
             ],
-            "title": "Exceptions and Errors"
+            "title": "Concurrency"
         },
         {
             "informational": false,
@@ -243,27 +348,27 @@
                             "number": "13.2:4"
                         },
                         {
+                            "checksum": "6269ed848875ae982e4a9072782f1cfa3780e55c8ea94a205bbb145084c27786",
+                            "id": "fls_eOJS3mxa9xgu",
+                            "link": "attributes.html#fls_eOJS3mxa9xgu",
+                            "number": "13.2:5"
+                        },
+                        {
                             "checksum": "2f27a78e70b3ce7bcc2fa8fbd9d7e48bcf5f81303e22b4473c9ad67be8183e5c",
                             "id": "fls_q4c023zdsfgn",
                             "link": "attributes.html#fls_q4c023zdsfgn",
-                            "number": "13.2:5"
+                            "number": "13.2:6"
                         },
                         {
                             "checksum": "baed00b7e77547d373721bf0e05d646d88cb96ded2722b7505577f118cac0b81",
                             "id": "fls_xtu3p0kzwn7b",
                             "link": "attributes.html#fls_xtu3p0kzwn7b",
-                            "number": "13.2:6"
+                            "number": "13.2:7"
                         },
                         {
                             "checksum": "a1e7b39f6c99e32a187f228c19c2009de7fe6fdb93f751ce5336f2008300d9e9",
                             "id": "fls_gxxbf6eag3et",
                             "link": "attributes.html#fls_gxxbf6eag3et",
-                            "number": "13.2:7"
-                        },
-                        {
-                            "checksum": "6269ed848875ae982e4a9072782f1cfa3780e55c8ea94a205bbb145084c27786",
-                            "id": "fls_eOJS3mxa9xgu",
-                            "link": "attributes.html#fls_eOJS3mxa9xgu",
                             "number": "13.2:8"
                         },
                         {
@@ -327,33 +432,33 @@
                             "number": "13.2:18"
                         },
                         {
+                            "checksum": "a2d51f51657b328e4b3665e2f3a218dfe3cff69eb7b92a4c28eadc7343980475",
+                            "id": "fls_NrTL2FruARAv",
+                            "link": "attributes.html#fls_NrTL2FruARAv",
+                            "number": "13.2:19"
+                        },
+                        {
                             "checksum": "e79694d1fca990a102620dc1063eff04ea1dd5c1dfbe2141a22745bbe30aa92d",
                             "id": "fls_5ko0q9jnxv5a",
                             "link": "attributes.html#fls_5ko0q9jnxv5a",
-                            "number": "13.2:19"
+                            "number": "13.2:20"
                         },
                         {
                             "checksum": "e7a9d3069445027dd0df2d0ca2be3467b745bfedc8fda368fdea9ae8714a07b1",
                             "id": "fls_rgjf5ibhurda",
                             "link": "attributes.html#fls_rgjf5ibhurda",
-                            "number": "13.2:20"
-                        },
-                        {
-                            "checksum": "bdd154ea0f22fca637f51b6c83cb046352335e01a835e7578c6131621efacee3",
-                            "id": "fls_29y8icoou1gx",
-                            "link": "attributes.html#fls_29y8icoou1gx",
                             "number": "13.2:21"
-                        },
-                        {
-                            "checksum": "a2d51f51657b328e4b3665e2f3a218dfe3cff69eb7b92a4c28eadc7343980475",
-                            "id": "fls_NrTL2FruARAv",
-                            "link": "attributes.html#fls_NrTL2FruARAv",
-                            "number": "13.2:22"
                         },
                         {
                             "checksum": "876d87894c56c458cc8ab3b579b184d2e05b39c1d9795d16d057ce55b6efec98",
                             "id": "fls_4d2ArC50kNWL",
                             "link": "attributes.html#fls_4d2ArC50kNWL",
+                            "number": "13.2:22"
+                        },
+                        {
+                            "checksum": "bdd154ea0f22fca637f51b6c83cb046352335e01a835e7578c6131621efacee3",
+                            "id": "fls_29y8icoou1gx",
+                            "link": "attributes.html#fls_29y8icoou1gx",
                             "number": "13.2:23"
                         },
                         {
@@ -2429,256 +2534,6 @@
                 }
             ],
             "title": "FLS Background"
-        },
-        {
-            "informational": false,
-            "link": "associated-items.html",
-            "sections": [
-                {
-                    "id": "fls_l21tjqjkkaa0",
-                    "informational": false,
-                    "link": "associated-items.html",
-                    "number": "10",
-                    "paragraphs": [
-                        {
-                            "checksum": "c48bd96544b685d7b7a7e8a2e676eb1c8ed2066a485c20a48faa1c660ef8bdb7",
-                            "id": "fls_ckzd25qd213t",
-                            "link": "associated-items.html#fls_ckzd25qd213t",
-                            "number": "10:1"
-                        },
-                        {
-                            "checksum": "fd7bf7d0a40ad75d0809a98d1bd273b94708f4a26b1a3be16f7e8dbffbe638ec",
-                            "id": "fls_5y6ae0xqux57",
-                            "link": "associated-items.html#fls_5y6ae0xqux57",
-                            "number": "10:2"
-                        },
-                        {
-                            "checksum": "fda609cdbb71ae52c820019783b3b6858d633fdd6de601cfae585217aeb034aa",
-                            "id": "fls_lj7492aq7fzo",
-                            "link": "associated-items.html#fls_lj7492aq7fzo",
-                            "number": "10:3"
-                        },
-                        {
-                            "checksum": "d0a97d55dc69fb14de940c4597c8ec6cc4d1bdea2efef1f262ca235d4380a078",
-                            "id": "fls_8cz4rdrklaj4",
-                            "link": "associated-items.html#fls_8cz4rdrklaj4",
-                            "number": "10:4"
-                        },
-                        {
-                            "checksum": "a21d4472dc9edff52ba6084426735486e96547a9916ebbf6041810119a4ca7aa",
-                            "id": "fls_w8nu8suy7t5",
-                            "link": "associated-items.html#fls_w8nu8suy7t5",
-                            "number": "10:5"
-                        },
-                        {
-                            "checksum": "a5074f92b70f64ed6d002c08f65bfa91a814cf5b80b19137743ca62a12bda2b6",
-                            "id": "fls_wasocqdnuzd1",
-                            "link": "associated-items.html#fls_wasocqdnuzd1",
-                            "number": "10:6"
-                        },
-                        {
-                            "checksum": "61134011658677b475c3f8e65ac36ab5b479e0746afd064ac6d0084c0441fbb6",
-                            "id": "fls_PeD0DzjK57be",
-                            "link": "associated-items.html#fls_PeD0DzjK57be",
-                            "number": "10:7"
-                        },
-                        {
-                            "checksum": "0dd68e90f7962b7f3ab0d020e22ee6db5fde4efa6ae628af968af3fe3d76baa8",
-                            "id": "fls_3foYUch29ZtF",
-                            "link": "associated-items.html#fls_3foYUch29ZtF",
-                            "number": "10:8"
-                        },
-                        {
-                            "checksum": "6f1791ecd8b47dfbf50561704cc838d8b0e544cf7c69b576dd48120715a47166",
-                            "id": "fls_SnQc0zZS57Cz",
-                            "link": "associated-items.html#fls_SnQc0zZS57Cz",
-                            "number": "10:9"
-                        },
-                        {
-                            "checksum": "85d03d9e5ceb6390c1024e3f0079563e480155c17b687f8118d280be74b27d92",
-                            "id": "fls_6Z05BK2JSzpP",
-                            "link": "associated-items.html#fls_6Z05BK2JSzpP",
-                            "number": "10:10"
-                        },
-                        {
-                            "checksum": "1a672e4e07310314b3ed72804595330ecf46d9177808d67beee1497db38edc76",
-                            "id": "fls_AtItgS1UvwiX",
-                            "link": "associated-items.html#fls_AtItgS1UvwiX",
-                            "number": "10:11"
-                        },
-                        {
-                            "checksum": "f83c7a08c44f0dc091a19c1014f202ab5538474a3d818f1583bd138daef33ecf",
-                            "id": "fls_l3iwn56n1uz8",
-                            "link": "associated-items.html#fls_l3iwn56n1uz8",
-                            "number": "10:12"
-                        },
-                        {
-                            "checksum": "41db8d1e89a48299f2506f2fd5b398d24cc65ebba4aced317857a727822d1c4e",
-                            "id": "fls_4ftfefcotb4g",
-                            "link": "associated-items.html#fls_4ftfefcotb4g",
-                            "number": "10:13"
-                        },
-                        {
-                            "checksum": "66b5d7677a5542109bcd8f36408c3ed7ec1aca313c4c747fc28557fb2dd3c6c0",
-                            "id": "fls_qb5qpfe0uwk",
-                            "link": "associated-items.html#fls_qb5qpfe0uwk",
-                            "number": "10:14"
-                        },
-                        {
-                            "checksum": "96a142348655f7c0d311daed418fc24259286e2108efc574894af02cf2471c36",
-                            "id": "fls_1zlkeb6fz10j",
-                            "link": "associated-items.html#fls_1zlkeb6fz10j",
-                            "number": "10:15"
-                        },
-                        {
-                            "checksum": "b5024c3cf8ba9c9ff0e7a6bd05ae96c8f7c64599e2eaec349fae2ca6767f4bab",
-                            "id": "fls_tw8u0cc5867l",
-                            "link": "associated-items.html#fls_tw8u0cc5867l",
-                            "number": "10:16"
-                        },
-                        {
-                            "checksum": "a13634951f7946c3028793e284d6d7899f718840e70e5b30992ad30aa0b28a82",
-                            "id": "fls_bx7931x4155h",
-                            "link": "associated-items.html#fls_bx7931x4155h",
-                            "number": "10:17"
-                        },
-                        {
-                            "checksum": "8fb89c0b3f9ad0065b86652933686cc127a11676e7b59759588bf35bbe56a204",
-                            "id": "fls_bnTcCbDvdp94",
-                            "link": "associated-items.html#fls_bnTcCbDvdp94",
-                            "number": "10:18"
-                        },
-                        {
-                            "checksum": "22be2f18e00bb9e898293564455031809a4ffbdba44f030bff8af6c23ada5048",
-                            "id": "fls_N3cdn4lCZ2Bf",
-                            "link": "associated-items.html#fls_N3cdn4lCZ2Bf",
-                            "number": "10:19"
-                        },
-                        {
-                            "checksum": "9647e6f192f7a123a465887f651e66f32b17c903edd98aa87c48510b16acd40f",
-                            "id": "fls_x564isbhobym",
-                            "link": "associated-items.html#fls_x564isbhobym",
-                            "number": "10:20"
-                        },
-                        {
-                            "checksum": "d7e3897e8d4d866fe24ed708a542d480dd49b7432f4e1ab2b6e9f83e66beb79c",
-                            "id": "fls_b6nns7oqvdpm",
-                            "link": "associated-items.html#fls_b6nns7oqvdpm",
-                            "number": "10:21"
-                        },
-                        {
-                            "checksum": "f6efbcd47f77fb69c490956047b8fa92ddd13a1a56c2c82483cd10efd9f4abc8",
-                            "id": "fls_2TRwCz38kuRz",
-                            "link": "associated-items.html#fls_2TRwCz38kuRz",
-                            "number": "10:22"
-                        },
-                        {
-                            "checksum": "ef01e780fac2b6784fa9e17636be1c17d599f8831949c44ad35251b17052c1a3",
-                            "id": "fls_WnsVATJvUdza",
-                            "link": "associated-items.html#fls_WnsVATJvUdza",
-                            "number": "10:23"
-                        },
-                        {
-                            "checksum": "3b7142bcde18f322ffa41b2c57c18446ab40aa8a6612d601b48ec17273ad3d94",
-                            "id": "fls_yyhebj4qyk34",
-                            "link": "associated-items.html#fls_yyhebj4qyk34",
-                            "number": "10:24"
-                        },
-                        {
-                            "checksum": "53bc991f032b9bfaab3cb72189a8ae6d8772250cc7fbaefa3b80bbd25679141f",
-                            "id": "fls_kl9p3ycl5mzf",
-                            "link": "associated-items.html#fls_kl9p3ycl5mzf",
-                            "number": "10:25"
-                        },
-                        {
-                            "checksum": "6e869fbccfae9516ee3421a1571bd880ea5ec5dc5aedb65e32f5a6d2977b7955",
-                            "id": "fls_a5prbmuruma4",
-                            "link": "associated-items.html#fls_a5prbmuruma4",
-                            "number": "10:26"
-                        },
-                        {
-                            "checksum": "915d230d994ce8e745b1083bb75cb58b37ac8537af7fd5486a86d1314cb353d0",
-                            "id": "fls_vp2ov6ykueue",
-                            "link": "associated-items.html#fls_vp2ov6ykueue",
-                            "number": "10:27"
-                        },
-                        {
-                            "checksum": "338988e157f9ff9c04c5a8163cf72e90c0400a0e6ccb6b45e6f105a1b75ac855",
-                            "id": "fls_5uf74nvdm64o",
-                            "link": "associated-items.html#fls_5uf74nvdm64o",
-                            "number": "10:28"
-                        },
-                        {
-                            "checksum": "4e9d22ccfb80acfdb452f21eaa41d99e8b68d03dbf8ffcaca69016ad6b224e0c",
-                            "id": "fls_amWtS80fPtza",
-                            "link": "associated-items.html#fls_amWtS80fPtza",
-                            "number": "10:29"
-                        },
-                        {
-                            "checksum": "6b3108c40f22ac87f1e375b4907dc7e2565fc0fdb570d5e8e87d35f36da764fb",
-                            "id": "fls_Cu8FWrisrqz1",
-                            "link": "associated-items.html#fls_Cu8FWrisrqz1",
-                            "number": "10:30"
-                        },
-                        {
-                            "checksum": "c67bd6dc496b87f14e94eac06fb1dd53a785b33748660d90a3455b63b8f15dea",
-                            "id": "fls_oy92gzxgc273",
-                            "link": "associated-items.html#fls_oy92gzxgc273",
-                            "number": "10:31"
-                        },
-                        {
-                            "checksum": "1d3e0acf8e8b25427b6a4179ef6f36b9c9be2060806f8a4532c85d38970a854f",
-                            "id": "fls_WXnCWfJGoQx3",
-                            "link": "associated-items.html#fls_WXnCWfJGoQx3",
-                            "number": "10:32"
-                        },
-                        {
-                            "checksum": "f1864701261d89610bc085bf20379aabb9a7f867190c51deee3b5ab4e0731ab4",
-                            "id": "fls_OaszUw4IFobz",
-                            "link": "associated-items.html#fls_OaszUw4IFobz",
-                            "number": "10:33"
-                        },
-                        {
-                            "checksum": "a56737ff1c2a54b21dd0325776e037cb33b634928cad055fc83c168e8513e490",
-                            "id": "fls_Wd2FZRomB5yn",
-                            "link": "associated-items.html#fls_Wd2FZRomB5yn",
-                            "number": "10:34"
-                        },
-                        {
-                            "checksum": "8c0ecdddfa88a992b09009b5167f4dc68b5f53f241a872c2a1e85f8eb610f1e5",
-                            "id": "fls_lcEyToYIlcmf",
-                            "link": "associated-items.html#fls_lcEyToYIlcmf",
-                            "number": "10:35"
-                        },
-                        {
-                            "checksum": "2313193d9ba1cea774bf3d4a520130dc60870cdf9f64464a5745c228f3b647fa",
-                            "id": "fls_IKSPR7ZQMErU",
-                            "link": "associated-items.html#fls_IKSPR7ZQMErU",
-                            "number": "10:36"
-                        },
-                        {
-                            "checksum": "a9ddbf6bc0c06113d12f75ca1fe4401527ac5ff2a0384f375f53b2b7eedc084d",
-                            "id": "fls_oHxzyaiT7Qm6",
-                            "link": "associated-items.html#fls_oHxzyaiT7Qm6",
-                            "number": "10:37"
-                        },
-                        {
-                            "checksum": "17b593b8d0cb4dacc6eb9d143a7e49048a6708d07c811e2595e8cfbb89483827",
-                            "id": "fls_znfADVeOvXHD",
-                            "link": "associated-items.html#fls_znfADVeOvXHD",
-                            "number": "10:38"
-                        }
-                    ],
-                    "title": "Associated Items"
-                }
-            ],
-            "title": "Associated Items"
-        },
-        {
-            "informational": true,
-            "link": "changelog.html",
-            "sections": [],
-            "title": "Changelog"
         },
         {
             "informational": false,
@@ -5070,1478 +4925,365 @@
         },
         {
             "informational": false,
-            "link": "concurrency.html",
+            "link": "exceptions-and-errors.html",
             "sections": [
                 {
-                    "id": "fls_3v733mnewssy",
+                    "id": "fls_dzq9cdz4ibsz",
                     "informational": false,
-                    "link": "concurrency.html",
-                    "number": "17",
+                    "link": "exceptions-and-errors.html",
+                    "number": "16",
                     "paragraphs": [
                         {
-                            "checksum": "58e23287dc1c3ffbe6b2c4672501d222916a129910befc8fadc364de5171c351",
-                            "id": "fls_opt7v0mopxc8",
-                            "link": "concurrency.html#fls_opt7v0mopxc8",
-                            "number": "17:1"
+                            "checksum": "d0dadbee084de3030e81aaf2325ea8878e99a72e77800a2662c1fe290bbc9d62",
+                            "id": "fls_vsk4vhnuiyyz",
+                            "link": "exceptions-and-errors.html#fls_vsk4vhnuiyyz",
+                            "number": "16:1"
                         },
                         {
-                            "checksum": "60786d66db9926333e9768b0cc8aa490ff764f600fdbdb389912f9e85add0678",
-                            "id": "fls_tx4b8r6i93n4",
-                            "link": "concurrency.html#fls_tx4b8r6i93n4",
-                            "number": "17:2"
+                            "checksum": "f2e56f24b5565d180411f7693f63a3b70001ae9c0e4e605e1bd11ea5c207f968",
+                            "id": "fls_ebangxc36t74",
+                            "link": "exceptions-and-errors.html#fls_ebangxc36t74",
+                            "number": "16:2"
                         },
                         {
-                            "checksum": "5a06090908c3a726a0df6203b3e9f7c460c35609c758b6db09cf2d5c5c753c8e",
-                            "id": "fls_isypweqewe78",
-                            "link": "concurrency.html#fls_isypweqewe78",
-                            "number": "17:3"
+                            "checksum": "1fd314e20308ba8d525a721f6a9bf050a337f71186510503044dc84efe09173e",
+                            "id": "fls_ckeitwiv326r",
+                            "link": "exceptions-and-errors.html#fls_ckeitwiv326r",
+                            "number": "16:3"
+                        },
+                        {
+                            "checksum": "b346390e8119d57549b96dcb345a29235552cdc69a61d7d2c8c883cf6d34ae61",
+                            "id": "fls_eg0orgibg98m",
+                            "link": "exceptions-and-errors.html#fls_eg0orgibg98m",
+                            "number": "16:4"
+                        },
+                        {
+                            "checksum": "83c2582339039d863409873a919aa3040ed86f444b3a5f5729e9fe0d65313c5e",
+                            "id": "fls_ko1x0gp9e7y3",
+                            "link": "exceptions-and-errors.html#fls_ko1x0gp9e7y3",
+                            "number": "16:5"
+                        },
+                        {
+                            "checksum": "475f3e3082b2760a32589c7540d5123f0459abea622ba1ae15aa53068c337d7b",
+                            "id": "fls_gwu4cn4ziabe",
+                            "link": "exceptions-and-errors.html#fls_gwu4cn4ziabe",
+                            "number": "16:6"
                         }
                     ],
-                    "title": "Concurrency"
+                    "title": "Exceptions and Errors"
                 },
                 {
-                    "id": "fls_eiw4by8z75di",
+                    "id": "fls_k02nt1m5fq1z",
                     "informational": false,
-                    "link": "concurrency.html#send-and-sync",
-                    "number": "17.1",
+                    "link": "exceptions-and-errors.html#panic",
+                    "number": "16.1",
                     "paragraphs": [
                         {
-                            "checksum": "18cfbb89a43fe476f2c0e5f3299b552fe8abafac2b759f081654338c7597f688",
-                            "id": "fls_n5l17mlglq11",
-                            "link": "concurrency.html#fls_n5l17mlglq11",
-                            "number": "17.1:1"
+                            "checksum": "f4d500cf3ddd573cf21ec19b03d0e534bb8caa50bdf5d11eecd095eeaae539f2",
+                            "id": "fls_a554v4n0khye",
+                            "link": "exceptions-and-errors.html#fls_a554v4n0khye",
+                            "number": "16.1:1"
                         },
                         {
-                            "checksum": "2c6d410f6594c15bcbb289be0b5a44ae8b19c478583342e5405aef3abbdb8951",
-                            "id": "fls_2jujsujpjp3w",
-                            "link": "concurrency.html#fls_2jujsujpjp3w",
-                            "number": "17.1:2"
+                            "checksum": "d0ec8ad699ff1c4778bd35b0577f2de16559c4f7a8a67503e9d8b5ffb3feefe0",
+                            "id": "fls_i9njhpte5l0t",
+                            "link": "exceptions-and-errors.html#fls_i9njhpte5l0t",
+                            "number": "16.1:2"
                         },
                         {
-                            "checksum": "11baae79e2b2bec1ba1dccff05f08bedf2b603f0b2748f345dafa59243aab72f",
-                            "id": "fls_cax6fe4em23k",
-                            "link": "concurrency.html#fls_cax6fe4em23k",
-                            "number": "17.1:3"
+                            "checksum": "df2cd62113f2dc6ca452da3c12891fd958bc64f17397066b0a128c09a0fef520",
+                            "id": "fls_n6q7bksyn1m",
+                            "link": "exceptions-and-errors.html#fls_n6q7bksyn1m",
+                            "number": "16.1:3"
                         },
                         {
-                            "checksum": "14b867fe8baaef726910084c46d92291fffbfe3b462586c4a7ecd134f8152d96",
-                            "id": "fls_4ypqdehn7b0v",
-                            "link": "concurrency.html#fls_4ypqdehn7b0v",
-                            "number": "17.1:4"
-                        },
-                        {
-                            "checksum": "3e1f608593a27c63b70db641f71e71a331b116739b77b1bc9ce207481f0dd8be",
-                            "id": "fls_dekskhk4g895",
-                            "link": "concurrency.html#fls_dekskhk4g895",
-                            "number": "17.1:5"
-                        },
-                        {
-                            "checksum": "37c5ee82be489b2f1bd2eb9efdd02a9e9734ac2867c6bfc04f37f9877a9ab760",
-                            "id": "fls_y0iqr5ibnbfe",
-                            "link": "concurrency.html#fls_y0iqr5ibnbfe",
-                            "number": "17.1:6"
-                        },
-                        {
-                            "checksum": "a206190ea6bc9a6672886ed000599cd972f4abec22f754db4c4d9acbc6754a4c",
-                            "id": "fls_zgemofbs5q2x",
-                            "link": "concurrency.html#fls_zgemofbs5q2x",
-                            "number": "17.1:7"
+                            "checksum": "7ce748762310bab19fffad785d50307098ea7d0e69ac336f7218ce22e6205dfa",
+                            "id": "fls_xmtt04lw517w",
+                            "link": "exceptions-and-errors.html#fls_xmtt04lw517w",
+                            "number": "16.1:4"
                         }
                     ],
-                    "title": "Send and Sync"
+                    "title": "Panic"
                 },
                 {
-                    "id": "fls_vyc9vcuamlph",
+                    "id": "fls_hi1iz0gbnksi",
                     "informational": false,
-                    "link": "concurrency.html#atomics",
-                    "number": "17.2",
+                    "link": "exceptions-and-errors.html#abort",
+                    "number": "16.2",
                     "paragraphs": [
                         {
-                            "checksum": "aca31f1758bf227f88cdd68e64370874768f51dd10e9211ec344537b1d7ba6cd",
-                            "id": "fls_3pjla9s93mhd",
-                            "link": "concurrency.html#fls_3pjla9s93mhd",
-                            "number": "17.2:1"
+                            "checksum": "7a15948904b2de411b7c6338a4b97095cd8046a23ef8462801fa784b9b75ba03",
+                            "id": "fls_9a1izu3omkbn",
+                            "link": "exceptions-and-errors.html#fls_9a1izu3omkbn",
+                            "number": "16.2:1"
                         },
                         {
-                            "checksum": "ce72ccfc2f3e59228fae42edd3521e8333bddb6951896be2347ec2387355262a",
-                            "id": "fls_wn4ynaio8u47",
-                            "link": "concurrency.html#fls_wn4ynaio8u47",
-                            "number": "17.2:2"
+                            "checksum": "890c034f6aea73b0142607337332d673a009ec8f47e288cd2cfdab3f5c91cee4",
+                            "id": "fls_iq6olct3rw4u",
+                            "link": "exceptions-and-errors.html#fls_iq6olct3rw4u",
+                            "number": "16.2:2"
                         },
                         {
-                            "checksum": "f04e33b2cedb200500a0733c23e46638bb219c9422ea4796905e57f57c0bc457",
-                            "id": "fls_q7mn6pdd8bix",
-                            "link": "concurrency.html#fls_q7mn6pdd8bix",
-                            "number": "17.2:3"
+                            "checksum": "77bbb6c647c37714e1fa9e1f81b3f63485155de50d4d371608e8f006a638a216",
+                            "id": "fls_wd2q6ft9yzrg",
+                            "link": "exceptions-and-errors.html#fls_wd2q6ft9yzrg",
+                            "number": "16.2:3"
                         },
                         {
-                            "checksum": "fa9d632297e07c71321455d7ac82181279f4349b2878ed60e0088fb76453fa21",
-                            "id": "fls_jx0784jzxy00",
-                            "link": "concurrency.html#fls_jx0784jzxy00",
-                            "number": "17.2:4"
-                        },
-                        {
-                            "checksum": "17b8684e84e891ce119a119dcdf3b5cc1df0bd9132fc39002ef445333a7386cf",
-                            "id": "fls_vzuwnpx7mt08",
-                            "link": "concurrency.html#fls_vzuwnpx7mt08",
-                            "number": "17.2:5"
-                        },
-                        {
-                            "checksum": "3df9c673e62071885a6938566ce59609242470b1c63272f358bf5f999f2324fe",
-                            "id": "fls_cpcd0vexfbhj",
-                            "link": "concurrency.html#fls_cpcd0vexfbhj",
-                            "number": "17.2:6"
-                        },
-                        {
-                            "checksum": "9c9a349252f3cb141e008067381e5a19c45f3b1738132bfebc02583b25c36873",
-                            "id": "fls_jt7rfq9atbiv",
-                            "link": "concurrency.html#fls_jt7rfq9atbiv",
-                            "number": "17.2:7"
-                        },
-                        {
-                            "checksum": "72763ab828f9c57a7ba7ae57c095d30f4ef5bb34e5319df45f176f6570588e00",
-                            "id": "fls_2hqmfwswc6k",
-                            "link": "concurrency.html#fls_2hqmfwswc6k",
-                            "number": "17.2:8"
-                        },
-                        {
-                            "checksum": "051b06b8e012ef9e9c02369b0cb8074a99acd99781938a746c9de16fa2ce4dcd",
-                            "id": "fls_5ab2sw3gwmt3",
-                            "link": "concurrency.html#fls_5ab2sw3gwmt3",
-                            "number": "17.2:9"
-                        },
-                        {
-                            "checksum": "a8ab421b6894b056917c74396d9ac843c73dad27e12268a43fad03a877c8009c",
-                            "id": "fls_w2mw833g28eb",
-                            "link": "concurrency.html#fls_w2mw833g28eb",
-                            "number": "17.2:10"
-                        },
-                        {
-                            "checksum": "f182e5451b68bf0b4094178052d33c3a59b7d40c5282e4bf77de423b44b77f8d",
-                            "id": "fls_mjq1l1y0vmz4",
-                            "link": "concurrency.html#fls_mjq1l1y0vmz4",
-                            "number": "17.2:11"
-                        },
-                        {
-                            "checksum": "3b07334d52a95685b653abaecb58f071b99276e911b0f4bc4ab80cda4ef4ff1f",
-                            "id": "fls_906978wtss6n",
-                            "link": "concurrency.html#fls_906978wtss6n",
-                            "number": "17.2:12"
-                        },
-                        {
-                            "checksum": "5b5d7f2d72de32a5c8c9e36b4111885655abad9b351cd2bdd65dac06dcdf6660",
-                            "id": "fls_4urmnh4mfehl",
-                            "link": "concurrency.html#fls_4urmnh4mfehl",
-                            "number": "17.2:13"
-                        },
-                        {
-                            "checksum": "b14552f886fa68d1904ccff6320f2d395f90fee027a70f30588a9ba68a53b172",
-                            "id": "fls_2qkrcd5eovpe",
-                            "link": "concurrency.html#fls_2qkrcd5eovpe",
-                            "number": "17.2:14"
-                        },
-                        {
-                            "checksum": "1bf7e1661a0f7e7762a5549fe82988a4afbe4436720588214b9ad3857ecc02a7",
-                            "id": "fls_cry1e78gp19q",
-                            "link": "concurrency.html#fls_cry1e78gp19q",
-                            "number": "17.2:15"
+                            "checksum": "b5c6b6bfc6de8e05e13b1fa486c385523fa6472c257f7c8c4b2b86ec91d6664f",
+                            "id": "fls_7bnrbjb0pq5n",
+                            "link": "exceptions-and-errors.html#fls_7bnrbjb0pq5n",
+                            "number": "16.2:4"
                         }
                     ],
-                    "title": "Atomics"
-                },
-                {
-                    "id": "fls_mtuwzinpfvkl",
-                    "informational": false,
-                    "link": "concurrency.html#asynchronous-computation",
-                    "number": "17.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "dfbc3bd3bcdae5a3f76ab60f5c1fbcb25458c3975778746db7eea952015a2f79",
-                            "id": "fls_g40xp4andj5g",
-                            "link": "concurrency.html#fls_g40xp4andj5g",
-                            "number": "17.3:1"
-                        },
-                        {
-                            "checksum": "0a94602025c891b37d5f98e1ccd525f0cd66c06df02df85b06336668d0711cbe",
-                            "id": "fls_fte085hi1yqj",
-                            "link": "concurrency.html#fls_fte085hi1yqj",
-                            "number": "17.3:2"
-                        },
-                        {
-                            "checksum": "306a3b2eabc2ff31f77f6446060185578f9427fcc497d1588cb51a4c94ae4819",
-                            "id": "fls_7muubin2wn1v",
-                            "link": "concurrency.html#fls_7muubin2wn1v",
-                            "number": "17.3:3"
-                        },
-                        {
-                            "checksum": "d6389f23a8eff8343451429941d835b9e1b00fa45cf260112041467021172752",
-                            "id": "fls_ftzey2156ha",
-                            "link": "concurrency.html#fls_ftzey2156ha",
-                            "number": "17.3:4"
-                        }
-                    ],
-                    "title": "Asynchronous Computation"
+                    "title": "Abort"
                 }
             ],
-            "title": "Concurrency"
+            "title": "Exceptions and Errors"
         },
         {
             "informational": false,
-            "link": "macros.html",
+            "link": "associated-items.html",
             "sections": [
                 {
-                    "id": "fls_83182bfa9uqb",
+                    "id": "fls_l21tjqjkkaa0",
                     "informational": false,
-                    "link": "macros.html",
-                    "number": "20",
+                    "link": "associated-items.html",
+                    "number": "10",
                     "paragraphs": [
                         {
-                            "checksum": "23ad7afdee8d11ed607ec24d3a0e15437d673156ba4b127587b5669f1832653b",
-                            "id": "fls_j1jc83erljo0",
-                            "link": "macros.html#fls_j1jc83erljo0",
-                            "number": "20:1"
+                            "checksum": "c48bd96544b685d7b7a7e8a2e676eb1c8ed2066a485c20a48faa1c660ef8bdb7",
+                            "id": "fls_ckzd25qd213t",
+                            "link": "associated-items.html#fls_ckzd25qd213t",
+                            "number": "10:1"
                         },
                         {
-                            "checksum": "f3350d5be59f16503e8f202eed548f9142e23d0995f540a0fe8dbfa0790eb114",
-                            "id": "fls_23eapx3ckymf",
-                            "link": "macros.html#fls_23eapx3ckymf",
-                            "number": "20:2"
+                            "checksum": "fd7bf7d0a40ad75d0809a98d1bd273b94708f4a26b1a3be16f7e8dbffbe638ec",
+                            "id": "fls_5y6ae0xqux57",
+                            "link": "associated-items.html#fls_5y6ae0xqux57",
+                            "number": "10:2"
                         },
                         {
-                            "checksum": "b37827025945e3ebe09fb51af413ab507e55bef20cbd1cdc0d88bda1e5b31868",
-                            "id": "fls_a5uemz2hnbi8",
-                            "link": "macros.html#fls_a5uemz2hnbi8",
-                            "number": "20:3"
+                            "checksum": "fda609cdbb71ae52c820019783b3b6858d633fdd6de601cfae585217aeb034aa",
+                            "id": "fls_lj7492aq7fzo",
+                            "link": "associated-items.html#fls_lj7492aq7fzo",
+                            "number": "10:3"
                         },
                         {
-                            "checksum": "f947401b4192d1cb447cdbc6dfa662250896c68e1cb0477bdfdbc7dfaf9b809c",
-                            "id": "fls_rnty1c8l5495",
-                            "link": "macros.html#fls_rnty1c8l5495",
-                            "number": "20:4"
+                            "checksum": "d0a97d55dc69fb14de940c4597c8ec6cc4d1bdea2efef1f262ca235d4380a078",
+                            "id": "fls_8cz4rdrklaj4",
+                            "link": "associated-items.html#fls_8cz4rdrklaj4",
+                            "number": "10:4"
+                        },
+                        {
+                            "checksum": "a21d4472dc9edff52ba6084426735486e96547a9916ebbf6041810119a4ca7aa",
+                            "id": "fls_w8nu8suy7t5",
+                            "link": "associated-items.html#fls_w8nu8suy7t5",
+                            "number": "10:5"
+                        },
+                        {
+                            "checksum": "a5074f92b70f64ed6d002c08f65bfa91a814cf5b80b19137743ca62a12bda2b6",
+                            "id": "fls_wasocqdnuzd1",
+                            "link": "associated-items.html#fls_wasocqdnuzd1",
+                            "number": "10:6"
+                        },
+                        {
+                            "checksum": "61134011658677b475c3f8e65ac36ab5b479e0746afd064ac6d0084c0441fbb6",
+                            "id": "fls_PeD0DzjK57be",
+                            "link": "associated-items.html#fls_PeD0DzjK57be",
+                            "number": "10:7"
+                        },
+                        {
+                            "checksum": "0dd68e90f7962b7f3ab0d020e22ee6db5fde4efa6ae628af968af3fe3d76baa8",
+                            "id": "fls_3foYUch29ZtF",
+                            "link": "associated-items.html#fls_3foYUch29ZtF",
+                            "number": "10:8"
+                        },
+                        {
+                            "checksum": "6f1791ecd8b47dfbf50561704cc838d8b0e544cf7c69b576dd48120715a47166",
+                            "id": "fls_SnQc0zZS57Cz",
+                            "link": "associated-items.html#fls_SnQc0zZS57Cz",
+                            "number": "10:9"
+                        },
+                        {
+                            "checksum": "85d03d9e5ceb6390c1024e3f0079563e480155c17b687f8118d280be74b27d92",
+                            "id": "fls_6Z05BK2JSzpP",
+                            "link": "associated-items.html#fls_6Z05BK2JSzpP",
+                            "number": "10:10"
+                        },
+                        {
+                            "checksum": "1a672e4e07310314b3ed72804595330ecf46d9177808d67beee1497db38edc76",
+                            "id": "fls_AtItgS1UvwiX",
+                            "link": "associated-items.html#fls_AtItgS1UvwiX",
+                            "number": "10:11"
+                        },
+                        {
+                            "checksum": "f83c7a08c44f0dc091a19c1014f202ab5538474a3d818f1583bd138daef33ecf",
+                            "id": "fls_l3iwn56n1uz8",
+                            "link": "associated-items.html#fls_l3iwn56n1uz8",
+                            "number": "10:12"
+                        },
+                        {
+                            "checksum": "41db8d1e89a48299f2506f2fd5b398d24cc65ebba4aced317857a727822d1c4e",
+                            "id": "fls_4ftfefcotb4g",
+                            "link": "associated-items.html#fls_4ftfefcotb4g",
+                            "number": "10:13"
+                        },
+                        {
+                            "checksum": "66b5d7677a5542109bcd8f36408c3ed7ec1aca313c4c747fc28557fb2dd3c6c0",
+                            "id": "fls_qb5qpfe0uwk",
+                            "link": "associated-items.html#fls_qb5qpfe0uwk",
+                            "number": "10:14"
+                        },
+                        {
+                            "checksum": "96a142348655f7c0d311daed418fc24259286e2108efc574894af02cf2471c36",
+                            "id": "fls_1zlkeb6fz10j",
+                            "link": "associated-items.html#fls_1zlkeb6fz10j",
+                            "number": "10:15"
+                        },
+                        {
+                            "checksum": "b5024c3cf8ba9c9ff0e7a6bd05ae96c8f7c64599e2eaec349fae2ca6767f4bab",
+                            "id": "fls_tw8u0cc5867l",
+                            "link": "associated-items.html#fls_tw8u0cc5867l",
+                            "number": "10:16"
+                        },
+                        {
+                            "checksum": "a13634951f7946c3028793e284d6d7899f718840e70e5b30992ad30aa0b28a82",
+                            "id": "fls_bx7931x4155h",
+                            "link": "associated-items.html#fls_bx7931x4155h",
+                            "number": "10:17"
+                        },
+                        {
+                            "checksum": "8fb89c0b3f9ad0065b86652933686cc127a11676e7b59759588bf35bbe56a204",
+                            "id": "fls_bnTcCbDvdp94",
+                            "link": "associated-items.html#fls_bnTcCbDvdp94",
+                            "number": "10:18"
+                        },
+                        {
+                            "checksum": "22be2f18e00bb9e898293564455031809a4ffbdba44f030bff8af6c23ada5048",
+                            "id": "fls_N3cdn4lCZ2Bf",
+                            "link": "associated-items.html#fls_N3cdn4lCZ2Bf",
+                            "number": "10:19"
+                        },
+                        {
+                            "checksum": "9647e6f192f7a123a465887f651e66f32b17c903edd98aa87c48510b16acd40f",
+                            "id": "fls_x564isbhobym",
+                            "link": "associated-items.html#fls_x564isbhobym",
+                            "number": "10:20"
+                        },
+                        {
+                            "checksum": "d7e3897e8d4d866fe24ed708a542d480dd49b7432f4e1ab2b6e9f83e66beb79c",
+                            "id": "fls_b6nns7oqvdpm",
+                            "link": "associated-items.html#fls_b6nns7oqvdpm",
+                            "number": "10:21"
+                        },
+                        {
+                            "checksum": "f6efbcd47f77fb69c490956047b8fa92ddd13a1a56c2c82483cd10efd9f4abc8",
+                            "id": "fls_2TRwCz38kuRz",
+                            "link": "associated-items.html#fls_2TRwCz38kuRz",
+                            "number": "10:22"
+                        },
+                        {
+                            "checksum": "ef01e780fac2b6784fa9e17636be1c17d599f8831949c44ad35251b17052c1a3",
+                            "id": "fls_WnsVATJvUdza",
+                            "link": "associated-items.html#fls_WnsVATJvUdza",
+                            "number": "10:23"
+                        },
+                        {
+                            "checksum": "3b7142bcde18f322ffa41b2c57c18446ab40aa8a6612d601b48ec17273ad3d94",
+                            "id": "fls_yyhebj4qyk34",
+                            "link": "associated-items.html#fls_yyhebj4qyk34",
+                            "number": "10:24"
+                        },
+                        {
+                            "checksum": "53bc991f032b9bfaab3cb72189a8ae6d8772250cc7fbaefa3b80bbd25679141f",
+                            "id": "fls_kl9p3ycl5mzf",
+                            "link": "associated-items.html#fls_kl9p3ycl5mzf",
+                            "number": "10:25"
+                        },
+                        {
+                            "checksum": "6e869fbccfae9516ee3421a1571bd880ea5ec5dc5aedb65e32f5a6d2977b7955",
+                            "id": "fls_a5prbmuruma4",
+                            "link": "associated-items.html#fls_a5prbmuruma4",
+                            "number": "10:26"
+                        },
+                        {
+                            "checksum": "915d230d994ce8e745b1083bb75cb58b37ac8537af7fd5486a86d1314cb353d0",
+                            "id": "fls_vp2ov6ykueue",
+                            "link": "associated-items.html#fls_vp2ov6ykueue",
+                            "number": "10:27"
+                        },
+                        {
+                            "checksum": "338988e157f9ff9c04c5a8163cf72e90c0400a0e6ccb6b45e6f105a1b75ac855",
+                            "id": "fls_5uf74nvdm64o",
+                            "link": "associated-items.html#fls_5uf74nvdm64o",
+                            "number": "10:28"
+                        },
+                        {
+                            "checksum": "4e9d22ccfb80acfdb452f21eaa41d99e8b68d03dbf8ffcaca69016ad6b224e0c",
+                            "id": "fls_amWtS80fPtza",
+                            "link": "associated-items.html#fls_amWtS80fPtza",
+                            "number": "10:29"
+                        },
+                        {
+                            "checksum": "6b3108c40f22ac87f1e375b4907dc7e2565fc0fdb570d5e8e87d35f36da764fb",
+                            "id": "fls_Cu8FWrisrqz1",
+                            "link": "associated-items.html#fls_Cu8FWrisrqz1",
+                            "number": "10:30"
+                        },
+                        {
+                            "checksum": "c67bd6dc496b87f14e94eac06fb1dd53a785b33748660d90a3455b63b8f15dea",
+                            "id": "fls_oy92gzxgc273",
+                            "link": "associated-items.html#fls_oy92gzxgc273",
+                            "number": "10:31"
+                        },
+                        {
+                            "checksum": "1d3e0acf8e8b25427b6a4179ef6f36b9c9be2060806f8a4532c85d38970a854f",
+                            "id": "fls_WXnCWfJGoQx3",
+                            "link": "associated-items.html#fls_WXnCWfJGoQx3",
+                            "number": "10:32"
+                        },
+                        {
+                            "checksum": "f1864701261d89610bc085bf20379aabb9a7f867190c51deee3b5ab4e0731ab4",
+                            "id": "fls_OaszUw4IFobz",
+                            "link": "associated-items.html#fls_OaszUw4IFobz",
+                            "number": "10:33"
+                        },
+                        {
+                            "checksum": "a56737ff1c2a54b21dd0325776e037cb33b634928cad055fc83c168e8513e490",
+                            "id": "fls_Wd2FZRomB5yn",
+                            "link": "associated-items.html#fls_Wd2FZRomB5yn",
+                            "number": "10:34"
+                        },
+                        {
+                            "checksum": "8c0ecdddfa88a992b09009b5167f4dc68b5f53f241a872c2a1e85f8eb610f1e5",
+                            "id": "fls_lcEyToYIlcmf",
+                            "link": "associated-items.html#fls_lcEyToYIlcmf",
+                            "number": "10:35"
+                        },
+                        {
+                            "checksum": "2313193d9ba1cea774bf3d4a520130dc60870cdf9f64464a5745c228f3b647fa",
+                            "id": "fls_IKSPR7ZQMErU",
+                            "link": "associated-items.html#fls_IKSPR7ZQMErU",
+                            "number": "10:36"
+                        },
+                        {
+                            "checksum": "a9ddbf6bc0c06113d12f75ca1fe4401527ac5ff2a0384f375f53b2b7eedc084d",
+                            "id": "fls_oHxzyaiT7Qm6",
+                            "link": "associated-items.html#fls_oHxzyaiT7Qm6",
+                            "number": "10:37"
+                        },
+                        {
+                            "checksum": "17b593b8d0cb4dacc6eb9d143a7e49048a6708d07c811e2595e8cfbb89483827",
+                            "id": "fls_znfADVeOvXHD",
+                            "link": "associated-items.html#fls_znfADVeOvXHD",
+                            "number": "10:38"
                         }
                     ],
-                    "title": "Macros"
-                },
-                {
-                    "id": "fls_xa7lp0zg1ol2",
-                    "informational": false,
-                    "link": "macros.html#declarative-macros",
-                    "number": "20.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "8cffdd9962e92466f819713aab704c780ae0d98dac229021c576afa2742830ba",
-                            "id": "fls_ikzjsq8heyk6",
-                            "link": "macros.html#fls_ikzjsq8heyk6",
-                            "number": "20.1:1"
-                        },
-                        {
-                            "checksum": "4e9e7f12e6633dbb05180c17c6a222b11c2760152ee1a091050e70af0a2f4238",
-                            "id": "fls_w44hav7mw3ao",
-                            "link": "macros.html#fls_w44hav7mw3ao",
-                            "number": "20.1:2"
-                        },
-                        {
-                            "checksum": "af67fc9d046886fb7c793c0a9eef775cd020529cf8ec85a93167f1e58f4122fa",
-                            "id": "fls_dw1nq4r9ghhd",
-                            "link": "macros.html#fls_dw1nq4r9ghhd",
-                            "number": "20.1:3"
-                        },
-                        {
-                            "checksum": "13beaa609262aa0b7e0b3212da54ac78e68086106c14cc11e081e7132158286b",
-                            "id": "fls_oq4xn8guos8f",
-                            "link": "macros.html#fls_oq4xn8guos8f",
-                            "number": "20.1:4"
-                        },
-                        {
-                            "checksum": "b549b18e6de60d1ec130ab38737806e6ea0cbd0d471501c476916eefe2be7228",
-                            "id": "fls_cdaf8viwmdfe",
-                            "link": "macros.html#fls_cdaf8viwmdfe",
-                            "number": "20.1:5"
-                        },
-                        {
-                            "checksum": "238647cd9313b6607667d9993c8bf87f5406351bd4a87045bd0850f5063f6b84",
-                            "id": "fls_ljavs0w61z3j",
-                            "link": "macros.html#fls_ljavs0w61z3j",
-                            "number": "20.1:6"
-                        },
-                        {
-                            "checksum": "41d7cadc4529963b5fae05cea05d12721cc023eac8db3ab3013c78712f677f92",
-                            "id": "fls_3jspk8obv7sd",
-                            "link": "macros.html#fls_3jspk8obv7sd",
-                            "number": "20.1:7"
-                        }
-                    ],
-                    "title": "Declarative Macros"
-                },
-                {
-                    "id": "fls_8nzypdu9j3ge",
-                    "informational": false,
-                    "link": "macros.html#metavariables",
-                    "number": "20.1.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "142bdc43ec20b9deed884f97e167a2a47e1cd8cab76ba4b6a81e5b3ec56b69ea",
-                            "id": "fls_g93r3teei8wo",
-                            "link": "macros.html#fls_g93r3teei8wo",
-                            "number": "20.1.1:1"
-                        },
-                        {
-                            "checksum": "260a8af1053ab13b37c8171151aec029a2b0049a4db4d2fa4c072391caa7c788",
-                            "id": "fls_4zdait30exvn",
-                            "link": "macros.html#fls_4zdait30exvn",
-                            "number": "20.1.1:2"
-                        },
-                        {
-                            "checksum": "0e475930b62b5e6e2c4eaa5d954c01002c3918fb1243f5ffd3b8b5959e5350f0",
-                            "id": "fls_2HguXbL7DjKH",
-                            "link": "macros.html#fls_2HguXbL7DjKH",
-                            "number": "20.1.1:3"
-                        },
-                        {
-                            "checksum": "e16b11f619d14521da5d28556e2228fd055de524ae57da0397dc5fb7f244b522",
-                            "id": "fls_8zypylq60zba",
-                            "link": "macros.html#fls_8zypylq60zba",
-                            "number": "20.1.1:4"
-                        },
-                        {
-                            "checksum": "a7305e4a6c0db284c01d3b766c9526e183f139d0d6b3417b05a0a25448deb2e1",
-                            "id": "fls_8o9mcV2KrKac",
-                            "link": "macros.html#fls_8o9mcV2KrKac",
-                            "number": "20.1.1:5"
-                        },
-                        {
-                            "checksum": "bbdb87195b02f153c61cd395d1d5db4690ef89af595efddbf90e07037c6d88fd",
-                            "id": "fls_PxR9vNHsaFnI",
-                            "link": "macros.html#fls_PxR9vNHsaFnI",
-                            "number": "20.1.1:6"
-                        },
-                        {
-                            "checksum": "db57f38586128d0f797f87a3bec37a62e9bc1ffe1a0b5b3634c97bbbd3c3a923",
-                            "id": "fls_ePyoTeJJ11N0",
-                            "link": "macros.html#fls_ePyoTeJJ11N0",
-                            "number": "20.1.1:7"
-                        },
-                        {
-                            "checksum": "5ab36e5b8b233c50fbb634f2ddb85db4a65676e58884c4e545002ad8ae792716",
-                            "id": "fls_0j7VOV4ewfeY",
-                            "link": "macros.html#fls_0j7VOV4ewfeY",
-                            "number": "20.1.1:8"
-                        },
-                        {
-                            "checksum": "7e4c3dc1c34fcadf4bb70df2a2ca55cb16019fe78a19c5f625a3407c7f23de0c",
-                            "id": "fls_80cOMpIMU2gx",
-                            "link": "macros.html#fls_80cOMpIMU2gx",
-                            "number": "20.1.1:9"
-                        },
-                        {
-                            "checksum": "ae189445a188e528fc320b0716648ea260e44624143f233a7a3d6594c319fc71",
-                            "id": "fls_DFMRwsWI8e5z",
-                            "link": "macros.html#fls_DFMRwsWI8e5z",
-                            "number": "20.1.1:10"
-                        },
-                        {
-                            "checksum": "3a94c395e86b915f016782c8e832229ac77ff7d26c4468f604f4d1346d410385",
-                            "id": "fls_BoIGgrFdyhwH",
-                            "link": "macros.html#fls_BoIGgrFdyhwH",
-                            "number": "20.1.1:11"
-                        },
-                        {
-                            "checksum": "10fac2b91182e4a802d41382e138eeea01e0169f14fd98576dec0541757d3d52",
-                            "id": "fls_NBbygZwUxjFp",
-                            "link": "macros.html#fls_NBbygZwUxjFp",
-                            "number": "20.1.1:12"
-                        },
-                        {
-                            "checksum": "a397be8475f298d03d342d1d7922a7addc7c4e01708dbc748271e89ff6e4e91a",
-                            "id": "fls_lZ8F1zUJju33",
-                            "link": "macros.html#fls_lZ8F1zUJju33",
-                            "number": "20.1.1:13"
-                        },
-                        {
-                            "checksum": "6d1e723dc52e63b247ff2a9f36fd2a2448c78a8a6c0785d9bc962cbf164a68ff",
-                            "id": "fls_ephlmLsGTMgw",
-                            "link": "macros.html#fls_ephlmLsGTMgw",
-                            "number": "20.1.1:14"
-                        }
-                    ],
-                    "title": "Metavariables"
-                },
-                {
-                    "id": "fls_k01lsksqtq1r",
-                    "informational": false,
-                    "link": "macros.html#repetition",
-                    "number": "20.1.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "9be00a29faba4cce56b85af749378910166a176caaf783feb7f21917b113f4fc",
-                            "id": "fls_4ps4x4513xau",
-                            "link": "macros.html#fls_4ps4x4513xau",
-                            "number": "20.1.2:1"
-                        },
-                        {
-                            "checksum": "0afa98bdb2bc52d07887d1af628eba5846e5110da9bf813ba1906139eba01c98",
-                            "id": "fls_8byjmlgum2f3",
-                            "link": "macros.html#fls_8byjmlgum2f3",
-                            "number": "20.1.2:2"
-                        },
-                        {
-                            "checksum": "43358f7409e5fcf8e712e18e535f05897041a0c7ee20dc9c07eaae0a6a5b463c",
-                            "id": "fls_ltdp3zs60dzr",
-                            "link": "macros.html#fls_ltdp3zs60dzr",
-                            "number": "20.1.2:3"
-                        },
-                        {
-                            "checksum": "fb90822182dbef1ad0b6848a7d2b4784a72127a44df216ec0a2fc1e4f586298c",
-                            "id": "fls_V1WRuzZUWUGj",
-                            "link": "macros.html#fls_V1WRuzZUWUGj",
-                            "number": "20.1.2:4"
-                        },
-                        {
-                            "checksum": "cc21d8251493e001ac2bf6dc3b6d9869a4525b75ff8bdd4a6b96569f649bd5a7",
-                            "id": "fls_u86j0zm2jshf",
-                            "link": "macros.html#fls_u86j0zm2jshf",
-                            "number": "20.1.2:5"
-                        },
-                        {
-                            "checksum": "decb59aaa3220c66f8fa18342f46b9dbbd8d79ae738262d7cc8d3276f0d6f871",
-                            "id": "fls_h5f8x4jdnvbu",
-                            "link": "macros.html#fls_h5f8x4jdnvbu",
-                            "number": "20.1.2:6"
-                        },
-                        {
-                            "checksum": "8cb8cbde345ddbe65efa4ff3d8e5aa2db38eaa6626cdd39220f0a691c264783d",
-                            "id": "fls_hf4gj5pfl437",
-                            "link": "macros.html#fls_hf4gj5pfl437",
-                            "number": "20.1.2:7"
-                        },
-                        {
-                            "checksum": "e94a58c9be4a3e503fe157cfb77e90b5e89fe37b134ffb1f6f08c47bd52ea5f9",
-                            "id": "fls_tm0w0680wf4x",
-                            "link": "macros.html#fls_tm0w0680wf4x",
-                            "number": "20.1.2:8"
-                        },
-                        {
-                            "checksum": "3cdc79fac2c5194ed7084ae18321fb32b4db88a78ed80cc4f4432b4894648505",
-                            "id": "fls_10lsg5212ffb",
-                            "link": "macros.html#fls_10lsg5212ffb",
-                            "number": "20.1.2:9"
-                        },
-                        {
-                            "checksum": "44e5e09eadfa0ef32f2aa42f5d86aefc29a08264af8ea9678ec830ac5d0d919c",
-                            "id": "fls_UnfvR9NB1Nze",
-                            "link": "macros.html#fls_UnfvR9NB1Nze",
-                            "number": "20.1.2:10"
-                        },
-                        {
-                            "checksum": "ada08a290b60070c6aae793052fba60f6404e5668f5da364e16a178044452d6a",
-                            "id": "fls_Sm4qVsHKYLY2",
-                            "link": "macros.html#fls_Sm4qVsHKYLY2",
-                            "number": "20.1.2:11"
-                        },
-                        {
-                            "checksum": "ea5e5013c9fbf8d7b889cd0fe21718fb395b30a9d7cd9f10b911a150dc32decd",
-                            "id": "fls_Rdvs8Dz6OUU7",
-                            "link": "macros.html#fls_Rdvs8Dz6OUU7",
-                            "number": "20.1.2:12"
-                        },
-                        {
-                            "checksum": "e9e82608e910aea5e4b9b881e3bbc4f832130dd93a971ad1d979ae6b3be81ba8",
-                            "id": "fls_UIlj6Csow81w",
-                            "link": "macros.html#fls_UIlj6Csow81w",
-                            "number": "20.1.2:13"
-                        },
-                        {
-                            "checksum": "31f297fdd3706a0010aae6400f9a4d0d7368160c1aebd8e60699f9e9fbdf2639",
-                            "id": "fls_yp2XxDv4DzEi",
-                            "link": "macros.html#fls_yp2XxDv4DzEi",
-                            "number": "20.1.2:14"
-                        },
-                        {
-                            "checksum": "e542a9b407077073772387ef8c3ca43d8afb0cf939f1285a5c47b7d07ad1979d",
-                            "id": "fls_n5TkJKWiDhCD",
-                            "link": "macros.html#fls_n5TkJKWiDhCD",
-                            "number": "20.1.2:15"
-                        }
-                    ],
-                    "title": "Repetition"
-                },
-                {
-                    "id": "fls_wn1i6hzg2ff7",
-                    "informational": false,
-                    "link": "macros.html#procedural-macros",
-                    "number": "20.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "40ae367af875e89e010e4d22a7cfe13aa5dbaed9fc46011de6b52d138577092f",
-                            "id": "fls_ejbddhggstd2",
-                            "link": "macros.html#fls_ejbddhggstd2",
-                            "number": "20.2:1"
-                        },
-                        {
-                            "checksum": "a154977cec887d19447bb9d7566684f5f07b10108feaad22add360f52cade411",
-                            "id": "fls_pcce9gmjpxba",
-                            "link": "macros.html#fls_pcce9gmjpxba",
-                            "number": "20.2:2"
-                        },
-                        {
-                            "checksum": "0f0739a1ed671f541972aa194b63778a35eef1f8a258625357bad1dfb79126ec",
-                            "id": "fls_vtzuplb1p3s",
-                            "link": "macros.html#fls_vtzuplb1p3s",
-                            "number": "20.2:3"
-                        },
-                        {
-                            "checksum": "b0d421770e39ab6631e15b540881bf6453ecda3a0bbc8c78183bba9be46e6c77",
-                            "id": "fls_mewfehvgm16r",
-                            "link": "macros.html#fls_mewfehvgm16r",
-                            "number": "20.2:4"
-                        }
-                    ],
-                    "title": "Procedural Macros"
-                },
-                {
-                    "id": "fls_2d6bqnpy6tvs",
-                    "informational": false,
-                    "link": "macros.html#function-like-macros",
-                    "number": "20.2.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "35211e047d31106ec03bc1b7ccba14cee77f4c950b50ddedbd47d9cbe9dc876f",
-                            "id": "fls_utd3zqczix",
-                            "link": "macros.html#fls_utd3zqczix",
-                            "number": "20.2.1:1"
-                        },
-                        {
-                            "checksum": "195f49e7c5486c12cd274b338a19d3eaa1a19f99570f7ee0b52a3b1eeb90251e",
-                            "id": "fls_ojr30lf6jfx0",
-                            "link": "macros.html#fls_ojr30lf6jfx0",
-                            "number": "20.2.1:2"
-                        },
-                        {
-                            "checksum": "1d126893f14def3d9f5d85d0190f84dc53a460ce5e6da350afffa20da8714d0b",
-                            "id": "fls_ljkjmegynhiy",
-                            "link": "macros.html#fls_ljkjmegynhiy",
-                            "number": "20.2.1:3"
-                        },
-                        {
-                            "checksum": "1a1931bdd5b2a64999e14fa18b646001ec64e8e677c906ce614ba221a5dbf2c6",
-                            "id": "fls_8a8qhzjw5hax",
-                            "link": "macros.html#fls_8a8qhzjw5hax",
-                            "number": "20.2.1:4"
-                        },
-                        {
-                            "checksum": "589f04afe8c234ee2c179f3f0931eaded30292da86287719098525edb953002c",
-                            "id": "fls_ofzql79i9if",
-                            "link": "macros.html#fls_ofzql79i9if",
-                            "number": "20.2.1:5"
-                        },
-                        {
-                            "checksum": "67268d716ea7849d7125350436f4e4a6d5d38effc37ae5216408b2690ab8d033",
-                            "id": "fls_j1wsyzip2qb3",
-                            "link": "macros.html#fls_j1wsyzip2qb3",
-                            "number": "20.2.1:6"
-                        },
-                        {
-                            "checksum": "ba0099799988b2f6d17799a6f6f9c33b477183b8eeec921be942c1c46fe6e668",
-                            "id": "fls_etyo9bmzxby6",
-                            "link": "macros.html#fls_etyo9bmzxby6",
-                            "number": "20.2.1:7"
-                        },
-                        {
-                            "checksum": "7de42cd159846bf2a84aba1bcaf2c1f39e0a6092c7db776d8abb5854419ee2c1",
-                            "id": "fls_mkl9b38m0sf1",
-                            "link": "macros.html#fls_mkl9b38m0sf1",
-                            "number": "20.2.1:8"
-                        },
-                        {
-                            "checksum": "6e54b9a8b956ed9a206672b6145a346a9d87f0734de85341ef04814529bcee31",
-                            "id": "fls_lfmb22bfnrye",
-                            "link": "macros.html#fls_lfmb22bfnrye",
-                            "number": "20.2.1:9"
-                        },
-                        {
-                            "checksum": "78e85689e473377a80352ef6fe022993d405de27b2c6c0393cc70edc6d40e0e8",
-                            "id": "fls_fbgal48cgj44",
-                            "link": "macros.html#fls_fbgal48cgj44",
-                            "number": "20.2.1:10"
-                        }
-                    ],
-                    "title": "Function-like Macros"
-                },
-                {
-                    "id": "fls_o8s3r7m90q59",
-                    "informational": false,
-                    "link": "macros.html#derive-macros",
-                    "number": "20.2.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "aeee3f491d3c18c862f68c8f41eed353a109270ae1f717f9d5620bd9e311fbc6",
-                            "id": "fls_e5x92q2rq8a0",
-                            "link": "macros.html#fls_e5x92q2rq8a0",
-                            "number": "20.2.2:1"
-                        },
-                        {
-                            "checksum": "5242e5a075162a366a5adf0a32e20e73a4ed4c93a3b63541a8201de95af0cbfe",
-                            "id": "fls_ldw75sy5uj7p",
-                            "link": "macros.html#fls_ldw75sy5uj7p",
-                            "number": "20.2.2:2"
-                        },
-                        {
-                            "checksum": "77dd4bd0709e93df0c9294bd185bd0cb487a9e1991042f0cb0ecffb5df13bc60",
-                            "id": "fls_7gcnui9beky",
-                            "link": "macros.html#fls_7gcnui9beky",
-                            "number": "20.2.2:3"
-                        },
-                        {
-                            "checksum": "7fa2a69e91d4ee885cc21d70cb2d326b60305f03bba8a17a36209a53457749bb",
-                            "id": "fls_ef30ropg7dhx",
-                            "link": "macros.html#fls_ef30ropg7dhx",
-                            "number": "20.2.2:4"
-                        },
-                        {
-                            "checksum": "700ee188839152335fdb7422422a37ae9cb40c8bb9bc9940787cd260d61e7276",
-                            "id": "fls_mo00vqm9xfqc",
-                            "link": "macros.html#fls_mo00vqm9xfqc",
-                            "number": "20.2.2:5"
-                        },
-                        {
-                            "checksum": "d8d72a951c13aa5fe8714a16539462fbbaf7ead2c1ad8ecd97cf3071f5db6ab8",
-                            "id": "fls_gr9wugeqyb3b",
-                            "link": "macros.html#fls_gr9wugeqyb3b",
-                            "number": "20.2.2:6"
-                        },
-                        {
-                            "checksum": "6a638cc0c5ef1383ed2612ba3ab85735c70a35cbabcde5839d61b426d3411406",
-                            "id": "fls_npnze2cg8ae",
-                            "link": "macros.html#fls_npnze2cg8ae",
-                            "number": "20.2.2:7"
-                        },
-                        {
-                            "checksum": "704edbd352cfa964eac3571f6d328a271b59ec3801b0d4deb1b3ff167d9edcbf",
-                            "id": "fls_w2h4lk6bmht",
-                            "link": "macros.html#fls_w2h4lk6bmht",
-                            "number": "20.2.2:8"
-                        },
-                        {
-                            "checksum": "f217c6bc6e853a2b8556dbc0b41314003eaa542eca75e8a17d1573264d4e2151",
-                            "id": "fls_x96a0xzcyrko",
-                            "link": "macros.html#fls_x96a0xzcyrko",
-                            "number": "20.2.2:9"
-                        },
-                        {
-                            "checksum": "a284d52790bdad317fdaac6d6bb30541a4dba804471aa74bf317849a3eba4ca2",
-                            "id": "fls_caa16usjxryg",
-                            "link": "macros.html#fls_caa16usjxryg",
-                            "number": "20.2.2:10"
-                        },
-                        {
-                            "checksum": "81811154b26e520b237186a9289476a52adca1dac91598bea29f6d2f8ad5c0af",
-                            "id": "fls_H5ipqqlH3pJh",
-                            "link": "macros.html#fls_H5ipqqlH3pJh",
-                            "number": "20.2.2:11"
-                        },
-                        {
-                            "checksum": "99a2dde0b9166346d32d075006f6fff461527d79389470e64b255fb7a9f63733",
-                            "id": "fls_mobky5ck1mi",
-                            "link": "macros.html#fls_mobky5ck1mi",
-                            "number": "20.2.2:12"
-                        }
-                    ],
-                    "title": "Derive Macros"
-                },
-                {
-                    "id": "fls_4vjbkm4ceymk",
-                    "informational": false,
-                    "link": "macros.html#attribute-macros",
-                    "number": "20.2.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "a507e2ee0a755f9e9bef9483a14b746466426c98185a2634629bff10acf93070",
-                            "id": "fls_l3epi1dqpi8o",
-                            "link": "macros.html#fls_l3epi1dqpi8o",
-                            "number": "20.2.3:1"
-                        },
-                        {
-                            "checksum": "ad536eef612c80a23662ccb5976e09fc7a7cd564b3099362de958cb078de4636",
-                            "id": "fls_3sublbi9bz7k",
-                            "link": "macros.html#fls_3sublbi9bz7k",
-                            "number": "20.2.3:2"
-                        },
-                        {
-                            "checksum": "0e6bc1537645755a80173fb2e360056fe473f07b84fa83e420a2119802b5688e",
-                            "id": "fls_eb8jxl70wmeh",
-                            "link": "macros.html#fls_eb8jxl70wmeh",
-                            "number": "20.2.3:3"
-                        },
-                        {
-                            "checksum": "65f907abc0b4741ed3d04dfb54bf57f7733475bd00f7eb52a681cf2df6dd26cf",
-                            "id": "fls_7ugtmobgb2t9",
-                            "link": "macros.html#fls_7ugtmobgb2t9",
-                            "number": "20.2.3:4"
-                        },
-                        {
-                            "checksum": "ef5cb13d4e805e4e81816f26647b316792ceb249829578bfaa57070acb415879",
-                            "id": "fls_y700oif45wum",
-                            "link": "macros.html#fls_y700oif45wum",
-                            "number": "20.2.3:5"
-                        },
-                        {
-                            "checksum": "a67726cd1b3c0fa718910126228b74a584cd8d14685cff5a51c66aecafa25a2e",
-                            "id": "fls_hhsf1a9p6o55",
-                            "link": "macros.html#fls_hhsf1a9p6o55",
-                            "number": "20.2.3:6"
-                        },
-                        {
-                            "checksum": "85bf012ed3c7f1fe9e724f38a2d891b1697ec17ecde0a3277e037fe496069d6a",
-                            "id": "fls_4g932k8ueyqp",
-                            "link": "macros.html#fls_4g932k8ueyqp",
-                            "number": "20.2.3:7"
-                        },
-                        {
-                            "checksum": "301c590c9b06bc5965288c7611ce54546237f2ab270ad8d08ada06606d3129bf",
-                            "id": "fls_f5qy1pnlbpng",
-                            "link": "macros.html#fls_f5qy1pnlbpng",
-                            "number": "20.2.3:8"
-                        },
-                        {
-                            "checksum": "db387e1df17fe1b34f0785313cbd032471da2d489046fbbd57783da324ddd87b",
-                            "id": "fls_rzn48xylk4yj",
-                            "link": "macros.html#fls_rzn48xylk4yj",
-                            "number": "20.2.3:9"
-                        },
-                        {
-                            "checksum": "ae2d00ba71cdeeebcbc5ba13db842b607d9367375f608225d84eeb55ce0afb90",
-                            "id": "fls_78400zh02sdq",
-                            "link": "macros.html#fls_78400zh02sdq",
-                            "number": "20.2.3:10"
-                        },
-                        {
-                            "checksum": "130f778e0740bb2eac48f0b045d7c7d7854a7f114684fd426c548a5289d530b9",
-                            "id": "fls_eyesmvuwpjn1",
-                            "link": "macros.html#fls_eyesmvuwpjn1",
-                            "number": "20.2.3:11"
-                        },
-                        {
-                            "checksum": "a9469713d62e5ab294be5b5463896a680482fe532ef2db60c9a17dd040147917",
-                            "id": "fls_fku5beu3mr4c",
-                            "link": "macros.html#fls_fku5beu3mr4c",
-                            "number": "20.2.3:12"
-                        },
-                        {
-                            "checksum": "1f2493e72099adeeabdbdb5af0e9a9021fe478c82c788215781e06312b59c4e4",
-                            "id": "fls_knjsslplv5ri",
-                            "link": "macros.html#fls_knjsslplv5ri",
-                            "number": "20.2.3:13"
-                        }
-                    ],
-                    "title": "Attribute Macros"
-                },
-                {
-                    "id": "fls_vnvt40pa48n8",
-                    "informational": false,
-                    "link": "macros.html#macro-invocation",
-                    "number": "20.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "2d88086f369da9c00a710d6478ff80775749dcb789b8f28b671fa96d22b5c01e",
-                            "id": "fls_wushtmw9qt3y",
-                            "link": "macros.html#fls_wushtmw9qt3y",
-                            "number": "20.3:1"
-                        },
-                        {
-                            "checksum": "974d06554ff28647c4f903fa86768f1e175bc518e3c538c7d26f09ca32580f3a",
-                            "id": "fls_snpxxcqhtjfv",
-                            "link": "macros.html#fls_snpxxcqhtjfv",
-                            "number": "20.3:2"
-                        },
-                        {
-                            "checksum": "9331eac9772bb3030cfa592afd0542c15f135b1445df9e764e483111e6e799e5",
-                            "id": "fls_6v06zvi1ctub",
-                            "link": "macros.html#fls_6v06zvi1ctub",
-                            "number": "20.3:3"
-                        },
-                        {
-                            "checksum": "7b9182c06cf00fd455b1965ab8a30dda3df6d618c935ed284f6ca291707e0599",
-                            "id": "fls_338rmbazl67o",
-                            "link": "macros.html#fls_338rmbazl67o",
-                            "number": "20.3:4"
-                        },
-                        {
-                            "checksum": "f0d9a1f0b0eab822233723ad23f52e94ac8af7a075116203900e841cce37b8ed",
-                            "id": "fls_lrr7gg8tian",
-                            "link": "macros.html#fls_lrr7gg8tian",
-                            "number": "20.3:5"
-                        },
-                        {
-                            "checksum": "2f1f05665a7725eb786fccfba3d43fc78ce77ef15cfcf47af07e6cb0c9b8b6ff",
-                            "id": "fls_8qxwwf4trnl",
-                            "link": "macros.html#fls_8qxwwf4trnl",
-                            "number": "20.3:6"
-                        },
-                        {
-                            "checksum": "c0738db650ac62715e9597df801371e725fa1a1faf26794dba7b764fe0e1c70b",
-                            "id": "fls_8z1sgtvchhhw",
-                            "link": "macros.html#fls_8z1sgtvchhhw",
-                            "number": "20.3:7"
-                        },
-                        {
-                            "checksum": "27e64c85ad3e00def820e0904a4aa2d4beaac06c9fb0feccce519d3b3d81492d",
-                            "id": "fls_d9w3dn2yn7mo",
-                            "link": "macros.html#fls_d9w3dn2yn7mo",
-                            "number": "20.3:8"
-                        },
-                        {
-                            "checksum": "a5ebe407976f7eb1733d25250fff1be138a66bf342fac15d3226e09e6ffbcb31",
-                            "id": "fls_1tftbd91yfpd",
-                            "link": "macros.html#fls_1tftbd91yfpd",
-                            "number": "20.3:9"
-                        }
-                    ],
-                    "title": "Macro Invocation"
-                },
-                {
-                    "id": "fls_wjldgtio5o75",
-                    "informational": false,
-                    "link": "macros.html#macro-expansion",
-                    "number": "20.4",
-                    "paragraphs": [
-                        {
-                            "checksum": "8026222297277fbad4ed1549d49f0c3e75d7e5157adbb94d90360ceb716f2a3d",
-                            "id": "fls_xscdaxvs4wx4",
-                            "link": "macros.html#fls_xscdaxvs4wx4",
-                            "number": "20.4:1"
-                        },
-                        {
-                            "checksum": "81bdfdb7218e324273181015cf2a0058601e53a6f07875e9c55f6b9ccd110600",
-                            "id": "fls_nz5stwcc41gk",
-                            "link": "macros.html#fls_nz5stwcc41gk",
-                            "number": "20.4:2"
-                        },
-                        {
-                            "checksum": "bf49814afca1afc4a1ea61da7acaf9bb0ac3da4e8a3d40a8a0ad770017aaf4e2",
-                            "id": "fls_40xq8Ri1OMZZ",
-                            "link": "macros.html#fls_40xq8Ri1OMZZ",
-                            "number": "20.4:3"
-                        },
-                        {
-                            "checksum": "f2e3b68bee58b99bd43a9238014702fed0da098493aea6cd5ee8c35d689b2cfb",
-                            "id": "fls_76prdp6k1fga",
-                            "link": "macros.html#fls_76prdp6k1fga",
-                            "number": "20.4:4"
-                        },
-                        {
-                            "checksum": "74b6ccc123fd68357e50a1ba7a24fcfb694a68271bd2c7156e558945c62bb744",
-                            "id": "fls_76u274l4kew8",
-                            "link": "macros.html#fls_76u274l4kew8",
-                            "number": "20.4:5"
-                        },
-                        {
-                            "checksum": "41396541fe1131f8e3a05e47eb4dc795aca82ca7744db28c5808acbbcec8c548",
-                            "id": "fls_lakpily1zwfl",
-                            "link": "macros.html#fls_lakpily1zwfl",
-                            "number": "20.4:6"
-                        },
-                        {
-                            "checksum": "145096281559894c5fdd9c34f4c59020e8018a542a295c4718a2158eb1c24db6",
-                            "id": "fls_y20pmwo3v3uu",
-                            "link": "macros.html#fls_y20pmwo3v3uu",
-                            "number": "20.4:7"
-                        },
-                        {
-                            "checksum": "73e7c3d42509b26c6836a37c592ce6b5f8b4b8d51bdd13b1e69c781dbdb074ac",
-                            "id": "fls_nsh2vwx8oiw",
-                            "link": "macros.html#fls_nsh2vwx8oiw",
-                            "number": "20.4:8"
-                        },
-                        {
-                            "checksum": "2e54f1caa1c75bb8c551cb037444610dab84c77e38bccd44a64d81885462bfb0",
-                            "id": "fls_tu6kmwm4v9nj",
-                            "link": "macros.html#fls_tu6kmwm4v9nj",
-                            "number": "20.4:9"
-                        },
-                        {
-                            "checksum": "3b01afcc0d4c9f2696ea110f2556ea0c37503ac92544dd77a5853e2bc4cc735c",
-                            "id": "fls_3zn4dz19nyvq",
-                            "link": "macros.html#fls_3zn4dz19nyvq",
-                            "number": "20.4:10"
-                        },
-                        {
-                            "checksum": "39601be41eaf38c2fe68a562e68628c4c897e8c99f95ec75e583dbefab3af157",
-                            "id": "fls_t89sw6az99z7",
-                            "link": "macros.html#fls_t89sw6az99z7",
-                            "number": "20.4:11"
-                        },
-                        {
-                            "checksum": "48dbce0bae72db846dd146bad2ff656a10cf5dd99c403720ad8a65ff71bf965e",
-                            "id": "fls_417hvhvj2554",
-                            "link": "macros.html#fls_417hvhvj2554",
-                            "number": "20.4:12"
-                        },
-                        {
-                            "checksum": "10c68086f5de7156157c189ebd2864036d21287d9219fdce6f5e9df7658f3e2a",
-                            "id": "fls_nNrs4EC3ff5T",
-                            "link": "macros.html#fls_nNrs4EC3ff5T",
-                            "number": "20.4:13"
-                        },
-                        {
-                            "checksum": "303da91f4606ee986ceddcb3a6dd2990ea1a5d6f4d8ff9eba1411b05f9cfa29c",
-                            "id": "fls_srtqkdceaz5t",
-                            "link": "macros.html#fls_srtqkdceaz5t",
-                            "number": "20.4:14"
-                        },
-                        {
-                            "checksum": "57347ca4d51ad58880a851280bfb8d8e529e1b9951a52ca4929e47b94f19be4e",
-                            "id": "fls_mi92etjtpamu",
-                            "link": "macros.html#fls_mi92etjtpamu",
-                            "number": "20.4:15"
-                        },
-                        {
-                            "checksum": "9a60784d14b99e43a10674a97c9f853c1fda603311694eaa435886353f7102ab",
-                            "id": "fls_n8beqlt54rhy",
-                            "link": "macros.html#fls_n8beqlt54rhy",
-                            "number": "20.4:16"
-                        },
-                        {
-                            "checksum": "04d7c36c59b8db5f9cd9d437097d1287b1462b3d1a28b1af866979139758cf22",
-                            "id": "fls_vd3dzvr6re19",
-                            "link": "macros.html#fls_vd3dzvr6re19",
-                            "number": "20.4:17"
-                        },
-                        {
-                            "checksum": "8738a7304a24b50b3140d449d1bfca2c9baf6da9f0d078a51401795554fd4474",
-                            "id": "fls_l8j2jiuuao4f",
-                            "link": "macros.html#fls_l8j2jiuuao4f",
-                            "number": "20.4:18"
-                        },
-                        {
-                            "checksum": "d26201e9ec1b8ce4e8d0ce918281c597b4207dd5c717ab9d2f690dc2d3fa69f6",
-                            "id": "fls_xvemyqj5gc6g",
-                            "link": "macros.html#fls_xvemyqj5gc6g",
-                            "number": "20.4:19"
-                        },
-                        {
-                            "checksum": "9cd6b3fdd12de5819ef5f034cd512142d9ea7275dd351bb3364534aede42230d",
-                            "id": "fls_stseor6tln22",
-                            "link": "macros.html#fls_stseor6tln22",
-                            "number": "20.4:20"
-                        },
-                        {
-                            "checksum": "785c20cd4ee512f170f8821ae84ac3e0164356afb744c5eb7766d1b428f43f95",
-                            "id": "fls_u11o90szy68s",
-                            "link": "macros.html#fls_u11o90szy68s",
-                            "number": "20.4:21"
-                        },
-                        {
-                            "checksum": "42ff8c1ac6cc0dad7129ac746debad5fa96d773994a30fdf5b71496e0fe894be",
-                            "id": "fls_qi5kyvj1e8th",
-                            "link": "macros.html#fls_qi5kyvj1e8th",
-                            "number": "20.4:22"
-                        },
-                        {
-                            "checksum": "75411eced63ec88091cc61ad48545c56af50d13cdfbb58da468cfcd471b1d753",
-                            "id": "fls_vqIZaEl4EKu5",
-                            "link": "macros.html#fls_vqIZaEl4EKu5",
-                            "number": "20.4:23"
-                        },
-                        {
-                            "checksum": "8336e9a3dc539d94ebc4c3f4d1db0a002daac4a11ed04f66f0c8944f7c59dadc",
-                            "id": "fls_grtiwf7q8jah",
-                            "link": "macros.html#fls_grtiwf7q8jah",
-                            "number": "20.4:24"
-                        },
-                        {
-                            "checksum": "862660c9a7927486f4ab97a5219efca956468b25a372e7f0b8778d938fea614f",
-                            "id": "fls_tbe2qq7whq10",
-                            "link": "macros.html#fls_tbe2qq7whq10",
-                            "number": "20.4:25"
-                        },
-                        {
-                            "checksum": "56c2e17cefa41716653ddebd7376d5e765866b6b48613007cbd6fa266ec588a1",
-                            "id": "fls_my93neopj9x0",
-                            "link": "macros.html#fls_my93neopj9x0",
-                            "number": "20.4:26"
-                        },
-                        {
-                            "checksum": "6f0481d9039a52034b6e9c95142a26b01f4af587546d9d2ca76ccdcdce2cf14c",
-                            "id": "fls_zat7kwi5vc5c",
-                            "link": "macros.html#fls_zat7kwi5vc5c",
-                            "number": "20.4:27"
-                        },
-                        {
-                            "checksum": "4ed573b9e2ba6991e0c8cd77151c8f7fb439090236dff6dcba9b8dd9d06d2604",
-                            "id": "fls_tjn92evtlflq",
-                            "link": "macros.html#fls_tjn92evtlflq",
-                            "number": "20.4:28"
-                        },
-                        {
-                            "checksum": "9e9dd4998f98b6a17410d0f5050a5640b8a7d12b16d5ccc1fbf5ddfc4fa2c910",
-                            "id": "fls_AJmPrhHfZo6J",
-                            "link": "macros.html#fls_AJmPrhHfZo6J",
-                            "number": "20.4:29"
-                        },
-                        {
-                            "checksum": "d54d6148b8f96f7ae615b20d921e9536dec2d40191387304db5912c07457039c",
-                            "id": "fls_mpgh22bi8caz",
-                            "link": "macros.html#fls_mpgh22bi8caz",
-                            "number": "20.4:30"
-                        },
-                        {
-                            "checksum": "ecc18764aaf923e05323ff7d8dbc3196f9c2a677d000895c4350a34de447d370",
-                            "id": "fls_ul7nhfyvyzh",
-                            "link": "macros.html#fls_ul7nhfyvyzh",
-                            "number": "20.4:31"
-                        },
-                        {
-                            "checksum": "61b9b13308b8c7583de5aab70fe1644dee9867664a812351e4a713132df8f246",
-                            "id": "fls_z6xfhf71w10a",
-                            "link": "macros.html#fls_z6xfhf71w10a",
-                            "number": "20.4:32"
-                        }
-                    ],
-                    "title": "Macro Expansion"
-                },
-                {
-                    "id": "fls_4apk1exafxii",
-                    "informational": false,
-                    "link": "macros.html#macro-matching",
-                    "number": "20.4.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "6b8396da1325228a967d0d28720f37811bfec9f46d17c5b5d20ab8838236c8d1",
-                            "id": "fls_ZmQZ8HQWv77L",
-                            "link": "macros.html#fls_ZmQZ8HQWv77L",
-                            "number": "20.4.1:1"
-                        }
-                    ],
-                    "title": "Macro Matching"
-                },
-                {
-                    "id": "fls_n3ktmjqf87qb",
-                    "informational": false,
-                    "link": "macros.html#rule-matching",
-                    "number": "20.4.1.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "86e93126d0e6c567afa83d3532a9dda63596c2a3a1b8fa60469481ff4891e786",
-                            "id": "fls_77ucvwu6idms",
-                            "link": "macros.html#fls_77ucvwu6idms",
-                            "number": "20.4.1.1:1"
-                        },
-                        {
-                            "checksum": "4c41fb4fb8823d556cfb539659a3c4703c73a1c321684dd511b7f178f2ee5439",
-                            "id": "fls_6h1jqhxzku5v",
-                            "link": "macros.html#fls_6h1jqhxzku5v",
-                            "number": "20.4.1.1:2"
-                        },
-                        {
-                            "checksum": "6ff3d3159841229f8392ab25c21c4749d84f44f9448851671427adf3fa2c97f8",
-                            "id": "fls_r6i1ykrhb49j",
-                            "link": "macros.html#fls_r6i1ykrhb49j",
-                            "number": "20.4.1.1:3"
-                        },
-                        {
-                            "checksum": "d6cdc5aaa72a1fe038b82e1c7963c4446c2bc7668ed2fae5540f1dd6416a865f",
-                            "id": "fls_3qzes4lr8yuv",
-                            "link": "macros.html#fls_3qzes4lr8yuv",
-                            "number": "20.4.1.1:4"
-                        },
-                        {
-                            "checksum": "b69c21d1eb5931b6f4848c2e230a9199999a3b94ade1ff93a4c66ba685343958",
-                            "id": "fls_r878ysvsy4jb",
-                            "link": "macros.html#fls_r878ysvsy4jb",
-                            "number": "20.4.1.1:5"
-                        }
-                    ],
-                    "title": "Rule Matching"
-                },
-                {
-                    "id": "fls_qpx6lgapce57",
-                    "informational": false,
-                    "link": "macros.html#token-matching",
-                    "number": "20.4.1.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "939454db28503818aeec06820dacf2ab2a82bb11e9ebd50d2b097213c7223ae4",
-                            "id": "fls_k6a24sbon5v9",
-                            "link": "macros.html#fls_k6a24sbon5v9",
-                            "number": "20.4.1.2:1"
-                        },
-                        {
-                            "checksum": "69d0900d72789c738bb16a2cd4d7cd0938784373e5835a4c87c5655968e72f06",
-                            "id": "fls_6uuxv91xgmfz",
-                            "link": "macros.html#fls_6uuxv91xgmfz",
-                            "number": "20.4.1.2:2"
-                        },
-                        {
-                            "checksum": "9676823aa002fa0b34ed9ceb6cdf528e036dd054cc9680fd769fbfbabbdf2f33",
-                            "id": "fls_g1rml9tavh8v",
-                            "link": "macros.html#fls_g1rml9tavh8v",
-                            "number": "20.4.1.2:3"
-                        },
-                        {
-                            "checksum": "485dc2a03abcfc575a18d12f44392c25e70e3d6c8c7defe90be8b259721e9cf2",
-                            "id": "fls_h7x3tc208zpk",
-                            "link": "macros.html#fls_h7x3tc208zpk",
-                            "number": "20.4.1.2:4"
-                        },
-                        {
-                            "checksum": "4e3b1a4397f68e72da8d33b18764d344b2cdc18f83b97ddefee8dbdef401dc87",
-                            "id": "fls_p9eqa17d3dx",
-                            "link": "macros.html#fls_p9eqa17d3dx",
-                            "number": "20.4.1.2:5"
-                        },
-                        {
-                            "checksum": "d54b6dc3d7995358cb1bb0e6672591cf1d8416a887f73cf8f3f2d2d7347d499b",
-                            "id": "fls_k00bck2k8tde",
-                            "link": "macros.html#fls_k00bck2k8tde",
-                            "number": "20.4.1.2:6"
-                        },
-                        {
-                            "checksum": "9beee8340868a57b1052f0fc0b375a60221fffc91fe52f2b2a049ecea579e62e",
-                            "id": "fls_pf0qrz5nadl2",
-                            "link": "macros.html#fls_pf0qrz5nadl2",
-                            "number": "20.4.1.2:7"
-                        },
-                        {
-                            "checksum": "944fc29dfd11666e10802285b2515966d675e8dd3dba1e06c0e50e2db56199cf",
-                            "id": "fls_9fioah171ojx",
-                            "link": "macros.html#fls_9fioah171ojx",
-                            "number": "20.4.1.2:8"
-                        },
-                        {
-                            "checksum": "3a4366c2f44243bd2284234dca5b270e4dc4a86d1f32a617a269adb290fb8985",
-                            "id": "fls_j2o0f52zyvyb",
-                            "link": "macros.html#fls_j2o0f52zyvyb",
-                            "number": "20.4.1.2:9"
-                        },
-                        {
-                            "checksum": "e4f9ae7e642ed779024a8e69cea6afc9bd400fd2105ce496a574bcc9be0bf3d7",
-                            "id": "fls_w5dzv3z4zd5a",
-                            "link": "macros.html#fls_w5dzv3z4zd5a",
-                            "number": "20.4.1.2:10"
-                        },
-                        {
-                            "checksum": "a6923eaff6739eb4d6492f970c783cfdabc71c275843e5ef6405fff5af5b0432",
-                            "id": "fls_wtol98rrqka5",
-                            "link": "macros.html#fls_wtol98rrqka5",
-                            "number": "20.4.1.2:11"
-                        },
-                        {
-                            "checksum": "80a04645ad370bbb071324afb5d55d19b18f915e9fadfab568496d6a3a18fa5f",
-                            "id": "fls_iorqt9q4ie9j",
-                            "link": "macros.html#fls_iorqt9q4ie9j",
-                            "number": "20.4.1.2:12"
-                        },
-                        {
-                            "checksum": "b45c38305f3c3ffa6bf27034b89cc6b8baac7a4e72914a0cfdf7eeee7da69266",
-                            "id": "fls_2zjed913qpvi",
-                            "link": "macros.html#fls_2zjed913qpvi",
-                            "number": "20.4.1.2:13"
-                        },
-                        {
-                            "checksum": "d58dc97395dae9ccb1d8fe2a21911f6287c2676be72fea50a94301b4b85614fb",
-                            "id": "fls_3zdts0fsa36u",
-                            "link": "macros.html#fls_3zdts0fsa36u",
-                            "number": "20.4.1.2:14"
-                        },
-                        {
-                            "checksum": "0f22177e56930189a013cc165f27159e88950b6309aec5aa8f36dad4fc00070b",
-                            "id": "fls_mb3yr1j7npv5",
-                            "link": "macros.html#fls_mb3yr1j7npv5",
-                            "number": "20.4.1.2:15"
-                        },
-                        {
-                            "checksum": "8b44cfe64ffb38c055354fd03755c38a67d369899996d279000749b6938b4130",
-                            "id": "fls_xbuixjt9pum6",
-                            "link": "macros.html#fls_xbuixjt9pum6",
-                            "number": "20.4.1.2:16"
-                        },
-                        {
-                            "checksum": "2868c75bd1038a056153d19675c38e727498801f62dcf998f97e79d1feb762aa",
-                            "id": "fls_6annifhk6cd8",
-                            "link": "macros.html#fls_6annifhk6cd8",
-                            "number": "20.4.1.2:17"
-                        },
-                        {
-                            "checksum": "8a369cdda5e38c9d0c9235244570dc6350c8f7513c2a5dc0ce5b97503f92b7ef",
-                            "id": "fls_2zu22efr6ncy",
-                            "link": "macros.html#fls_2zu22efr6ncy",
-                            "number": "20.4.1.2:18"
-                        },
-                        {
-                            "checksum": "235bfe3d83907a5ee61a001a2b2acac3b0e021e603831aed451c1cc984b6a784",
-                            "id": "fls_dqroklsaayzb",
-                            "link": "macros.html#fls_dqroklsaayzb",
-                            "number": "20.4.1.2:19"
-                        },
-                        {
-                            "checksum": "273716f2c264d37ea340ce796a784d1e2b3cb3a16578a954da0dcab1900b6ca9",
-                            "id": "fls_ghqjk6xj85ng",
-                            "link": "macros.html#fls_ghqjk6xj85ng",
-                            "number": "20.4.1.2:20"
-                        },
-                        {
-                            "checksum": "1ff9a6a6d1f6eb7b4c668c7940b8c2e1490c37f93b536e4b0f4468a49095216f",
-                            "id": "fls_lzwl4en5wcw0",
-                            "link": "macros.html#fls_lzwl4en5wcw0",
-                            "number": "20.4.1.2:21"
-                        },
-                        {
-                            "checksum": "622a0124d322fc811ce341d23c250c1d22df2be7065199c523a053e04f93655b",
-                            "id": "fls_cz44evkjzv29",
-                            "link": "macros.html#fls_cz44evkjzv29",
-                            "number": "20.4.1.2:22"
-                        },
-                        {
-                            "checksum": "61ca7e8337e433a1f27f8ca82eda551971c4361a34cf11fb7c23f53368ee2593",
-                            "id": "fls_o2exsai4m0gy",
-                            "link": "macros.html#fls_o2exsai4m0gy",
-                            "number": "20.4.1.2:23"
-                        },
-                        {
-                            "checksum": "2b361f50a42eadd00c2c0ca748063e0d34342f34e39bae540bb8802a83f14882",
-                            "id": "fls_1ch299zp8h7",
-                            "link": "macros.html#fls_1ch299zp8h7",
-                            "number": "20.4.1.2:24"
-                        },
-                        {
-                            "checksum": "225d33e4ff2e8e37f77d0d4ba4811088ee088d027a6ae4a1a4882ca9b039fa98",
-                            "id": "fls_55ptfjlvoo8o",
-                            "link": "macros.html#fls_55ptfjlvoo8o",
-                            "number": "20.4.1.2:25"
-                        },
-                        {
-                            "checksum": "17b373ea759d5c509466cee1cd0f9941a470f136a1109fb7f745dd87e096bcf9",
-                            "id": "fls_finzfb5ljkf8",
-                            "link": "macros.html#fls_finzfb5ljkf8",
-                            "number": "20.4.1.2:26"
-                        },
-                        {
-                            "checksum": "34a0742ef58a8b7fe215596c5252975ec70b4b86687272048bf5ccbee1c21eda",
-                            "id": "fls_s1ccs6jocsgr",
-                            "link": "macros.html#fls_s1ccs6jocsgr",
-                            "number": "20.4.1.2:27"
-                        },
-                        {
-                            "checksum": "408711d561d0aa646b34d91388c4abb3e0e292eecb966dc171c8368efaca46c5",
-                            "id": "fls_wpi2i6hoj3li",
-                            "link": "macros.html#fls_wpi2i6hoj3li",
-                            "number": "20.4.1.2:28"
-                        },
-                        {
-                            "checksum": "c8977ccaa62d4c406898dba6432a60322e5b401d6bd0f7cda07b4b0979bb29f6",
-                            "id": "fls_uuey421a8n96",
-                            "link": "macros.html#fls_uuey421a8n96",
-                            "number": "20.4.1.2:29"
-                        },
-                        {
-                            "checksum": "4538f5121ec15ee6fbd7d3cb0bb690cc955c3d8655feceab5333045461750c15",
-                            "id": "fls_b5u47tuu136r",
-                            "link": "macros.html#fls_b5u47tuu136r",
-                            "number": "20.4.1.2:30"
-                        },
-                        {
-                            "checksum": "38cb0f7a2daa5611bc22dac0b50c555f9d3ffb1127900a2f86ba5a79ff08498a",
-                            "id": "fls_rb1tu4e7dpma",
-                            "link": "macros.html#fls_rb1tu4e7dpma",
-                            "number": "20.4.1.2:31"
-                        },
-                        {
-                            "checksum": "3f33b5ba4b848845ef3c885d9b0b6d3309d5d903bf48ba507cc368dc25cad1ce",
-                            "id": "fls_c76sdvos5xeo",
-                            "link": "macros.html#fls_c76sdvos5xeo",
-                            "number": "20.4.1.2:32"
-                        }
-                    ],
-                    "title": "Token Matching"
-                },
-                {
-                    "id": "fls_ym00b6ewf4n3",
-                    "informational": false,
-                    "link": "macros.html#macro-transcription",
-                    "number": "20.4.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "0625ef0bcc1537bbd7e48bbb52e650fac001e4ce41c99c213d6d9c46b45e74e0",
-                            "id": "fls_y21i8062mft0",
-                            "link": "macros.html#fls_y21i8062mft0",
-                            "number": "20.4.2:1"
-                        },
-                        {
-                            "checksum": "3a923fd62e7cb8e223448548b2aa38404e63cc3e8b41254c70fa1d13076ad338",
-                            "id": "fls_n2dx4ug5nd5w",
-                            "link": "macros.html#fls_n2dx4ug5nd5w",
-                            "number": "20.4.2:2"
-                        },
-                        {
-                            "checksum": "3a3dab26920d694cfc94f0c1b2f51523cd3b42dbae5b61643d7c56834c7220cf",
-                            "id": "fls_iw7322ycvhkc",
-                            "link": "macros.html#fls_iw7322ycvhkc",
-                            "number": "20.4.2:3"
-                        },
-                        {
-                            "checksum": "0138c8400ce4f71c65b6aa2722efe3060cbd1d41df1c72e0d5f3b34a20f300b5",
-                            "id": "fls_jgitbqmyixem",
-                            "link": "macros.html#fls_jgitbqmyixem",
-                            "number": "20.4.2:4"
-                        },
-                        {
-                            "checksum": "5c84ed6a518944136878abb4c88f566d332adfa28adc88939272040b8b6376d9",
-                            "id": "fls_ihcwl6taptas",
-                            "link": "macros.html#fls_ihcwl6taptas",
-                            "number": "20.4.2:5"
-                        },
-                        {
-                            "checksum": "ccd3909779e2ae52e078ac9ec0171a31569a1a5f27a764f1116aa514d4ab1e76",
-                            "id": "fls_g3dtpw4rtgdr",
-                            "link": "macros.html#fls_g3dtpw4rtgdr",
-                            "number": "20.4.2:6"
-                        },
-                        {
-                            "checksum": "cfa58e13c7d71f34271957f476e066a784af6a8ed0072bb215252e5c076b03c3",
-                            "id": "fls_pvp6dxykuv66",
-                            "link": "macros.html#fls_pvp6dxykuv66",
-                            "number": "20.4.2:7"
-                        },
-                        {
-                            "checksum": "c46a8e07cda751526560f7fc97ae3c1b78414ebc17c1ce3cd210620619ebbf25",
-                            "id": "fls_bd673n5awwbz",
-                            "link": "macros.html#fls_bd673n5awwbz",
-                            "number": "20.4.2:8"
-                        },
-                        {
-                            "checksum": "89ea10945ee36c0a8d05b165f2dab20d4778edf60bc0f8b3696a46d9199743b8",
-                            "id": "fls_zbtwrtcy7pzf",
-                            "link": "macros.html#fls_zbtwrtcy7pzf",
-                            "number": "20.4.2:9"
-                        },
-                        {
-                            "checksum": "928fa72878c7bba4b1bce0f51d05314cb2480974eb15a3baa42edf4802016c4b",
-                            "id": "fls_eacyb6jap9ru",
-                            "link": "macros.html#fls_eacyb6jap9ru",
-                            "number": "20.4.2:10"
-                        },
-                        {
-                            "checksum": "923b9e5ad7c41a86ba16ba5fc020547055484598d353ee7d4600ac28f7464960",
-                            "id": "fls_y4podc7ee8lf",
-                            "link": "macros.html#fls_y4podc7ee8lf",
-                            "number": "20.4.2:11"
-                        },
-                        {
-                            "checksum": "b20e0ffba294f223744cb483c484961c3e57930764952f5beab1e3448b7f8cde",
-                            "id": "fls_wbys0m4a1omg",
-                            "link": "macros.html#fls_wbys0m4a1omg",
-                            "number": "20.4.2:12"
-                        },
-                        {
-                            "checksum": "ffbe98be6393f55c5b73a7849f41caadf322b1ac4e018fa42c59e7305db89820",
-                            "id": "fls_g445ovedgo4q",
-                            "link": "macros.html#fls_g445ovedgo4q",
-                            "number": "20.4.2:13"
-                        },
-                        {
-                            "checksum": "4f0f8d199b56a8e97493384b9448af0cf2c03e0ee0924725a9973869747db80f",
-                            "id": "fls_ctzthi6keit2",
-                            "link": "macros.html#fls_ctzthi6keit2",
-                            "number": "20.4.2:14"
-                        },
-                        {
-                            "checksum": "924ac328fa7b1c896d1efd435201562db8738164a53715c1956c4c2da5a4012c",
-                            "id": "fls_9n46ugmcqmix",
-                            "link": "macros.html#fls_9n46ugmcqmix",
-                            "number": "20.4.2:15"
-                        },
-                        {
-                            "checksum": "7c1fe9eccd483e7a420e8b7c1d1c1164588a91adea0ff813953d9cf07171ea38",
-                            "id": "fls_JinrPA0pMZCr",
-                            "link": "macros.html#fls_JinrPA0pMZCr",
-                            "number": "20.4.2:16"
-                        },
-                        {
-                            "checksum": "7b97106af69b3585b467ae757b209987fcfa719d9d0056adfca9fbc914a2d73b",
-                            "id": "fls_95rn4cvgznmd",
-                            "link": "macros.html#fls_95rn4cvgznmd",
-                            "number": "20.4.2:17"
-                        },
-                        {
-                            "checksum": "a990d3628235419098482e04aad2d699f6205b88761be1c1cea45b6dad882cd1",
-                            "id": "fls_yg4c9x7049y4",
-                            "link": "macros.html#fls_yg4c9x7049y4",
-                            "number": "20.4.2:18"
-                        },
-                        {
-                            "checksum": "30c1a84b2185098caed8510493324650b62ebcbc98651ffdef52e7656b859109",
-                            "id": "fls_o9rwz9z0a2h4",
-                            "link": "macros.html#fls_o9rwz9z0a2h4",
-                            "number": "20.4.2:19"
-                        }
-                    ],
-                    "title": "Macro Transcription"
-                },
-                {
-                    "id": "fls_xlfo7di0gsqz",
-                    "informational": false,
-                    "link": "macros.html#hygiene",
-                    "number": "20.5",
-                    "paragraphs": [
-                        {
-                            "checksum": "dd8bbb6eef9dde4a235a404d36082ffd706c870db1421a4681408cf45d6a6bcc",
-                            "id": "fls_7ezc7ncs678f",
-                            "link": "macros.html#fls_7ezc7ncs678f",
-                            "number": "20.5:1"
-                        },
-                        {
-                            "checksum": "950f5e9f05dfb90a7771b7b56a2c154f09546fdb6ee7b4947d3598357e680977",
-                            "id": "fls_3axjf28xb1nt",
-                            "link": "macros.html#fls_3axjf28xb1nt",
-                            "number": "20.5:2"
-                        },
-                        {
-                            "checksum": "341839374d80c8018873df9d4ddc4bc416d5bc2dac1e9b09bc7a56b94374252a",
-                            "id": "fls_dz2mvodl818d",
-                            "link": "macros.html#fls_dz2mvodl818d",
-                            "number": "20.5:3"
-                        },
-                        {
-                            "checksum": "e4746196f1fb7989f818766502b19a237f5b3740241baf2dfd8cb4211c05f424",
-                            "id": "fls_puqhytfzfsg6",
-                            "link": "macros.html#fls_puqhytfzfsg6",
-                            "number": "20.5:4"
-                        },
-                        {
-                            "checksum": "93e969fde4270a39d3cee8c4a0b19185228c33e8b24df9d0ef270765e9824d81",
-                            "id": "fls_uyvnq88y9gk3",
-                            "link": "macros.html#fls_uyvnq88y9gk3",
-                            "number": "20.5:5"
-                        },
-                        {
-                            "checksum": "20c309825d7777388bd6af5804c0c7762b4fe76a90f7d2eb118d92ba8f547c1c",
-                            "id": "fls_yxqcr19dig18",
-                            "link": "macros.html#fls_yxqcr19dig18",
-                            "number": "20.5:6"
-                        },
-                        {
-                            "checksum": "64745f1bbadaf610e425de55287699402147860a4554484ba0071db41bc7ed34",
-                            "id": "fls_kx25olky1jov",
-                            "link": "macros.html#fls_kx25olky1jov",
-                            "number": "20.5:7"
-                        },
-                        {
-                            "checksum": "143bbe1668afc34dcafc68eddd7634b71e3847e8f9416dc8dedcee0d2d5198f5",
-                            "id": "fls_v46v0t2vh6x4",
-                            "link": "macros.html#fls_v46v0t2vh6x4",
-                            "number": "20.5:8"
-                        },
-                        {
-                            "checksum": "82fe4be1744d0478a0bcbed88a26bf676ea9c239bd2e996210ce59ad724a104b",
-                            "id": "fls_7eqqk2cj0clr",
-                            "link": "macros.html#fls_7eqqk2cj0clr",
-                            "number": "20.5:9"
-                        }
-                    ],
-                    "title": "Hygiene"
+                    "title": "Associated Items"
                 }
             ],
-            "title": "Macros"
+            "title": "Associated Items"
         },
         {
             "informational": false,
@@ -8589,6 +7331,12 @@
         },
         {
             "informational": false,
+            "link": "index.html",
+            "sections": [],
+            "title": "FLS"
+        },
+        {
+            "informational": false,
             "link": "ownership-and-deconstruction.html",
             "sections": [
                 {
@@ -9600,6 +8348,1264 @@
         },
         {
             "informational": false,
+            "link": "macros.html",
+            "sections": [
+                {
+                    "id": "fls_83182bfa9uqb",
+                    "informational": false,
+                    "link": "macros.html",
+                    "number": "20",
+                    "paragraphs": [
+                        {
+                            "checksum": "23ad7afdee8d11ed607ec24d3a0e15437d673156ba4b127587b5669f1832653b",
+                            "id": "fls_j1jc83erljo0",
+                            "link": "macros.html#fls_j1jc83erljo0",
+                            "number": "20:1"
+                        },
+                        {
+                            "checksum": "f3350d5be59f16503e8f202eed548f9142e23d0995f540a0fe8dbfa0790eb114",
+                            "id": "fls_23eapx3ckymf",
+                            "link": "macros.html#fls_23eapx3ckymf",
+                            "number": "20:2"
+                        },
+                        {
+                            "checksum": "b37827025945e3ebe09fb51af413ab507e55bef20cbd1cdc0d88bda1e5b31868",
+                            "id": "fls_a5uemz2hnbi8",
+                            "link": "macros.html#fls_a5uemz2hnbi8",
+                            "number": "20:3"
+                        },
+                        {
+                            "checksum": "f947401b4192d1cb447cdbc6dfa662250896c68e1cb0477bdfdbc7dfaf9b809c",
+                            "id": "fls_rnty1c8l5495",
+                            "link": "macros.html#fls_rnty1c8l5495",
+                            "number": "20:4"
+                        }
+                    ],
+                    "title": "Macros"
+                },
+                {
+                    "id": "fls_xa7lp0zg1ol2",
+                    "informational": false,
+                    "link": "macros.html#declarative-macros",
+                    "number": "20.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "8cffdd9962e92466f819713aab704c780ae0d98dac229021c576afa2742830ba",
+                            "id": "fls_ikzjsq8heyk6",
+                            "link": "macros.html#fls_ikzjsq8heyk6",
+                            "number": "20.1:1"
+                        },
+                        {
+                            "checksum": "4e9e7f12e6633dbb05180c17c6a222b11c2760152ee1a091050e70af0a2f4238",
+                            "id": "fls_w44hav7mw3ao",
+                            "link": "macros.html#fls_w44hav7mw3ao",
+                            "number": "20.1:2"
+                        },
+                        {
+                            "checksum": "af67fc9d046886fb7c793c0a9eef775cd020529cf8ec85a93167f1e58f4122fa",
+                            "id": "fls_dw1nq4r9ghhd",
+                            "link": "macros.html#fls_dw1nq4r9ghhd",
+                            "number": "20.1:3"
+                        },
+                        {
+                            "checksum": "13beaa609262aa0b7e0b3212da54ac78e68086106c14cc11e081e7132158286b",
+                            "id": "fls_oq4xn8guos8f",
+                            "link": "macros.html#fls_oq4xn8guos8f",
+                            "number": "20.1:4"
+                        },
+                        {
+                            "checksum": "b549b18e6de60d1ec130ab38737806e6ea0cbd0d471501c476916eefe2be7228",
+                            "id": "fls_cdaf8viwmdfe",
+                            "link": "macros.html#fls_cdaf8viwmdfe",
+                            "number": "20.1:5"
+                        },
+                        {
+                            "checksum": "238647cd9313b6607667d9993c8bf87f5406351bd4a87045bd0850f5063f6b84",
+                            "id": "fls_ljavs0w61z3j",
+                            "link": "macros.html#fls_ljavs0w61z3j",
+                            "number": "20.1:6"
+                        },
+                        {
+                            "checksum": "41d7cadc4529963b5fae05cea05d12721cc023eac8db3ab3013c78712f677f92",
+                            "id": "fls_3jspk8obv7sd",
+                            "link": "macros.html#fls_3jspk8obv7sd",
+                            "number": "20.1:7"
+                        }
+                    ],
+                    "title": "Declarative Macros"
+                },
+                {
+                    "id": "fls_8nzypdu9j3ge",
+                    "informational": false,
+                    "link": "macros.html#metavariables",
+                    "number": "20.1.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "142bdc43ec20b9deed884f97e167a2a47e1cd8cab76ba4b6a81e5b3ec56b69ea",
+                            "id": "fls_g93r3teei8wo",
+                            "link": "macros.html#fls_g93r3teei8wo",
+                            "number": "20.1.1:1"
+                        },
+                        {
+                            "checksum": "260a8af1053ab13b37c8171151aec029a2b0049a4db4d2fa4c072391caa7c788",
+                            "id": "fls_4zdait30exvn",
+                            "link": "macros.html#fls_4zdait30exvn",
+                            "number": "20.1.1:2"
+                        },
+                        {
+                            "checksum": "0e475930b62b5e6e2c4eaa5d954c01002c3918fb1243f5ffd3b8b5959e5350f0",
+                            "id": "fls_2HguXbL7DjKH",
+                            "link": "macros.html#fls_2HguXbL7DjKH",
+                            "number": "20.1.1:3"
+                        },
+                        {
+                            "checksum": "e16b11f619d14521da5d28556e2228fd055de524ae57da0397dc5fb7f244b522",
+                            "id": "fls_8zypylq60zba",
+                            "link": "macros.html#fls_8zypylq60zba",
+                            "number": "20.1.1:4"
+                        },
+                        {
+                            "checksum": "a7305e4a6c0db284c01d3b766c9526e183f139d0d6b3417b05a0a25448deb2e1",
+                            "id": "fls_8o9mcV2KrKac",
+                            "link": "macros.html#fls_8o9mcV2KrKac",
+                            "number": "20.1.1:5"
+                        },
+                        {
+                            "checksum": "bbdb87195b02f153c61cd395d1d5db4690ef89af595efddbf90e07037c6d88fd",
+                            "id": "fls_PxR9vNHsaFnI",
+                            "link": "macros.html#fls_PxR9vNHsaFnI",
+                            "number": "20.1.1:6"
+                        },
+                        {
+                            "checksum": "db57f38586128d0f797f87a3bec37a62e9bc1ffe1a0b5b3634c97bbbd3c3a923",
+                            "id": "fls_ePyoTeJJ11N0",
+                            "link": "macros.html#fls_ePyoTeJJ11N0",
+                            "number": "20.1.1:7"
+                        },
+                        {
+                            "checksum": "5ab36e5b8b233c50fbb634f2ddb85db4a65676e58884c4e545002ad8ae792716",
+                            "id": "fls_0j7VOV4ewfeY",
+                            "link": "macros.html#fls_0j7VOV4ewfeY",
+                            "number": "20.1.1:8"
+                        },
+                        {
+                            "checksum": "7e4c3dc1c34fcadf4bb70df2a2ca55cb16019fe78a19c5f625a3407c7f23de0c",
+                            "id": "fls_80cOMpIMU2gx",
+                            "link": "macros.html#fls_80cOMpIMU2gx",
+                            "number": "20.1.1:9"
+                        },
+                        {
+                            "checksum": "ae189445a188e528fc320b0716648ea260e44624143f233a7a3d6594c319fc71",
+                            "id": "fls_DFMRwsWI8e5z",
+                            "link": "macros.html#fls_DFMRwsWI8e5z",
+                            "number": "20.1.1:10"
+                        },
+                        {
+                            "checksum": "3a94c395e86b915f016782c8e832229ac77ff7d26c4468f604f4d1346d410385",
+                            "id": "fls_BoIGgrFdyhwH",
+                            "link": "macros.html#fls_BoIGgrFdyhwH",
+                            "number": "20.1.1:11"
+                        },
+                        {
+                            "checksum": "10fac2b91182e4a802d41382e138eeea01e0169f14fd98576dec0541757d3d52",
+                            "id": "fls_NBbygZwUxjFp",
+                            "link": "macros.html#fls_NBbygZwUxjFp",
+                            "number": "20.1.1:12"
+                        },
+                        {
+                            "checksum": "a397be8475f298d03d342d1d7922a7addc7c4e01708dbc748271e89ff6e4e91a",
+                            "id": "fls_lZ8F1zUJju33",
+                            "link": "macros.html#fls_lZ8F1zUJju33",
+                            "number": "20.1.1:13"
+                        },
+                        {
+                            "checksum": "6d1e723dc52e63b247ff2a9f36fd2a2448c78a8a6c0785d9bc962cbf164a68ff",
+                            "id": "fls_ephlmLsGTMgw",
+                            "link": "macros.html#fls_ephlmLsGTMgw",
+                            "number": "20.1.1:14"
+                        }
+                    ],
+                    "title": "Metavariables"
+                },
+                {
+                    "id": "fls_k01lsksqtq1r",
+                    "informational": false,
+                    "link": "macros.html#repetition",
+                    "number": "20.1.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "9be00a29faba4cce56b85af749378910166a176caaf783feb7f21917b113f4fc",
+                            "id": "fls_4ps4x4513xau",
+                            "link": "macros.html#fls_4ps4x4513xau",
+                            "number": "20.1.2:1"
+                        },
+                        {
+                            "checksum": "0afa98bdb2bc52d07887d1af628eba5846e5110da9bf813ba1906139eba01c98",
+                            "id": "fls_8byjmlgum2f3",
+                            "link": "macros.html#fls_8byjmlgum2f3",
+                            "number": "20.1.2:2"
+                        },
+                        {
+                            "checksum": "43358f7409e5fcf8e712e18e535f05897041a0c7ee20dc9c07eaae0a6a5b463c",
+                            "id": "fls_ltdp3zs60dzr",
+                            "link": "macros.html#fls_ltdp3zs60dzr",
+                            "number": "20.1.2:3"
+                        },
+                        {
+                            "checksum": "fb90822182dbef1ad0b6848a7d2b4784a72127a44df216ec0a2fc1e4f586298c",
+                            "id": "fls_V1WRuzZUWUGj",
+                            "link": "macros.html#fls_V1WRuzZUWUGj",
+                            "number": "20.1.2:4"
+                        },
+                        {
+                            "checksum": "cc21d8251493e001ac2bf6dc3b6d9869a4525b75ff8bdd4a6b96569f649bd5a7",
+                            "id": "fls_u86j0zm2jshf",
+                            "link": "macros.html#fls_u86j0zm2jshf",
+                            "number": "20.1.2:5"
+                        },
+                        {
+                            "checksum": "decb59aaa3220c66f8fa18342f46b9dbbd8d79ae738262d7cc8d3276f0d6f871",
+                            "id": "fls_h5f8x4jdnvbu",
+                            "link": "macros.html#fls_h5f8x4jdnvbu",
+                            "number": "20.1.2:6"
+                        },
+                        {
+                            "checksum": "8cb8cbde345ddbe65efa4ff3d8e5aa2db38eaa6626cdd39220f0a691c264783d",
+                            "id": "fls_hf4gj5pfl437",
+                            "link": "macros.html#fls_hf4gj5pfl437",
+                            "number": "20.1.2:7"
+                        },
+                        {
+                            "checksum": "e94a58c9be4a3e503fe157cfb77e90b5e89fe37b134ffb1f6f08c47bd52ea5f9",
+                            "id": "fls_tm0w0680wf4x",
+                            "link": "macros.html#fls_tm0w0680wf4x",
+                            "number": "20.1.2:8"
+                        },
+                        {
+                            "checksum": "3cdc79fac2c5194ed7084ae18321fb32b4db88a78ed80cc4f4432b4894648505",
+                            "id": "fls_10lsg5212ffb",
+                            "link": "macros.html#fls_10lsg5212ffb",
+                            "number": "20.1.2:9"
+                        },
+                        {
+                            "checksum": "44e5e09eadfa0ef32f2aa42f5d86aefc29a08264af8ea9678ec830ac5d0d919c",
+                            "id": "fls_UnfvR9NB1Nze",
+                            "link": "macros.html#fls_UnfvR9NB1Nze",
+                            "number": "20.1.2:10"
+                        },
+                        {
+                            "checksum": "ada08a290b60070c6aae793052fba60f6404e5668f5da364e16a178044452d6a",
+                            "id": "fls_Sm4qVsHKYLY2",
+                            "link": "macros.html#fls_Sm4qVsHKYLY2",
+                            "number": "20.1.2:11"
+                        },
+                        {
+                            "checksum": "ea5e5013c9fbf8d7b889cd0fe21718fb395b30a9d7cd9f10b911a150dc32decd",
+                            "id": "fls_Rdvs8Dz6OUU7",
+                            "link": "macros.html#fls_Rdvs8Dz6OUU7",
+                            "number": "20.1.2:12"
+                        },
+                        {
+                            "checksum": "e9e82608e910aea5e4b9b881e3bbc4f832130dd93a971ad1d979ae6b3be81ba8",
+                            "id": "fls_UIlj6Csow81w",
+                            "link": "macros.html#fls_UIlj6Csow81w",
+                            "number": "20.1.2:13"
+                        },
+                        {
+                            "checksum": "31f297fdd3706a0010aae6400f9a4d0d7368160c1aebd8e60699f9e9fbdf2639",
+                            "id": "fls_yp2XxDv4DzEi",
+                            "link": "macros.html#fls_yp2XxDv4DzEi",
+                            "number": "20.1.2:14"
+                        },
+                        {
+                            "checksum": "e542a9b407077073772387ef8c3ca43d8afb0cf939f1285a5c47b7d07ad1979d",
+                            "id": "fls_n5TkJKWiDhCD",
+                            "link": "macros.html#fls_n5TkJKWiDhCD",
+                            "number": "20.1.2:15"
+                        }
+                    ],
+                    "title": "Repetition"
+                },
+                {
+                    "id": "fls_wn1i6hzg2ff7",
+                    "informational": false,
+                    "link": "macros.html#procedural-macros",
+                    "number": "20.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "40ae367af875e89e010e4d22a7cfe13aa5dbaed9fc46011de6b52d138577092f",
+                            "id": "fls_ejbddhggstd2",
+                            "link": "macros.html#fls_ejbddhggstd2",
+                            "number": "20.2:1"
+                        },
+                        {
+                            "checksum": "a154977cec887d19447bb9d7566684f5f07b10108feaad22add360f52cade411",
+                            "id": "fls_pcce9gmjpxba",
+                            "link": "macros.html#fls_pcce9gmjpxba",
+                            "number": "20.2:2"
+                        },
+                        {
+                            "checksum": "0f0739a1ed671f541972aa194b63778a35eef1f8a258625357bad1dfb79126ec",
+                            "id": "fls_vtzuplb1p3s",
+                            "link": "macros.html#fls_vtzuplb1p3s",
+                            "number": "20.2:3"
+                        },
+                        {
+                            "checksum": "b0d421770e39ab6631e15b540881bf6453ecda3a0bbc8c78183bba9be46e6c77",
+                            "id": "fls_mewfehvgm16r",
+                            "link": "macros.html#fls_mewfehvgm16r",
+                            "number": "20.2:4"
+                        }
+                    ],
+                    "title": "Procedural Macros"
+                },
+                {
+                    "id": "fls_2d6bqnpy6tvs",
+                    "informational": false,
+                    "link": "macros.html#function-like-macros",
+                    "number": "20.2.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "35211e047d31106ec03bc1b7ccba14cee77f4c950b50ddedbd47d9cbe9dc876f",
+                            "id": "fls_utd3zqczix",
+                            "link": "macros.html#fls_utd3zqczix",
+                            "number": "20.2.1:1"
+                        },
+                        {
+                            "checksum": "195f49e7c5486c12cd274b338a19d3eaa1a19f99570f7ee0b52a3b1eeb90251e",
+                            "id": "fls_ojr30lf6jfx0",
+                            "link": "macros.html#fls_ojr30lf6jfx0",
+                            "number": "20.2.1:2"
+                        },
+                        {
+                            "checksum": "1d126893f14def3d9f5d85d0190f84dc53a460ce5e6da350afffa20da8714d0b",
+                            "id": "fls_ljkjmegynhiy",
+                            "link": "macros.html#fls_ljkjmegynhiy",
+                            "number": "20.2.1:3"
+                        },
+                        {
+                            "checksum": "1a1931bdd5b2a64999e14fa18b646001ec64e8e677c906ce614ba221a5dbf2c6",
+                            "id": "fls_8a8qhzjw5hax",
+                            "link": "macros.html#fls_8a8qhzjw5hax",
+                            "number": "20.2.1:4"
+                        },
+                        {
+                            "checksum": "589f04afe8c234ee2c179f3f0931eaded30292da86287719098525edb953002c",
+                            "id": "fls_ofzql79i9if",
+                            "link": "macros.html#fls_ofzql79i9if",
+                            "number": "20.2.1:5"
+                        },
+                        {
+                            "checksum": "67268d716ea7849d7125350436f4e4a6d5d38effc37ae5216408b2690ab8d033",
+                            "id": "fls_j1wsyzip2qb3",
+                            "link": "macros.html#fls_j1wsyzip2qb3",
+                            "number": "20.2.1:6"
+                        },
+                        {
+                            "checksum": "ba0099799988b2f6d17799a6f6f9c33b477183b8eeec921be942c1c46fe6e668",
+                            "id": "fls_etyo9bmzxby6",
+                            "link": "macros.html#fls_etyo9bmzxby6",
+                            "number": "20.2.1:7"
+                        },
+                        {
+                            "checksum": "7de42cd159846bf2a84aba1bcaf2c1f39e0a6092c7db776d8abb5854419ee2c1",
+                            "id": "fls_mkl9b38m0sf1",
+                            "link": "macros.html#fls_mkl9b38m0sf1",
+                            "number": "20.2.1:8"
+                        },
+                        {
+                            "checksum": "6e54b9a8b956ed9a206672b6145a346a9d87f0734de85341ef04814529bcee31",
+                            "id": "fls_lfmb22bfnrye",
+                            "link": "macros.html#fls_lfmb22bfnrye",
+                            "number": "20.2.1:9"
+                        },
+                        {
+                            "checksum": "78e85689e473377a80352ef6fe022993d405de27b2c6c0393cc70edc6d40e0e8",
+                            "id": "fls_fbgal48cgj44",
+                            "link": "macros.html#fls_fbgal48cgj44",
+                            "number": "20.2.1:10"
+                        }
+                    ],
+                    "title": "Function-like Macros"
+                },
+                {
+                    "id": "fls_o8s3r7m90q59",
+                    "informational": false,
+                    "link": "macros.html#derive-macros",
+                    "number": "20.2.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "aeee3f491d3c18c862f68c8f41eed353a109270ae1f717f9d5620bd9e311fbc6",
+                            "id": "fls_e5x92q2rq8a0",
+                            "link": "macros.html#fls_e5x92q2rq8a0",
+                            "number": "20.2.2:1"
+                        },
+                        {
+                            "checksum": "5242e5a075162a366a5adf0a32e20e73a4ed4c93a3b63541a8201de95af0cbfe",
+                            "id": "fls_ldw75sy5uj7p",
+                            "link": "macros.html#fls_ldw75sy5uj7p",
+                            "number": "20.2.2:2"
+                        },
+                        {
+                            "checksum": "77dd4bd0709e93df0c9294bd185bd0cb487a9e1991042f0cb0ecffb5df13bc60",
+                            "id": "fls_7gcnui9beky",
+                            "link": "macros.html#fls_7gcnui9beky",
+                            "number": "20.2.2:3"
+                        },
+                        {
+                            "checksum": "7fa2a69e91d4ee885cc21d70cb2d326b60305f03bba8a17a36209a53457749bb",
+                            "id": "fls_ef30ropg7dhx",
+                            "link": "macros.html#fls_ef30ropg7dhx",
+                            "number": "20.2.2:4"
+                        },
+                        {
+                            "checksum": "700ee188839152335fdb7422422a37ae9cb40c8bb9bc9940787cd260d61e7276",
+                            "id": "fls_mo00vqm9xfqc",
+                            "link": "macros.html#fls_mo00vqm9xfqc",
+                            "number": "20.2.2:5"
+                        },
+                        {
+                            "checksum": "d8d72a951c13aa5fe8714a16539462fbbaf7ead2c1ad8ecd97cf3071f5db6ab8",
+                            "id": "fls_gr9wugeqyb3b",
+                            "link": "macros.html#fls_gr9wugeqyb3b",
+                            "number": "20.2.2:6"
+                        },
+                        {
+                            "checksum": "6a638cc0c5ef1383ed2612ba3ab85735c70a35cbabcde5839d61b426d3411406",
+                            "id": "fls_npnze2cg8ae",
+                            "link": "macros.html#fls_npnze2cg8ae",
+                            "number": "20.2.2:7"
+                        },
+                        {
+                            "checksum": "704edbd352cfa964eac3571f6d328a271b59ec3801b0d4deb1b3ff167d9edcbf",
+                            "id": "fls_w2h4lk6bmht",
+                            "link": "macros.html#fls_w2h4lk6bmht",
+                            "number": "20.2.2:8"
+                        },
+                        {
+                            "checksum": "f217c6bc6e853a2b8556dbc0b41314003eaa542eca75e8a17d1573264d4e2151",
+                            "id": "fls_x96a0xzcyrko",
+                            "link": "macros.html#fls_x96a0xzcyrko",
+                            "number": "20.2.2:9"
+                        },
+                        {
+                            "checksum": "a284d52790bdad317fdaac6d6bb30541a4dba804471aa74bf317849a3eba4ca2",
+                            "id": "fls_caa16usjxryg",
+                            "link": "macros.html#fls_caa16usjxryg",
+                            "number": "20.2.2:10"
+                        },
+                        {
+                            "checksum": "81811154b26e520b237186a9289476a52adca1dac91598bea29f6d2f8ad5c0af",
+                            "id": "fls_H5ipqqlH3pJh",
+                            "link": "macros.html#fls_H5ipqqlH3pJh",
+                            "number": "20.2.2:11"
+                        },
+                        {
+                            "checksum": "99a2dde0b9166346d32d075006f6fff461527d79389470e64b255fb7a9f63733",
+                            "id": "fls_mobky5ck1mi",
+                            "link": "macros.html#fls_mobky5ck1mi",
+                            "number": "20.2.2:12"
+                        }
+                    ],
+                    "title": "Derive Macros"
+                },
+                {
+                    "id": "fls_4vjbkm4ceymk",
+                    "informational": false,
+                    "link": "macros.html#attribute-macros",
+                    "number": "20.2.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "a507e2ee0a755f9e9bef9483a14b746466426c98185a2634629bff10acf93070",
+                            "id": "fls_l3epi1dqpi8o",
+                            "link": "macros.html#fls_l3epi1dqpi8o",
+                            "number": "20.2.3:1"
+                        },
+                        {
+                            "checksum": "ad536eef612c80a23662ccb5976e09fc7a7cd564b3099362de958cb078de4636",
+                            "id": "fls_3sublbi9bz7k",
+                            "link": "macros.html#fls_3sublbi9bz7k",
+                            "number": "20.2.3:2"
+                        },
+                        {
+                            "checksum": "0e6bc1537645755a80173fb2e360056fe473f07b84fa83e420a2119802b5688e",
+                            "id": "fls_eb8jxl70wmeh",
+                            "link": "macros.html#fls_eb8jxl70wmeh",
+                            "number": "20.2.3:3"
+                        },
+                        {
+                            "checksum": "65f907abc0b4741ed3d04dfb54bf57f7733475bd00f7eb52a681cf2df6dd26cf",
+                            "id": "fls_7ugtmobgb2t9",
+                            "link": "macros.html#fls_7ugtmobgb2t9",
+                            "number": "20.2.3:4"
+                        },
+                        {
+                            "checksum": "ef5cb13d4e805e4e81816f26647b316792ceb249829578bfaa57070acb415879",
+                            "id": "fls_y700oif45wum",
+                            "link": "macros.html#fls_y700oif45wum",
+                            "number": "20.2.3:5"
+                        },
+                        {
+                            "checksum": "a67726cd1b3c0fa718910126228b74a584cd8d14685cff5a51c66aecafa25a2e",
+                            "id": "fls_hhsf1a9p6o55",
+                            "link": "macros.html#fls_hhsf1a9p6o55",
+                            "number": "20.2.3:6"
+                        },
+                        {
+                            "checksum": "85bf012ed3c7f1fe9e724f38a2d891b1697ec17ecde0a3277e037fe496069d6a",
+                            "id": "fls_4g932k8ueyqp",
+                            "link": "macros.html#fls_4g932k8ueyqp",
+                            "number": "20.2.3:7"
+                        },
+                        {
+                            "checksum": "301c590c9b06bc5965288c7611ce54546237f2ab270ad8d08ada06606d3129bf",
+                            "id": "fls_f5qy1pnlbpng",
+                            "link": "macros.html#fls_f5qy1pnlbpng",
+                            "number": "20.2.3:8"
+                        },
+                        {
+                            "checksum": "db387e1df17fe1b34f0785313cbd032471da2d489046fbbd57783da324ddd87b",
+                            "id": "fls_rzn48xylk4yj",
+                            "link": "macros.html#fls_rzn48xylk4yj",
+                            "number": "20.2.3:9"
+                        },
+                        {
+                            "checksum": "ae2d00ba71cdeeebcbc5ba13db842b607d9367375f608225d84eeb55ce0afb90",
+                            "id": "fls_78400zh02sdq",
+                            "link": "macros.html#fls_78400zh02sdq",
+                            "number": "20.2.3:10"
+                        },
+                        {
+                            "checksum": "130f778e0740bb2eac48f0b045d7c7d7854a7f114684fd426c548a5289d530b9",
+                            "id": "fls_eyesmvuwpjn1",
+                            "link": "macros.html#fls_eyesmvuwpjn1",
+                            "number": "20.2.3:11"
+                        },
+                        {
+                            "checksum": "a9469713d62e5ab294be5b5463896a680482fe532ef2db60c9a17dd040147917",
+                            "id": "fls_fku5beu3mr4c",
+                            "link": "macros.html#fls_fku5beu3mr4c",
+                            "number": "20.2.3:12"
+                        },
+                        {
+                            "checksum": "1f2493e72099adeeabdbdb5af0e9a9021fe478c82c788215781e06312b59c4e4",
+                            "id": "fls_knjsslplv5ri",
+                            "link": "macros.html#fls_knjsslplv5ri",
+                            "number": "20.2.3:13"
+                        }
+                    ],
+                    "title": "Attribute Macros"
+                },
+                {
+                    "id": "fls_vnvt40pa48n8",
+                    "informational": false,
+                    "link": "macros.html#macro-invocation",
+                    "number": "20.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "2d88086f369da9c00a710d6478ff80775749dcb789b8f28b671fa96d22b5c01e",
+                            "id": "fls_wushtmw9qt3y",
+                            "link": "macros.html#fls_wushtmw9qt3y",
+                            "number": "20.3:1"
+                        },
+                        {
+                            "checksum": "974d06554ff28647c4f903fa86768f1e175bc518e3c538c7d26f09ca32580f3a",
+                            "id": "fls_snpxxcqhtjfv",
+                            "link": "macros.html#fls_snpxxcqhtjfv",
+                            "number": "20.3:2"
+                        },
+                        {
+                            "checksum": "9331eac9772bb3030cfa592afd0542c15f135b1445df9e764e483111e6e799e5",
+                            "id": "fls_6v06zvi1ctub",
+                            "link": "macros.html#fls_6v06zvi1ctub",
+                            "number": "20.3:3"
+                        },
+                        {
+                            "checksum": "7b9182c06cf00fd455b1965ab8a30dda3df6d618c935ed284f6ca291707e0599",
+                            "id": "fls_338rmbazl67o",
+                            "link": "macros.html#fls_338rmbazl67o",
+                            "number": "20.3:4"
+                        },
+                        {
+                            "checksum": "f0d9a1f0b0eab822233723ad23f52e94ac8af7a075116203900e841cce37b8ed",
+                            "id": "fls_lrr7gg8tian",
+                            "link": "macros.html#fls_lrr7gg8tian",
+                            "number": "20.3:5"
+                        },
+                        {
+                            "checksum": "2f1f05665a7725eb786fccfba3d43fc78ce77ef15cfcf47af07e6cb0c9b8b6ff",
+                            "id": "fls_8qxwwf4trnl",
+                            "link": "macros.html#fls_8qxwwf4trnl",
+                            "number": "20.3:6"
+                        },
+                        {
+                            "checksum": "c0738db650ac62715e9597df801371e725fa1a1faf26794dba7b764fe0e1c70b",
+                            "id": "fls_8z1sgtvchhhw",
+                            "link": "macros.html#fls_8z1sgtvchhhw",
+                            "number": "20.3:7"
+                        },
+                        {
+                            "checksum": "27e64c85ad3e00def820e0904a4aa2d4beaac06c9fb0feccce519d3b3d81492d",
+                            "id": "fls_d9w3dn2yn7mo",
+                            "link": "macros.html#fls_d9w3dn2yn7mo",
+                            "number": "20.3:8"
+                        },
+                        {
+                            "checksum": "a5ebe407976f7eb1733d25250fff1be138a66bf342fac15d3226e09e6ffbcb31",
+                            "id": "fls_1tftbd91yfpd",
+                            "link": "macros.html#fls_1tftbd91yfpd",
+                            "number": "20.3:9"
+                        }
+                    ],
+                    "title": "Macro Invocation"
+                },
+                {
+                    "id": "fls_wjldgtio5o75",
+                    "informational": false,
+                    "link": "macros.html#macro-expansion",
+                    "number": "20.4",
+                    "paragraphs": [
+                        {
+                            "checksum": "8026222297277fbad4ed1549d49f0c3e75d7e5157adbb94d90360ceb716f2a3d",
+                            "id": "fls_xscdaxvs4wx4",
+                            "link": "macros.html#fls_xscdaxvs4wx4",
+                            "number": "20.4:1"
+                        },
+                        {
+                            "checksum": "81bdfdb7218e324273181015cf2a0058601e53a6f07875e9c55f6b9ccd110600",
+                            "id": "fls_nz5stwcc41gk",
+                            "link": "macros.html#fls_nz5stwcc41gk",
+                            "number": "20.4:2"
+                        },
+                        {
+                            "checksum": "bf49814afca1afc4a1ea61da7acaf9bb0ac3da4e8a3d40a8a0ad770017aaf4e2",
+                            "id": "fls_40xq8Ri1OMZZ",
+                            "link": "macros.html#fls_40xq8Ri1OMZZ",
+                            "number": "20.4:3"
+                        },
+                        {
+                            "checksum": "f2e3b68bee58b99bd43a9238014702fed0da098493aea6cd5ee8c35d689b2cfb",
+                            "id": "fls_76prdp6k1fga",
+                            "link": "macros.html#fls_76prdp6k1fga",
+                            "number": "20.4:4"
+                        },
+                        {
+                            "checksum": "74b6ccc123fd68357e50a1ba7a24fcfb694a68271bd2c7156e558945c62bb744",
+                            "id": "fls_76u274l4kew8",
+                            "link": "macros.html#fls_76u274l4kew8",
+                            "number": "20.4:5"
+                        },
+                        {
+                            "checksum": "41396541fe1131f8e3a05e47eb4dc795aca82ca7744db28c5808acbbcec8c548",
+                            "id": "fls_lakpily1zwfl",
+                            "link": "macros.html#fls_lakpily1zwfl",
+                            "number": "20.4:6"
+                        },
+                        {
+                            "checksum": "145096281559894c5fdd9c34f4c59020e8018a542a295c4718a2158eb1c24db6",
+                            "id": "fls_y20pmwo3v3uu",
+                            "link": "macros.html#fls_y20pmwo3v3uu",
+                            "number": "20.4:7"
+                        },
+                        {
+                            "checksum": "73e7c3d42509b26c6836a37c592ce6b5f8b4b8d51bdd13b1e69c781dbdb074ac",
+                            "id": "fls_nsh2vwx8oiw",
+                            "link": "macros.html#fls_nsh2vwx8oiw",
+                            "number": "20.4:8"
+                        },
+                        {
+                            "checksum": "2e54f1caa1c75bb8c551cb037444610dab84c77e38bccd44a64d81885462bfb0",
+                            "id": "fls_tu6kmwm4v9nj",
+                            "link": "macros.html#fls_tu6kmwm4v9nj",
+                            "number": "20.4:9"
+                        },
+                        {
+                            "checksum": "3b01afcc0d4c9f2696ea110f2556ea0c37503ac92544dd77a5853e2bc4cc735c",
+                            "id": "fls_3zn4dz19nyvq",
+                            "link": "macros.html#fls_3zn4dz19nyvq",
+                            "number": "20.4:10"
+                        },
+                        {
+                            "checksum": "39601be41eaf38c2fe68a562e68628c4c897e8c99f95ec75e583dbefab3af157",
+                            "id": "fls_t89sw6az99z7",
+                            "link": "macros.html#fls_t89sw6az99z7",
+                            "number": "20.4:11"
+                        },
+                        {
+                            "checksum": "48dbce0bae72db846dd146bad2ff656a10cf5dd99c403720ad8a65ff71bf965e",
+                            "id": "fls_417hvhvj2554",
+                            "link": "macros.html#fls_417hvhvj2554",
+                            "number": "20.4:12"
+                        },
+                        {
+                            "checksum": "10c68086f5de7156157c189ebd2864036d21287d9219fdce6f5e9df7658f3e2a",
+                            "id": "fls_nNrs4EC3ff5T",
+                            "link": "macros.html#fls_nNrs4EC3ff5T",
+                            "number": "20.4:13"
+                        },
+                        {
+                            "checksum": "303da91f4606ee986ceddcb3a6dd2990ea1a5d6f4d8ff9eba1411b05f9cfa29c",
+                            "id": "fls_srtqkdceaz5t",
+                            "link": "macros.html#fls_srtqkdceaz5t",
+                            "number": "20.4:14"
+                        },
+                        {
+                            "checksum": "57347ca4d51ad58880a851280bfb8d8e529e1b9951a52ca4929e47b94f19be4e",
+                            "id": "fls_mi92etjtpamu",
+                            "link": "macros.html#fls_mi92etjtpamu",
+                            "number": "20.4:15"
+                        },
+                        {
+                            "checksum": "9a60784d14b99e43a10674a97c9f853c1fda603311694eaa435886353f7102ab",
+                            "id": "fls_n8beqlt54rhy",
+                            "link": "macros.html#fls_n8beqlt54rhy",
+                            "number": "20.4:16"
+                        },
+                        {
+                            "checksum": "04d7c36c59b8db5f9cd9d437097d1287b1462b3d1a28b1af866979139758cf22",
+                            "id": "fls_vd3dzvr6re19",
+                            "link": "macros.html#fls_vd3dzvr6re19",
+                            "number": "20.4:17"
+                        },
+                        {
+                            "checksum": "8738a7304a24b50b3140d449d1bfca2c9baf6da9f0d078a51401795554fd4474",
+                            "id": "fls_l8j2jiuuao4f",
+                            "link": "macros.html#fls_l8j2jiuuao4f",
+                            "number": "20.4:18"
+                        },
+                        {
+                            "checksum": "d26201e9ec1b8ce4e8d0ce918281c597b4207dd5c717ab9d2f690dc2d3fa69f6",
+                            "id": "fls_xvemyqj5gc6g",
+                            "link": "macros.html#fls_xvemyqj5gc6g",
+                            "number": "20.4:19"
+                        },
+                        {
+                            "checksum": "9cd6b3fdd12de5819ef5f034cd512142d9ea7275dd351bb3364534aede42230d",
+                            "id": "fls_stseor6tln22",
+                            "link": "macros.html#fls_stseor6tln22",
+                            "number": "20.4:20"
+                        },
+                        {
+                            "checksum": "785c20cd4ee512f170f8821ae84ac3e0164356afb744c5eb7766d1b428f43f95",
+                            "id": "fls_u11o90szy68s",
+                            "link": "macros.html#fls_u11o90szy68s",
+                            "number": "20.4:21"
+                        },
+                        {
+                            "checksum": "42ff8c1ac6cc0dad7129ac746debad5fa96d773994a30fdf5b71496e0fe894be",
+                            "id": "fls_qi5kyvj1e8th",
+                            "link": "macros.html#fls_qi5kyvj1e8th",
+                            "number": "20.4:22"
+                        },
+                        {
+                            "checksum": "75411eced63ec88091cc61ad48545c56af50d13cdfbb58da468cfcd471b1d753",
+                            "id": "fls_vqIZaEl4EKu5",
+                            "link": "macros.html#fls_vqIZaEl4EKu5",
+                            "number": "20.4:23"
+                        },
+                        {
+                            "checksum": "8336e9a3dc539d94ebc4c3f4d1db0a002daac4a11ed04f66f0c8944f7c59dadc",
+                            "id": "fls_grtiwf7q8jah",
+                            "link": "macros.html#fls_grtiwf7q8jah",
+                            "number": "20.4:24"
+                        },
+                        {
+                            "checksum": "862660c9a7927486f4ab97a5219efca956468b25a372e7f0b8778d938fea614f",
+                            "id": "fls_tbe2qq7whq10",
+                            "link": "macros.html#fls_tbe2qq7whq10",
+                            "number": "20.4:25"
+                        },
+                        {
+                            "checksum": "56c2e17cefa41716653ddebd7376d5e765866b6b48613007cbd6fa266ec588a1",
+                            "id": "fls_my93neopj9x0",
+                            "link": "macros.html#fls_my93neopj9x0",
+                            "number": "20.4:26"
+                        },
+                        {
+                            "checksum": "6f0481d9039a52034b6e9c95142a26b01f4af587546d9d2ca76ccdcdce2cf14c",
+                            "id": "fls_zat7kwi5vc5c",
+                            "link": "macros.html#fls_zat7kwi5vc5c",
+                            "number": "20.4:27"
+                        },
+                        {
+                            "checksum": "4ed573b9e2ba6991e0c8cd77151c8f7fb439090236dff6dcba9b8dd9d06d2604",
+                            "id": "fls_tjn92evtlflq",
+                            "link": "macros.html#fls_tjn92evtlflq",
+                            "number": "20.4:28"
+                        },
+                        {
+                            "checksum": "9e9dd4998f98b6a17410d0f5050a5640b8a7d12b16d5ccc1fbf5ddfc4fa2c910",
+                            "id": "fls_AJmPrhHfZo6J",
+                            "link": "macros.html#fls_AJmPrhHfZo6J",
+                            "number": "20.4:29"
+                        },
+                        {
+                            "checksum": "d54d6148b8f96f7ae615b20d921e9536dec2d40191387304db5912c07457039c",
+                            "id": "fls_mpgh22bi8caz",
+                            "link": "macros.html#fls_mpgh22bi8caz",
+                            "number": "20.4:30"
+                        },
+                        {
+                            "checksum": "ecc18764aaf923e05323ff7d8dbc3196f9c2a677d000895c4350a34de447d370",
+                            "id": "fls_ul7nhfyvyzh",
+                            "link": "macros.html#fls_ul7nhfyvyzh",
+                            "number": "20.4:31"
+                        },
+                        {
+                            "checksum": "61b9b13308b8c7583de5aab70fe1644dee9867664a812351e4a713132df8f246",
+                            "id": "fls_z6xfhf71w10a",
+                            "link": "macros.html#fls_z6xfhf71w10a",
+                            "number": "20.4:32"
+                        }
+                    ],
+                    "title": "Macro Expansion"
+                },
+                {
+                    "id": "fls_4apk1exafxii",
+                    "informational": false,
+                    "link": "macros.html#macro-matching",
+                    "number": "20.4.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "6b8396da1325228a967d0d28720f37811bfec9f46d17c5b5d20ab8838236c8d1",
+                            "id": "fls_ZmQZ8HQWv77L",
+                            "link": "macros.html#fls_ZmQZ8HQWv77L",
+                            "number": "20.4.1:1"
+                        }
+                    ],
+                    "title": "Macro Matching"
+                },
+                {
+                    "id": "fls_n3ktmjqf87qb",
+                    "informational": false,
+                    "link": "macros.html#rule-matching",
+                    "number": "20.4.1.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "86e93126d0e6c567afa83d3532a9dda63596c2a3a1b8fa60469481ff4891e786",
+                            "id": "fls_77ucvwu6idms",
+                            "link": "macros.html#fls_77ucvwu6idms",
+                            "number": "20.4.1.1:1"
+                        },
+                        {
+                            "checksum": "4c41fb4fb8823d556cfb539659a3c4703c73a1c321684dd511b7f178f2ee5439",
+                            "id": "fls_6h1jqhxzku5v",
+                            "link": "macros.html#fls_6h1jqhxzku5v",
+                            "number": "20.4.1.1:2"
+                        },
+                        {
+                            "checksum": "6ff3d3159841229f8392ab25c21c4749d84f44f9448851671427adf3fa2c97f8",
+                            "id": "fls_r6i1ykrhb49j",
+                            "link": "macros.html#fls_r6i1ykrhb49j",
+                            "number": "20.4.1.1:3"
+                        },
+                        {
+                            "checksum": "d6cdc5aaa72a1fe038b82e1c7963c4446c2bc7668ed2fae5540f1dd6416a865f",
+                            "id": "fls_3qzes4lr8yuv",
+                            "link": "macros.html#fls_3qzes4lr8yuv",
+                            "number": "20.4.1.1:4"
+                        },
+                        {
+                            "checksum": "b69c21d1eb5931b6f4848c2e230a9199999a3b94ade1ff93a4c66ba685343958",
+                            "id": "fls_r878ysvsy4jb",
+                            "link": "macros.html#fls_r878ysvsy4jb",
+                            "number": "20.4.1.1:5"
+                        }
+                    ],
+                    "title": "Rule Matching"
+                },
+                {
+                    "id": "fls_qpx6lgapce57",
+                    "informational": false,
+                    "link": "macros.html#token-matching",
+                    "number": "20.4.1.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "939454db28503818aeec06820dacf2ab2a82bb11e9ebd50d2b097213c7223ae4",
+                            "id": "fls_k6a24sbon5v9",
+                            "link": "macros.html#fls_k6a24sbon5v9",
+                            "number": "20.4.1.2:1"
+                        },
+                        {
+                            "checksum": "69d0900d72789c738bb16a2cd4d7cd0938784373e5835a4c87c5655968e72f06",
+                            "id": "fls_6uuxv91xgmfz",
+                            "link": "macros.html#fls_6uuxv91xgmfz",
+                            "number": "20.4.1.2:2"
+                        },
+                        {
+                            "checksum": "9676823aa002fa0b34ed9ceb6cdf528e036dd054cc9680fd769fbfbabbdf2f33",
+                            "id": "fls_g1rml9tavh8v",
+                            "link": "macros.html#fls_g1rml9tavh8v",
+                            "number": "20.4.1.2:3"
+                        },
+                        {
+                            "checksum": "485dc2a03abcfc575a18d12f44392c25e70e3d6c8c7defe90be8b259721e9cf2",
+                            "id": "fls_h7x3tc208zpk",
+                            "link": "macros.html#fls_h7x3tc208zpk",
+                            "number": "20.4.1.2:4"
+                        },
+                        {
+                            "checksum": "4e3b1a4397f68e72da8d33b18764d344b2cdc18f83b97ddefee8dbdef401dc87",
+                            "id": "fls_p9eqa17d3dx",
+                            "link": "macros.html#fls_p9eqa17d3dx",
+                            "number": "20.4.1.2:5"
+                        },
+                        {
+                            "checksum": "d54b6dc3d7995358cb1bb0e6672591cf1d8416a887f73cf8f3f2d2d7347d499b",
+                            "id": "fls_k00bck2k8tde",
+                            "link": "macros.html#fls_k00bck2k8tde",
+                            "number": "20.4.1.2:6"
+                        },
+                        {
+                            "checksum": "9beee8340868a57b1052f0fc0b375a60221fffc91fe52f2b2a049ecea579e62e",
+                            "id": "fls_pf0qrz5nadl2",
+                            "link": "macros.html#fls_pf0qrz5nadl2",
+                            "number": "20.4.1.2:7"
+                        },
+                        {
+                            "checksum": "944fc29dfd11666e10802285b2515966d675e8dd3dba1e06c0e50e2db56199cf",
+                            "id": "fls_9fioah171ojx",
+                            "link": "macros.html#fls_9fioah171ojx",
+                            "number": "20.4.1.2:8"
+                        },
+                        {
+                            "checksum": "3a4366c2f44243bd2284234dca5b270e4dc4a86d1f32a617a269adb290fb8985",
+                            "id": "fls_j2o0f52zyvyb",
+                            "link": "macros.html#fls_j2o0f52zyvyb",
+                            "number": "20.4.1.2:9"
+                        },
+                        {
+                            "checksum": "e4f9ae7e642ed779024a8e69cea6afc9bd400fd2105ce496a574bcc9be0bf3d7",
+                            "id": "fls_w5dzv3z4zd5a",
+                            "link": "macros.html#fls_w5dzv3z4zd5a",
+                            "number": "20.4.1.2:10"
+                        },
+                        {
+                            "checksum": "a6923eaff6739eb4d6492f970c783cfdabc71c275843e5ef6405fff5af5b0432",
+                            "id": "fls_wtol98rrqka5",
+                            "link": "macros.html#fls_wtol98rrqka5",
+                            "number": "20.4.1.2:11"
+                        },
+                        {
+                            "checksum": "80a04645ad370bbb071324afb5d55d19b18f915e9fadfab568496d6a3a18fa5f",
+                            "id": "fls_iorqt9q4ie9j",
+                            "link": "macros.html#fls_iorqt9q4ie9j",
+                            "number": "20.4.1.2:12"
+                        },
+                        {
+                            "checksum": "b45c38305f3c3ffa6bf27034b89cc6b8baac7a4e72914a0cfdf7eeee7da69266",
+                            "id": "fls_2zjed913qpvi",
+                            "link": "macros.html#fls_2zjed913qpvi",
+                            "number": "20.4.1.2:13"
+                        },
+                        {
+                            "checksum": "d58dc97395dae9ccb1d8fe2a21911f6287c2676be72fea50a94301b4b85614fb",
+                            "id": "fls_3zdts0fsa36u",
+                            "link": "macros.html#fls_3zdts0fsa36u",
+                            "number": "20.4.1.2:14"
+                        },
+                        {
+                            "checksum": "0f22177e56930189a013cc165f27159e88950b6309aec5aa8f36dad4fc00070b",
+                            "id": "fls_mb3yr1j7npv5",
+                            "link": "macros.html#fls_mb3yr1j7npv5",
+                            "number": "20.4.1.2:15"
+                        },
+                        {
+                            "checksum": "8b44cfe64ffb38c055354fd03755c38a67d369899996d279000749b6938b4130",
+                            "id": "fls_xbuixjt9pum6",
+                            "link": "macros.html#fls_xbuixjt9pum6",
+                            "number": "20.4.1.2:16"
+                        },
+                        {
+                            "checksum": "2868c75bd1038a056153d19675c38e727498801f62dcf998f97e79d1feb762aa",
+                            "id": "fls_6annifhk6cd8",
+                            "link": "macros.html#fls_6annifhk6cd8",
+                            "number": "20.4.1.2:17"
+                        },
+                        {
+                            "checksum": "8a369cdda5e38c9d0c9235244570dc6350c8f7513c2a5dc0ce5b97503f92b7ef",
+                            "id": "fls_2zu22efr6ncy",
+                            "link": "macros.html#fls_2zu22efr6ncy",
+                            "number": "20.4.1.2:18"
+                        },
+                        {
+                            "checksum": "235bfe3d83907a5ee61a001a2b2acac3b0e021e603831aed451c1cc984b6a784",
+                            "id": "fls_dqroklsaayzb",
+                            "link": "macros.html#fls_dqroklsaayzb",
+                            "number": "20.4.1.2:19"
+                        },
+                        {
+                            "checksum": "273716f2c264d37ea340ce796a784d1e2b3cb3a16578a954da0dcab1900b6ca9",
+                            "id": "fls_ghqjk6xj85ng",
+                            "link": "macros.html#fls_ghqjk6xj85ng",
+                            "number": "20.4.1.2:20"
+                        },
+                        {
+                            "checksum": "1ff9a6a6d1f6eb7b4c668c7940b8c2e1490c37f93b536e4b0f4468a49095216f",
+                            "id": "fls_lzwl4en5wcw0",
+                            "link": "macros.html#fls_lzwl4en5wcw0",
+                            "number": "20.4.1.2:21"
+                        },
+                        {
+                            "checksum": "622a0124d322fc811ce341d23c250c1d22df2be7065199c523a053e04f93655b",
+                            "id": "fls_cz44evkjzv29",
+                            "link": "macros.html#fls_cz44evkjzv29",
+                            "number": "20.4.1.2:22"
+                        },
+                        {
+                            "checksum": "61ca7e8337e433a1f27f8ca82eda551971c4361a34cf11fb7c23f53368ee2593",
+                            "id": "fls_o2exsai4m0gy",
+                            "link": "macros.html#fls_o2exsai4m0gy",
+                            "number": "20.4.1.2:23"
+                        },
+                        {
+                            "checksum": "2b361f50a42eadd00c2c0ca748063e0d34342f34e39bae540bb8802a83f14882",
+                            "id": "fls_1ch299zp8h7",
+                            "link": "macros.html#fls_1ch299zp8h7",
+                            "number": "20.4.1.2:24"
+                        },
+                        {
+                            "checksum": "225d33e4ff2e8e37f77d0d4ba4811088ee088d027a6ae4a1a4882ca9b039fa98",
+                            "id": "fls_55ptfjlvoo8o",
+                            "link": "macros.html#fls_55ptfjlvoo8o",
+                            "number": "20.4.1.2:25"
+                        },
+                        {
+                            "checksum": "17b373ea759d5c509466cee1cd0f9941a470f136a1109fb7f745dd87e096bcf9",
+                            "id": "fls_finzfb5ljkf8",
+                            "link": "macros.html#fls_finzfb5ljkf8",
+                            "number": "20.4.1.2:26"
+                        },
+                        {
+                            "checksum": "34a0742ef58a8b7fe215596c5252975ec70b4b86687272048bf5ccbee1c21eda",
+                            "id": "fls_s1ccs6jocsgr",
+                            "link": "macros.html#fls_s1ccs6jocsgr",
+                            "number": "20.4.1.2:27"
+                        },
+                        {
+                            "checksum": "408711d561d0aa646b34d91388c4abb3e0e292eecb966dc171c8368efaca46c5",
+                            "id": "fls_wpi2i6hoj3li",
+                            "link": "macros.html#fls_wpi2i6hoj3li",
+                            "number": "20.4.1.2:28"
+                        },
+                        {
+                            "checksum": "c8977ccaa62d4c406898dba6432a60322e5b401d6bd0f7cda07b4b0979bb29f6",
+                            "id": "fls_uuey421a8n96",
+                            "link": "macros.html#fls_uuey421a8n96",
+                            "number": "20.4.1.2:29"
+                        },
+                        {
+                            "checksum": "4538f5121ec15ee6fbd7d3cb0bb690cc955c3d8655feceab5333045461750c15",
+                            "id": "fls_b5u47tuu136r",
+                            "link": "macros.html#fls_b5u47tuu136r",
+                            "number": "20.4.1.2:30"
+                        },
+                        {
+                            "checksum": "38cb0f7a2daa5611bc22dac0b50c555f9d3ffb1127900a2f86ba5a79ff08498a",
+                            "id": "fls_rb1tu4e7dpma",
+                            "link": "macros.html#fls_rb1tu4e7dpma",
+                            "number": "20.4.1.2:31"
+                        },
+                        {
+                            "checksum": "3f33b5ba4b848845ef3c885d9b0b6d3309d5d903bf48ba507cc368dc25cad1ce",
+                            "id": "fls_c76sdvos5xeo",
+                            "link": "macros.html#fls_c76sdvos5xeo",
+                            "number": "20.4.1.2:32"
+                        }
+                    ],
+                    "title": "Token Matching"
+                },
+                {
+                    "id": "fls_ym00b6ewf4n3",
+                    "informational": false,
+                    "link": "macros.html#macro-transcription",
+                    "number": "20.4.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "0625ef0bcc1537bbd7e48bbb52e650fac001e4ce41c99c213d6d9c46b45e74e0",
+                            "id": "fls_y21i8062mft0",
+                            "link": "macros.html#fls_y21i8062mft0",
+                            "number": "20.4.2:1"
+                        },
+                        {
+                            "checksum": "3a923fd62e7cb8e223448548b2aa38404e63cc3e8b41254c70fa1d13076ad338",
+                            "id": "fls_n2dx4ug5nd5w",
+                            "link": "macros.html#fls_n2dx4ug5nd5w",
+                            "number": "20.4.2:2"
+                        },
+                        {
+                            "checksum": "3a3dab26920d694cfc94f0c1b2f51523cd3b42dbae5b61643d7c56834c7220cf",
+                            "id": "fls_iw7322ycvhkc",
+                            "link": "macros.html#fls_iw7322ycvhkc",
+                            "number": "20.4.2:3"
+                        },
+                        {
+                            "checksum": "0138c8400ce4f71c65b6aa2722efe3060cbd1d41df1c72e0d5f3b34a20f300b5",
+                            "id": "fls_jgitbqmyixem",
+                            "link": "macros.html#fls_jgitbqmyixem",
+                            "number": "20.4.2:4"
+                        },
+                        {
+                            "checksum": "5c84ed6a518944136878abb4c88f566d332adfa28adc88939272040b8b6376d9",
+                            "id": "fls_ihcwl6taptas",
+                            "link": "macros.html#fls_ihcwl6taptas",
+                            "number": "20.4.2:5"
+                        },
+                        {
+                            "checksum": "ccd3909779e2ae52e078ac9ec0171a31569a1a5f27a764f1116aa514d4ab1e76",
+                            "id": "fls_g3dtpw4rtgdr",
+                            "link": "macros.html#fls_g3dtpw4rtgdr",
+                            "number": "20.4.2:6"
+                        },
+                        {
+                            "checksum": "cfa58e13c7d71f34271957f476e066a784af6a8ed0072bb215252e5c076b03c3",
+                            "id": "fls_pvp6dxykuv66",
+                            "link": "macros.html#fls_pvp6dxykuv66",
+                            "number": "20.4.2:7"
+                        },
+                        {
+                            "checksum": "c46a8e07cda751526560f7fc97ae3c1b78414ebc17c1ce3cd210620619ebbf25",
+                            "id": "fls_bd673n5awwbz",
+                            "link": "macros.html#fls_bd673n5awwbz",
+                            "number": "20.4.2:8"
+                        },
+                        {
+                            "checksum": "89ea10945ee36c0a8d05b165f2dab20d4778edf60bc0f8b3696a46d9199743b8",
+                            "id": "fls_zbtwrtcy7pzf",
+                            "link": "macros.html#fls_zbtwrtcy7pzf",
+                            "number": "20.4.2:9"
+                        },
+                        {
+                            "checksum": "928fa72878c7bba4b1bce0f51d05314cb2480974eb15a3baa42edf4802016c4b",
+                            "id": "fls_eacyb6jap9ru",
+                            "link": "macros.html#fls_eacyb6jap9ru",
+                            "number": "20.4.2:10"
+                        },
+                        {
+                            "checksum": "923b9e5ad7c41a86ba16ba5fc020547055484598d353ee7d4600ac28f7464960",
+                            "id": "fls_y4podc7ee8lf",
+                            "link": "macros.html#fls_y4podc7ee8lf",
+                            "number": "20.4.2:11"
+                        },
+                        {
+                            "checksum": "b20e0ffba294f223744cb483c484961c3e57930764952f5beab1e3448b7f8cde",
+                            "id": "fls_wbys0m4a1omg",
+                            "link": "macros.html#fls_wbys0m4a1omg",
+                            "number": "20.4.2:12"
+                        },
+                        {
+                            "checksum": "ffbe98be6393f55c5b73a7849f41caadf322b1ac4e018fa42c59e7305db89820",
+                            "id": "fls_g445ovedgo4q",
+                            "link": "macros.html#fls_g445ovedgo4q",
+                            "number": "20.4.2:13"
+                        },
+                        {
+                            "checksum": "4f0f8d199b56a8e97493384b9448af0cf2c03e0ee0924725a9973869747db80f",
+                            "id": "fls_ctzthi6keit2",
+                            "link": "macros.html#fls_ctzthi6keit2",
+                            "number": "20.4.2:14"
+                        },
+                        {
+                            "checksum": "924ac328fa7b1c896d1efd435201562db8738164a53715c1956c4c2da5a4012c",
+                            "id": "fls_9n46ugmcqmix",
+                            "link": "macros.html#fls_9n46ugmcqmix",
+                            "number": "20.4.2:15"
+                        },
+                        {
+                            "checksum": "7c1fe9eccd483e7a420e8b7c1d1c1164588a91adea0ff813953d9cf07171ea38",
+                            "id": "fls_JinrPA0pMZCr",
+                            "link": "macros.html#fls_JinrPA0pMZCr",
+                            "number": "20.4.2:16"
+                        },
+                        {
+                            "checksum": "7b97106af69b3585b467ae757b209987fcfa719d9d0056adfca9fbc914a2d73b",
+                            "id": "fls_95rn4cvgznmd",
+                            "link": "macros.html#fls_95rn4cvgznmd",
+                            "number": "20.4.2:17"
+                        },
+                        {
+                            "checksum": "a990d3628235419098482e04aad2d699f6205b88761be1c1cea45b6dad882cd1",
+                            "id": "fls_yg4c9x7049y4",
+                            "link": "macros.html#fls_yg4c9x7049y4",
+                            "number": "20.4.2:18"
+                        },
+                        {
+                            "checksum": "30c1a84b2185098caed8510493324650b62ebcbc98651ffdef52e7656b859109",
+                            "id": "fls_o9rwz9z0a2h4",
+                            "link": "macros.html#fls_o9rwz9z0a2h4",
+                            "number": "20.4.2:19"
+                        }
+                    ],
+                    "title": "Macro Transcription"
+                },
+                {
+                    "id": "fls_xlfo7di0gsqz",
+                    "informational": false,
+                    "link": "macros.html#hygiene",
+                    "number": "20.5",
+                    "paragraphs": [
+                        {
+                            "checksum": "dd8bbb6eef9dde4a235a404d36082ffd706c870db1421a4681408cf45d6a6bcc",
+                            "id": "fls_7ezc7ncs678f",
+                            "link": "macros.html#fls_7ezc7ncs678f",
+                            "number": "20.5:1"
+                        },
+                        {
+                            "checksum": "950f5e9f05dfb90a7771b7b56a2c154f09546fdb6ee7b4947d3598357e680977",
+                            "id": "fls_3axjf28xb1nt",
+                            "link": "macros.html#fls_3axjf28xb1nt",
+                            "number": "20.5:2"
+                        },
+                        {
+                            "checksum": "341839374d80c8018873df9d4ddc4bc416d5bc2dac1e9b09bc7a56b94374252a",
+                            "id": "fls_dz2mvodl818d",
+                            "link": "macros.html#fls_dz2mvodl818d",
+                            "number": "20.5:3"
+                        },
+                        {
+                            "checksum": "e4746196f1fb7989f818766502b19a237f5b3740241baf2dfd8cb4211c05f424",
+                            "id": "fls_puqhytfzfsg6",
+                            "link": "macros.html#fls_puqhytfzfsg6",
+                            "number": "20.5:4"
+                        },
+                        {
+                            "checksum": "93e969fde4270a39d3cee8c4a0b19185228c33e8b24df9d0ef270765e9824d81",
+                            "id": "fls_uyvnq88y9gk3",
+                            "link": "macros.html#fls_uyvnq88y9gk3",
+                            "number": "20.5:5"
+                        },
+                        {
+                            "checksum": "20c309825d7777388bd6af5804c0c7762b4fe76a90f7d2eb118d92ba8f547c1c",
+                            "id": "fls_yxqcr19dig18",
+                            "link": "macros.html#fls_yxqcr19dig18",
+                            "number": "20.5:6"
+                        },
+                        {
+                            "checksum": "64745f1bbadaf610e425de55287699402147860a4554484ba0071db41bc7ed34",
+                            "id": "fls_kx25olky1jov",
+                            "link": "macros.html#fls_kx25olky1jov",
+                            "number": "20.5:7"
+                        },
+                        {
+                            "checksum": "143bbe1668afc34dcafc68eddd7634b71e3847e8f9416dc8dedcee0d2d5198f5",
+                            "id": "fls_v46v0t2vh6x4",
+                            "link": "macros.html#fls_v46v0t2vh6x4",
+                            "number": "20.5:8"
+                        },
+                        {
+                            "checksum": "82fe4be1744d0478a0bcbed88a26bf676ea9c239bd2e996210ce59ad724a104b",
+                            "id": "fls_7eqqk2cj0clr",
+                            "link": "macros.html#fls_7eqqk2cj0clr",
+                            "number": "20.5:9"
+                        }
+                    ],
+                    "title": "Hygiene"
+                }
+            ],
+            "title": "Macros"
+        },
+        {
+            "informational": false,
             "link": "items.html",
             "sections": [
                 {
@@ -9625,6 +9631,324 @@
                 }
             ],
             "title": "Items"
+        },
+        {
+            "informational": true,
+            "link": "licenses.html",
+            "sections": [
+                {
+                    "id": "fls_kd7fcvfrwks0",
+                    "informational": false,
+                    "link": "licenses.html",
+                    "number": "A",
+                    "paragraphs": [],
+                    "title": "Licenses"
+                },
+                {
+                    "id": "fls_mwoe9jy6l7er",
+                    "informational": false,
+                    "link": "licenses.html#ada-reference-manual-copyright-notice",
+                    "number": "A.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "6af57950721e83dae393e90ca8d980bdcca5c9b81a188fe360ec5adfda00b6d5",
+                            "id": "fls_9rpvtm5tjrpp",
+                            "link": "licenses.html#fls_9rpvtm5tjrpp",
+                            "number": "A.1:1"
+                        },
+                        {
+                            "checksum": "ef760ed2bc838098d7e8efb78966c4cd75d281f71907582b05283c54343ba0ce",
+                            "id": "fls_7uhb9t9x8r0c",
+                            "link": "licenses.html#fls_7uhb9t9x8r0c",
+                            "number": "A.1:2"
+                        },
+                        {
+                            "checksum": "a5f9956bcdfc5ce615410d2af601a90ce92f066360a5467a27d39718da318796",
+                            "id": "fls_ej4g7lz5eqm8",
+                            "link": "licenses.html#fls_ej4g7lz5eqm8",
+                            "number": "A.1:3"
+                        },
+                        {
+                            "checksum": "20b03a1ea2320f89250e61fc875c4f01597a27856b189891293511d1c3c55df5",
+                            "id": "fls_l9uu4q48v1co",
+                            "link": "licenses.html#fls_l9uu4q48v1co",
+                            "number": "A.1:4"
+                        },
+                        {
+                            "checksum": "38194322b850acd0ebe5ec95d660959c07d88f87ef2fe6c7912a773201dc4836",
+                            "id": "fls_3j7jx4qsqucs",
+                            "link": "licenses.html#fls_3j7jx4qsqucs",
+                            "number": "A.1:5"
+                        }
+                    ],
+                    "title": "Ada Reference Manual Copyright Notice"
+                },
+                {
+                    "id": "fls_w6b35kn6la40",
+                    "informational": false,
+                    "link": "licenses.html#rust-reference-apache-license",
+                    "number": "A.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "7659351efeafb9bcab1f7bded9384347863a49e48384d8b8f59f4aadc9c047d5",
+                            "id": "fls_wn4kcs3skqra",
+                            "link": "licenses.html#fls_wn4kcs3skqra",
+                            "number": "A.2:1"
+                        },
+                        {
+                            "checksum": "6b9064c87e131c2318a938f837e161eb0c65d3f5fb3d76f34c6a07ac89c08f73",
+                            "id": "fls_mtcsb64efiw1",
+                            "link": "licenses.html#fls_mtcsb64efiw1",
+                            "number": "A.2:2"
+                        },
+                        {
+                            "checksum": "511b49aedd83a0711011cf0a3d3ffbc8faa1c1443f13b71376c4ce8d0b1c6f6d",
+                            "id": "fls_9tssu3wp22cz",
+                            "link": "licenses.html#fls_9tssu3wp22cz",
+                            "number": "A.2:3"
+                        },
+                        {
+                            "checksum": "a423d8767937df97db94bc21dea4f19e65f5d2a464521f2deca8482ccd4eb2e1",
+                            "id": "fls_4pclfuqukw5o",
+                            "link": "licenses.html#fls_4pclfuqukw5o",
+                            "number": "A.2:4"
+                        },
+                        {
+                            "checksum": "bcc06c2a274e4878336dd5b4c71758d3b854dcf325e9f4ca54c1c6501dccbcee",
+                            "id": "fls_rgn86bsd9tl5",
+                            "link": "licenses.html#fls_rgn86bsd9tl5",
+                            "number": "A.2:5"
+                        },
+                        {
+                            "checksum": "0c8baad676d0cb1c29fe117e5864ef351160f102c13d047d354e16c2145fc69a",
+                            "id": "fls_n6ash4u0e838",
+                            "link": "licenses.html#fls_n6ash4u0e838",
+                            "number": "A.2:6"
+                        },
+                        {
+                            "checksum": "619babacc89fcc3a48bee87f41d8567998cf7926a806e7bcb31bef0bc1bf70fd",
+                            "id": "fls_4z50m2plw8lg",
+                            "link": "licenses.html#fls_4z50m2plw8lg",
+                            "number": "A.2:7"
+                        },
+                        {
+                            "checksum": "d902ee93c8c40420453bff915be7d882e3390fbfb7c3d38905a094dde4369625",
+                            "id": "fls_bmx87il86j77",
+                            "link": "licenses.html#fls_bmx87il86j77",
+                            "number": "A.2:8"
+                        },
+                        {
+                            "checksum": "a5fd12a0acbcca3ac4cfca07cb3a66976c749dcabc7c73c69ed9abfad2067282",
+                            "id": "fls_467b9ucekcv3",
+                            "link": "licenses.html#fls_467b9ucekcv3",
+                            "number": "A.2:9"
+                        },
+                        {
+                            "checksum": "aa73e595c7b2ef9149acd45a1b91fed2704f511303a5b2ae619eb01a1ffb9410",
+                            "id": "fls_9ws2rqie234r",
+                            "link": "licenses.html#fls_9ws2rqie234r",
+                            "number": "A.2:10"
+                        },
+                        {
+                            "checksum": "c9b7d6603bdf686dc20a9604928e83ad51a6e432ce273673e0619de6904ad3a9",
+                            "id": "fls_j075fx75s7wg",
+                            "link": "licenses.html#fls_j075fx75s7wg",
+                            "number": "A.2:11"
+                        },
+                        {
+                            "checksum": "67a79516239a86e9f3ac268c33cea7354013e2efe8dae4acf776dbee55bdf3cb",
+                            "id": "fls_akjks1czkd7n",
+                            "link": "licenses.html#fls_akjks1czkd7n",
+                            "number": "A.2:12"
+                        },
+                        {
+                            "checksum": "03e71fa54f500a9dba9a17354fc29921b6a6421fbdde23db702448cfe7f3d731",
+                            "id": "fls_6n4t2e7lxq3",
+                            "link": "licenses.html#fls_6n4t2e7lxq3",
+                            "number": "A.2:13"
+                        },
+                        {
+                            "checksum": "d890372e8c497682bf9b4b51d8b75a7211ca6e6b4ee30436e8c59dbbb0149bf3",
+                            "id": "fls_g0gyduo0wc55",
+                            "link": "licenses.html#fls_g0gyduo0wc55",
+                            "number": "A.2:14"
+                        },
+                        {
+                            "checksum": "85d7c24f5cba0d54181181872cf27f0cad45c28f1d281733ef26114ef08e1bea",
+                            "id": "fls_w8npkgeox7u5",
+                            "link": "licenses.html#fls_w8npkgeox7u5",
+                            "number": "A.2:15"
+                        },
+                        {
+                            "checksum": "f0a11688e77729f1b2fa1e4efbc104a39c8fd916d1f58f90eefccd38b209c0d6",
+                            "id": "fls_iygftblnws72",
+                            "link": "licenses.html#fls_iygftblnws72",
+                            "number": "A.2:16"
+                        },
+                        {
+                            "checksum": "4a50d529d3ee650e897db5b0f8d99db215c718a75f11d527d5c560abc287de09",
+                            "id": "fls_s32i8ovj5nqu",
+                            "link": "licenses.html#fls_s32i8ovj5nqu",
+                            "number": "A.2:17"
+                        },
+                        {
+                            "checksum": "74231e6684fc04c3f1ed8c36da5619eb35f84411c9f9fbbc9354ff69182ec20e",
+                            "id": "fls_c673i0mbecb9",
+                            "link": "licenses.html#fls_c673i0mbecb9",
+                            "number": "A.2:18"
+                        },
+                        {
+                            "checksum": "b5a621567e61cacbad30b9320aa5fa59abe37e46a15e890c42ad445536c69bd0",
+                            "id": "fls_pwpt8rg76oj3",
+                            "link": "licenses.html#fls_pwpt8rg76oj3",
+                            "number": "A.2:19"
+                        },
+                        {
+                            "checksum": "aa50ce2c3adbcfcae86514a554462ac599522a77d99072af00fd41aee7896afc",
+                            "id": "fls_yu3hgzo57bvm",
+                            "link": "licenses.html#fls_yu3hgzo57bvm",
+                            "number": "A.2:20"
+                        },
+                        {
+                            "checksum": "ee98c5a9da1ccf20da27dc04bdfd4c6b0ee7b4dd5180bb435515d300e6aa7c1f",
+                            "id": "fls_37aibo9w67e8",
+                            "link": "licenses.html#fls_37aibo9w67e8",
+                            "number": "A.2:21"
+                        },
+                        {
+                            "checksum": "870cf6f77ad5d8ef0cfde85af78b7c2a507c6e6c8db5bbe62b60548c02229cfc",
+                            "id": "fls_py9om9jvbulw",
+                            "link": "licenses.html#fls_py9om9jvbulw",
+                            "number": "A.2:22"
+                        },
+                        {
+                            "checksum": "e4c5f14a1bc396e634f99d3e9c008a29af8f84b61dc6da057710d23ebb6a1855",
+                            "id": "fls_wkf26wyy0ndr",
+                            "link": "licenses.html#fls_wkf26wyy0ndr",
+                            "number": "A.2:23"
+                        },
+                        {
+                            "checksum": "d3162aaf802254c584ffd111d733498e754b056c61bdb59144aed5024b8bc566",
+                            "id": "fls_qsvzdiicam4f",
+                            "link": "licenses.html#fls_qsvzdiicam4f",
+                            "number": "A.2:24"
+                        },
+                        {
+                            "checksum": "c502f762cf1f733336f2b49fdabec625a400d1b9137ba436de9acfb180ea3681",
+                            "id": "fls_n4zpph83hza1",
+                            "link": "licenses.html#fls_n4zpph83hza1",
+                            "number": "A.2:25"
+                        },
+                        {
+                            "checksum": "c6ab38d458c9605260610ec31abaaf83a03d54cc4109c75ce57d5330b7e0ae43",
+                            "id": "fls_6gvjqsyyk3sg",
+                            "link": "licenses.html#fls_6gvjqsyyk3sg",
+                            "number": "A.2:26"
+                        },
+                        {
+                            "checksum": "dbb66a9641f131e6288803d7b31289cc46c0c00d4bf70ecaade3c44dfb5acfaa",
+                            "id": "fls_evwltjyhvhz",
+                            "link": "licenses.html#fls_evwltjyhvhz",
+                            "number": "A.2:27"
+                        },
+                        {
+                            "checksum": "f6437e117dc2304d057d9a5394bea1e927d97d91a0451366fb3bdbaa35556c6c",
+                            "id": "fls_xj0b5mrjgdbt",
+                            "link": "licenses.html#fls_xj0b5mrjgdbt",
+                            "number": "A.2:28"
+                        },
+                        {
+                            "checksum": "5cb92d044eeac194b5d3a2e2fed02e650bdca56fe9e6386c4729f39717879270",
+                            "id": "fls_ecitsmzb8l28",
+                            "link": "licenses.html#fls_ecitsmzb8l28",
+                            "number": "A.2:29"
+                        },
+                        {
+                            "checksum": "a69bf85bf1838570613037b4423858a9a047187494aea6e78ae1c91c9d58f711",
+                            "id": "fls_wx0hv6f68i4f",
+                            "link": "licenses.html#fls_wx0hv6f68i4f",
+                            "number": "A.2:30"
+                        },
+                        {
+                            "checksum": "df088a3e94ccbd2e98926c4f5ca34fd02f3cd8dfc3924b7ba3749ef0eb08b68d",
+                            "id": "fls_fgjjzdwbw1t8",
+                            "link": "licenses.html#fls_fgjjzdwbw1t8",
+                            "number": "A.2:31"
+                        },
+                        {
+                            "checksum": "1a6497e3eeb694644723d0a451104bff4dd133960c27e3d4e9b6c5282cdcdf2a",
+                            "id": "fls_hnxekf2ahnif",
+                            "link": "licenses.html#fls_hnxekf2ahnif",
+                            "number": "A.2:32"
+                        },
+                        {
+                            "checksum": "839ca0d83587df0f49d5e7af7a86cb4ed2526d3c7a4fb98ca1e7031d41e9c3bb",
+                            "id": "fls_e0ytxo6b451",
+                            "link": "licenses.html#fls_e0ytxo6b451",
+                            "number": "A.2:33"
+                        },
+                        {
+                            "checksum": "1c4d9cbfb808d36160fd3001c512e6887268a758682958c644bcbe07f04a32af",
+                            "id": "fls_145e22m6bw47",
+                            "link": "licenses.html#fls_145e22m6bw47",
+                            "number": "A.2:34"
+                        },
+                        {
+                            "checksum": "9c3bd1dd9f6780741a46dfb5af593752082db35d8ce9d3eb8ae7d663e403c665",
+                            "id": "fls_9o0wr812ggf2",
+                            "link": "licenses.html#fls_9o0wr812ggf2",
+                            "number": "A.2:35"
+                        },
+                        {
+                            "checksum": "a3d8a030eaf80e2f2d7b0b8c819a8b4a03d2468cad162b5778d7535713e6eb54",
+                            "id": "fls_cqaian5c7mwr",
+                            "link": "licenses.html#fls_cqaian5c7mwr",
+                            "number": "A.2:36"
+                        },
+                        {
+                            "checksum": "2caf6f88f365a1f0b8673022f566d0e34e5f487002cbb975f7a3810984aa2b33",
+                            "id": "fls_eil4b7ffojqa",
+                            "link": "licenses.html#fls_eil4b7ffojqa",
+                            "number": "A.2:37"
+                        }
+                    ],
+                    "title": "Rust Reference Apache License"
+                },
+                {
+                    "id": "fls_un9oqipiretc",
+                    "informational": false,
+                    "link": "licenses.html#rust-reference-mit-license",
+                    "number": "A.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "43b7d2588a00010b6644920dff56e6f4652ec966cf564d52f3e5e87748e58bbf",
+                            "id": "fls_bkxw1o1hanmk",
+                            "link": "licenses.html#fls_bkxw1o1hanmk",
+                            "number": "A.3:1"
+                        },
+                        {
+                            "checksum": "efda707a511b8c7e80727098049e5458105f2960dc74c0d7faa11a43f7e7d997",
+                            "id": "fls_yc3wyw3plm1s",
+                            "link": "licenses.html#fls_yc3wyw3plm1s",
+                            "number": "A.3:2"
+                        },
+                        {
+                            "checksum": "dc6e47d05ec79c0cbaa15dd61b6a60ab03fd6f9d7e2f51df6828fc53f4916265",
+                            "id": "fls_ypomxdgiswq8",
+                            "link": "licenses.html#fls_ypomxdgiswq8",
+                            "number": "A.3:3"
+                        },
+                        {
+                            "checksum": "f227391839011fc1299d7eef9855e682ceab676478b839480bb5cdea3359f70b",
+                            "id": "fls_q6rhvbuhxa21",
+                            "link": "licenses.html#fls_q6rhvbuhxa21",
+                            "number": "A.3:4"
+                        }
+                    ],
+                    "title": "Rust Reference MIT License"
+                }
+            ],
+            "title": "Licenses"
         },
         {
             "informational": false,
@@ -10921,7 +11245,7 @@
                             "number": "2.5:15"
                         },
                         {
-                            "checksum": "a8f479f20301435fdb8a2c41487c0cb7d5418c877b9e952dbf54836c18113058",
+                            "checksum": "fc50838ac3e706c4c30cfb01beba8783dc8fdb5dd7d6cb42ea6b4123e33b6e5b",
                             "id": "fls_ok0zvo9vcmzo",
                             "link": "lexical-elements.html#fls_ok0zvo9vcmzo",
                             "number": "2.5:16"
@@ -11027,2387 +11351,6 @@
                 }
             ],
             "title": "Lexical Elements"
-        },
-        {
-            "informational": true,
-            "link": "licenses.html",
-            "sections": [
-                {
-                    "id": "fls_kd7fcvfrwks0",
-                    "informational": false,
-                    "link": "licenses.html",
-                    "number": "A",
-                    "paragraphs": [],
-                    "title": "Licenses"
-                },
-                {
-                    "id": "fls_mwoe9jy6l7er",
-                    "informational": false,
-                    "link": "licenses.html#ada-reference-manual-copyright-notice",
-                    "number": "A.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "6af57950721e83dae393e90ca8d980bdcca5c9b81a188fe360ec5adfda00b6d5",
-                            "id": "fls_9rpvtm5tjrpp",
-                            "link": "licenses.html#fls_9rpvtm5tjrpp",
-                            "number": "A.1:1"
-                        },
-                        {
-                            "checksum": "ef760ed2bc838098d7e8efb78966c4cd75d281f71907582b05283c54343ba0ce",
-                            "id": "fls_7uhb9t9x8r0c",
-                            "link": "licenses.html#fls_7uhb9t9x8r0c",
-                            "number": "A.1:2"
-                        },
-                        {
-                            "checksum": "a5f9956bcdfc5ce615410d2af601a90ce92f066360a5467a27d39718da318796",
-                            "id": "fls_ej4g7lz5eqm8",
-                            "link": "licenses.html#fls_ej4g7lz5eqm8",
-                            "number": "A.1:3"
-                        },
-                        {
-                            "checksum": "20b03a1ea2320f89250e61fc875c4f01597a27856b189891293511d1c3c55df5",
-                            "id": "fls_l9uu4q48v1co",
-                            "link": "licenses.html#fls_l9uu4q48v1co",
-                            "number": "A.1:4"
-                        },
-                        {
-                            "checksum": "38194322b850acd0ebe5ec95d660959c07d88f87ef2fe6c7912a773201dc4836",
-                            "id": "fls_3j7jx4qsqucs",
-                            "link": "licenses.html#fls_3j7jx4qsqucs",
-                            "number": "A.1:5"
-                        }
-                    ],
-                    "title": "Ada Reference Manual Copyright Notice"
-                },
-                {
-                    "id": "fls_w6b35kn6la40",
-                    "informational": false,
-                    "link": "licenses.html#rust-reference-apache-license",
-                    "number": "A.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "7659351efeafb9bcab1f7bded9384347863a49e48384d8b8f59f4aadc9c047d5",
-                            "id": "fls_wn4kcs3skqra",
-                            "link": "licenses.html#fls_wn4kcs3skqra",
-                            "number": "A.2:1"
-                        },
-                        {
-                            "checksum": "6b9064c87e131c2318a938f837e161eb0c65d3f5fb3d76f34c6a07ac89c08f73",
-                            "id": "fls_mtcsb64efiw1",
-                            "link": "licenses.html#fls_mtcsb64efiw1",
-                            "number": "A.2:2"
-                        },
-                        {
-                            "checksum": "511b49aedd83a0711011cf0a3d3ffbc8faa1c1443f13b71376c4ce8d0b1c6f6d",
-                            "id": "fls_9tssu3wp22cz",
-                            "link": "licenses.html#fls_9tssu3wp22cz",
-                            "number": "A.2:3"
-                        },
-                        {
-                            "checksum": "a423d8767937df97db94bc21dea4f19e65f5d2a464521f2deca8482ccd4eb2e1",
-                            "id": "fls_4pclfuqukw5o",
-                            "link": "licenses.html#fls_4pclfuqukw5o",
-                            "number": "A.2:4"
-                        },
-                        {
-                            "checksum": "bcc06c2a274e4878336dd5b4c71758d3b854dcf325e9f4ca54c1c6501dccbcee",
-                            "id": "fls_rgn86bsd9tl5",
-                            "link": "licenses.html#fls_rgn86bsd9tl5",
-                            "number": "A.2:5"
-                        },
-                        {
-                            "checksum": "0c8baad676d0cb1c29fe117e5864ef351160f102c13d047d354e16c2145fc69a",
-                            "id": "fls_n6ash4u0e838",
-                            "link": "licenses.html#fls_n6ash4u0e838",
-                            "number": "A.2:6"
-                        },
-                        {
-                            "checksum": "619babacc89fcc3a48bee87f41d8567998cf7926a806e7bcb31bef0bc1bf70fd",
-                            "id": "fls_4z50m2plw8lg",
-                            "link": "licenses.html#fls_4z50m2plw8lg",
-                            "number": "A.2:7"
-                        },
-                        {
-                            "checksum": "d902ee93c8c40420453bff915be7d882e3390fbfb7c3d38905a094dde4369625",
-                            "id": "fls_bmx87il86j77",
-                            "link": "licenses.html#fls_bmx87il86j77",
-                            "number": "A.2:8"
-                        },
-                        {
-                            "checksum": "a5fd12a0acbcca3ac4cfca07cb3a66976c749dcabc7c73c69ed9abfad2067282",
-                            "id": "fls_467b9ucekcv3",
-                            "link": "licenses.html#fls_467b9ucekcv3",
-                            "number": "A.2:9"
-                        },
-                        {
-                            "checksum": "aa73e595c7b2ef9149acd45a1b91fed2704f511303a5b2ae619eb01a1ffb9410",
-                            "id": "fls_9ws2rqie234r",
-                            "link": "licenses.html#fls_9ws2rqie234r",
-                            "number": "A.2:10"
-                        },
-                        {
-                            "checksum": "c9b7d6603bdf686dc20a9604928e83ad51a6e432ce273673e0619de6904ad3a9",
-                            "id": "fls_j075fx75s7wg",
-                            "link": "licenses.html#fls_j075fx75s7wg",
-                            "number": "A.2:11"
-                        },
-                        {
-                            "checksum": "67a79516239a86e9f3ac268c33cea7354013e2efe8dae4acf776dbee55bdf3cb",
-                            "id": "fls_akjks1czkd7n",
-                            "link": "licenses.html#fls_akjks1czkd7n",
-                            "number": "A.2:12"
-                        },
-                        {
-                            "checksum": "03e71fa54f500a9dba9a17354fc29921b6a6421fbdde23db702448cfe7f3d731",
-                            "id": "fls_6n4t2e7lxq3",
-                            "link": "licenses.html#fls_6n4t2e7lxq3",
-                            "number": "A.2:13"
-                        },
-                        {
-                            "checksum": "d890372e8c497682bf9b4b51d8b75a7211ca6e6b4ee30436e8c59dbbb0149bf3",
-                            "id": "fls_g0gyduo0wc55",
-                            "link": "licenses.html#fls_g0gyduo0wc55",
-                            "number": "A.2:14"
-                        },
-                        {
-                            "checksum": "85d7c24f5cba0d54181181872cf27f0cad45c28f1d281733ef26114ef08e1bea",
-                            "id": "fls_w8npkgeox7u5",
-                            "link": "licenses.html#fls_w8npkgeox7u5",
-                            "number": "A.2:15"
-                        },
-                        {
-                            "checksum": "f0a11688e77729f1b2fa1e4efbc104a39c8fd916d1f58f90eefccd38b209c0d6",
-                            "id": "fls_iygftblnws72",
-                            "link": "licenses.html#fls_iygftblnws72",
-                            "number": "A.2:16"
-                        },
-                        {
-                            "checksum": "4a50d529d3ee650e897db5b0f8d99db215c718a75f11d527d5c560abc287de09",
-                            "id": "fls_s32i8ovj5nqu",
-                            "link": "licenses.html#fls_s32i8ovj5nqu",
-                            "number": "A.2:17"
-                        },
-                        {
-                            "checksum": "74231e6684fc04c3f1ed8c36da5619eb35f84411c9f9fbbc9354ff69182ec20e",
-                            "id": "fls_c673i0mbecb9",
-                            "link": "licenses.html#fls_c673i0mbecb9",
-                            "number": "A.2:18"
-                        },
-                        {
-                            "checksum": "b5a621567e61cacbad30b9320aa5fa59abe37e46a15e890c42ad445536c69bd0",
-                            "id": "fls_pwpt8rg76oj3",
-                            "link": "licenses.html#fls_pwpt8rg76oj3",
-                            "number": "A.2:19"
-                        },
-                        {
-                            "checksum": "aa50ce2c3adbcfcae86514a554462ac599522a77d99072af00fd41aee7896afc",
-                            "id": "fls_yu3hgzo57bvm",
-                            "link": "licenses.html#fls_yu3hgzo57bvm",
-                            "number": "A.2:20"
-                        },
-                        {
-                            "checksum": "ee98c5a9da1ccf20da27dc04bdfd4c6b0ee7b4dd5180bb435515d300e6aa7c1f",
-                            "id": "fls_37aibo9w67e8",
-                            "link": "licenses.html#fls_37aibo9w67e8",
-                            "number": "A.2:21"
-                        },
-                        {
-                            "checksum": "870cf6f77ad5d8ef0cfde85af78b7c2a507c6e6c8db5bbe62b60548c02229cfc",
-                            "id": "fls_py9om9jvbulw",
-                            "link": "licenses.html#fls_py9om9jvbulw",
-                            "number": "A.2:22"
-                        },
-                        {
-                            "checksum": "e4c5f14a1bc396e634f99d3e9c008a29af8f84b61dc6da057710d23ebb6a1855",
-                            "id": "fls_wkf26wyy0ndr",
-                            "link": "licenses.html#fls_wkf26wyy0ndr",
-                            "number": "A.2:23"
-                        },
-                        {
-                            "checksum": "d3162aaf802254c584ffd111d733498e754b056c61bdb59144aed5024b8bc566",
-                            "id": "fls_qsvzdiicam4f",
-                            "link": "licenses.html#fls_qsvzdiicam4f",
-                            "number": "A.2:24"
-                        },
-                        {
-                            "checksum": "c502f762cf1f733336f2b49fdabec625a400d1b9137ba436de9acfb180ea3681",
-                            "id": "fls_n4zpph83hza1",
-                            "link": "licenses.html#fls_n4zpph83hza1",
-                            "number": "A.2:25"
-                        },
-                        {
-                            "checksum": "c6ab38d458c9605260610ec31abaaf83a03d54cc4109c75ce57d5330b7e0ae43",
-                            "id": "fls_6gvjqsyyk3sg",
-                            "link": "licenses.html#fls_6gvjqsyyk3sg",
-                            "number": "A.2:26"
-                        },
-                        {
-                            "checksum": "dbb66a9641f131e6288803d7b31289cc46c0c00d4bf70ecaade3c44dfb5acfaa",
-                            "id": "fls_evwltjyhvhz",
-                            "link": "licenses.html#fls_evwltjyhvhz",
-                            "number": "A.2:27"
-                        },
-                        {
-                            "checksum": "f6437e117dc2304d057d9a5394bea1e927d97d91a0451366fb3bdbaa35556c6c",
-                            "id": "fls_xj0b5mrjgdbt",
-                            "link": "licenses.html#fls_xj0b5mrjgdbt",
-                            "number": "A.2:28"
-                        },
-                        {
-                            "checksum": "5cb92d044eeac194b5d3a2e2fed02e650bdca56fe9e6386c4729f39717879270",
-                            "id": "fls_ecitsmzb8l28",
-                            "link": "licenses.html#fls_ecitsmzb8l28",
-                            "number": "A.2:29"
-                        },
-                        {
-                            "checksum": "a69bf85bf1838570613037b4423858a9a047187494aea6e78ae1c91c9d58f711",
-                            "id": "fls_wx0hv6f68i4f",
-                            "link": "licenses.html#fls_wx0hv6f68i4f",
-                            "number": "A.2:30"
-                        },
-                        {
-                            "checksum": "df088a3e94ccbd2e98926c4f5ca34fd02f3cd8dfc3924b7ba3749ef0eb08b68d",
-                            "id": "fls_fgjjzdwbw1t8",
-                            "link": "licenses.html#fls_fgjjzdwbw1t8",
-                            "number": "A.2:31"
-                        },
-                        {
-                            "checksum": "1a6497e3eeb694644723d0a451104bff4dd133960c27e3d4e9b6c5282cdcdf2a",
-                            "id": "fls_hnxekf2ahnif",
-                            "link": "licenses.html#fls_hnxekf2ahnif",
-                            "number": "A.2:32"
-                        },
-                        {
-                            "checksum": "839ca0d83587df0f49d5e7af7a86cb4ed2526d3c7a4fb98ca1e7031d41e9c3bb",
-                            "id": "fls_e0ytxo6b451",
-                            "link": "licenses.html#fls_e0ytxo6b451",
-                            "number": "A.2:33"
-                        },
-                        {
-                            "checksum": "1c4d9cbfb808d36160fd3001c512e6887268a758682958c644bcbe07f04a32af",
-                            "id": "fls_145e22m6bw47",
-                            "link": "licenses.html#fls_145e22m6bw47",
-                            "number": "A.2:34"
-                        },
-                        {
-                            "checksum": "9c3bd1dd9f6780741a46dfb5af593752082db35d8ce9d3eb8ae7d663e403c665",
-                            "id": "fls_9o0wr812ggf2",
-                            "link": "licenses.html#fls_9o0wr812ggf2",
-                            "number": "A.2:35"
-                        },
-                        {
-                            "checksum": "a3d8a030eaf80e2f2d7b0b8c819a8b4a03d2468cad162b5778d7535713e6eb54",
-                            "id": "fls_cqaian5c7mwr",
-                            "link": "licenses.html#fls_cqaian5c7mwr",
-                            "number": "A.2:36"
-                        },
-                        {
-                            "checksum": "2caf6f88f365a1f0b8673022f566d0e34e5f487002cbb975f7a3810984aa2b33",
-                            "id": "fls_eil4b7ffojqa",
-                            "link": "licenses.html#fls_eil4b7ffojqa",
-                            "number": "A.2:37"
-                        }
-                    ],
-                    "title": "Rust Reference Apache License"
-                },
-                {
-                    "id": "fls_un9oqipiretc",
-                    "informational": false,
-                    "link": "licenses.html#rust-reference-mit-license",
-                    "number": "A.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "43b7d2588a00010b6644920dff56e6f4652ec966cf564d52f3e5e87748e58bbf",
-                            "id": "fls_bkxw1o1hanmk",
-                            "link": "licenses.html#fls_bkxw1o1hanmk",
-                            "number": "A.3:1"
-                        },
-                        {
-                            "checksum": "efda707a511b8c7e80727098049e5458105f2960dc74c0d7faa11a43f7e7d997",
-                            "id": "fls_yc3wyw3plm1s",
-                            "link": "licenses.html#fls_yc3wyw3plm1s",
-                            "number": "A.3:2"
-                        },
-                        {
-                            "checksum": "dc6e47d05ec79c0cbaa15dd61b6a60ab03fd6f9d7e2f51df6828fc53f4916265",
-                            "id": "fls_ypomxdgiswq8",
-                            "link": "licenses.html#fls_ypomxdgiswq8",
-                            "number": "A.3:3"
-                        },
-                        {
-                            "checksum": "f227391839011fc1299d7eef9855e682ceab676478b839480bb5cdea3359f70b",
-                            "id": "fls_q6rhvbuhxa21",
-                            "link": "licenses.html#fls_q6rhvbuhxa21",
-                            "number": "A.3:4"
-                        }
-                    ],
-                    "title": "Rust Reference MIT License"
-                }
-            ],
-            "title": "Licenses"
-        },
-        {
-            "informational": false,
-            "link": "index.html",
-            "sections": [],
-            "title": "FLS"
-        },
-        {
-            "informational": false,
-            "link": "patterns.html",
-            "sections": [
-                {
-                    "id": "fls_xgqh0ju6bmbn",
-                    "informational": false,
-                    "link": "patterns.html",
-                    "number": "5",
-                    "paragraphs": [
-                        {
-                            "checksum": "fd701b3ef4e17c49416e15bb5e0685b07ec2165ebe338ee5ed86433fe2a1791c",
-                            "id": "fls_imegtsi224ts",
-                            "link": "patterns.html#fls_imegtsi224ts",
-                            "number": "5:1"
-                        },
-                        {
-                            "checksum": "f11f4d96ce76157d36700b1642b225614023417f88f39e02004f751fa0ceca1c",
-                            "id": "fls_mp6i4blzexnu",
-                            "link": "patterns.html#fls_mp6i4blzexnu",
-                            "number": "5:2"
-                        },
-                        {
-                            "checksum": "640a01339d6302f50e834a92db0b99f585848a4dc1dfb4801941267dfe6c1eff",
-                            "id": "fls_JJ1fJa1SsaWh",
-                            "link": "patterns.html#fls_JJ1fJa1SsaWh",
-                            "number": "5:3"
-                        },
-                        {
-                            "checksum": "28dec289d15cad76b56462aa121b43b5d1e42ef0f0d0636c38ac0eb7eca4b4f9",
-                            "id": "fls_6xx34zr069bj",
-                            "link": "patterns.html#fls_6xx34zr069bj",
-                            "number": "5:4"
-                        },
-                        {
-                            "checksum": "32457ed53a0bf4373c4cfb97677b5e208930233d39b87a5accc8c508af6f58ce",
-                            "id": "fls_8xzjb0yzftkd",
-                            "link": "patterns.html#fls_8xzjb0yzftkd",
-                            "number": "5:5"
-                        },
-                        {
-                            "checksum": "5ac967f09550667532acd0916172717779d286369a004f6e89c12e7852e25bc4",
-                            "id": "fls_cma5t8waon0x",
-                            "link": "patterns.html#fls_cma5t8waon0x",
-                            "number": "5:6"
-                        },
-                        {
-                            "checksum": "d92c5c133b1308dfee746f9722cc628be4cc1b150f3f387c0d2c08e961e687fb",
-                            "id": "fls_TUanRT7WU14E",
-                            "link": "patterns.html#fls_TUanRT7WU14E",
-                            "number": "5:7"
-                        },
-                        {
-                            "checksum": "ee361e573cbe4dbcbc9c1aec4bea99d7af68ce46d7a8f305323fea2d888a73ae",
-                            "id": "fls_8luyomzppck",
-                            "link": "patterns.html#fls_8luyomzppck",
-                            "number": "5:8"
-                        },
-                        {
-                            "checksum": "b70079f33aaa9cb4c2507706bdb13c9e8beed748288a7751770b7aa4309c17bf",
-                            "id": "fls_rpvdfmy3n05a",
-                            "link": "patterns.html#fls_rpvdfmy3n05a",
-                            "number": "5:9"
-                        },
-                        {
-                            "checksum": "66e6567b6902e8a974dcb281251e03d5341f1fbcd6c52bc6d9398d5b175905b1",
-                            "id": "fls_kv533rntni1x",
-                            "link": "patterns.html#fls_kv533rntni1x",
-                            "number": "5:10"
-                        }
-                    ],
-                    "title": "Patterns"
-                },
-                {
-                    "id": "fls_uh76pw6ykd57",
-                    "informational": false,
-                    "link": "patterns.html#refutability",
-                    "number": "5.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "74e294f01efeecaf5f7ea7508839e45750aee3872825525951cd7e1a5a369127",
-                            "id": "fls_9ntc4qmjmo90",
-                            "link": "patterns.html#fls_9ntc4qmjmo90",
-                            "number": "5.1:1"
-                        },
-                        {
-                            "checksum": "bedd24701ba15fd54193582bf452c8d028b7e7d24e62f7cf549bccc5f8d4e4b8",
-                            "id": "fls_9fjspnefoyvz",
-                            "link": "patterns.html#fls_9fjspnefoyvz",
-                            "number": "5.1:2"
-                        },
-                        {
-                            "checksum": "30c83040e0dcb6e5472460546b82a2f1223224d1b6b315de2204a12c412741b0",
-                            "id": "fls_uq7ftuuq1sig",
-                            "link": "patterns.html#fls_uq7ftuuq1sig",
-                            "number": "5.1:3"
-                        },
-                        {
-                            "checksum": "788cc1b098646556626fa9669f0f2c05d8907e582b4bc899ecac453fcfc61dde",
-                            "id": "fls_mnbyt7jfYAZ9",
-                            "link": "patterns.html#fls_mnbyt7jfYAZ9",
-                            "number": "5.1:4"
-                        },
-                        {
-                            "checksum": "fb93c07735fd3880cae598758a01af1eb04fd98aa6fbdca79a2fd2e8a525c26d",
-                            "id": "fls_l76ycteulo8e",
-                            "link": "patterns.html#fls_l76ycteulo8e",
-                            "number": "5.1:5"
-                        },
-                        {
-                            "checksum": "8cbff3175ce2f1524fa0ece5a443ba2edd4a78433ff410a98a31ed00f38a2bde",
-                            "id": "fls_lh0d85tl4qvy",
-                            "link": "patterns.html#fls_lh0d85tl4qvy",
-                            "number": "5.1:6"
-                        },
-                        {
-                            "checksum": "abe5de2e97771298a372e5a404f34278ed54f0e8ada2a337d6f5d85fc5a7e7c0",
-                            "id": "fls_sgu9bnp7xajv",
-                            "link": "patterns.html#fls_sgu9bnp7xajv",
-                            "number": "5.1:7"
-                        },
-                        {
-                            "checksum": "d347b514f8d0662ae967270ae73f6f7be119b4ab60fdf44106ebe781e251e33d",
-                            "id": "fls_cl1g4fxfa020",
-                            "link": "patterns.html#fls_cl1g4fxfa020",
-                            "number": "5.1:8"
-                        }
-                    ],
-                    "title": "Refutability"
-                },
-                {
-                    "id": "fls_7bxv8lybxm18",
-                    "informational": false,
-                    "link": "patterns.html#identifier-patterns",
-                    "number": "5.1.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "12df3c9420d70b5492aee216c48d595bec10c1bfc7c95589c1aa150787788c68",
-                            "id": "fls_uljdw9rf7ies",
-                            "link": "patterns.html#fls_uljdw9rf7ies",
-                            "number": "5.1.1:1"
-                        },
-                        {
-                            "checksum": "241eeb37b7dae1635d202ba61372dfbf4a693e183ca1ece17e3818904f6c809d",
-                            "id": "fls_vy9uw586wy0d",
-                            "link": "patterns.html#fls_vy9uw586wy0d",
-                            "number": "5.1.1:2"
-                        },
-                        {
-                            "checksum": "d9b79bd4e33b5e5d59d8f9ed2df014f66c7fa0c487fc3b0b70e3700fdc7dc420",
-                            "id": "fls_hqwt3fvr063y",
-                            "link": "patterns.html#fls_hqwt3fvr063y",
-                            "number": "5.1.1:3"
-                        },
-                        {
-                            "checksum": "4f2142d8ccdb2e64efc1eaedfef6bdc5b02f5ab32bf7ed59698ff61681fd7384",
-                            "id": "fls_joIQdDn44oIT",
-                            "link": "patterns.html#fls_joIQdDn44oIT",
-                            "number": "5.1.1:4"
-                        },
-                        {
-                            "checksum": "e7b226edcf6dc4bc129b1212d923d2b0052764e5f3087f635a8f5c48af37d436",
-                            "id": "fls_24c95c56tugl",
-                            "link": "patterns.html#fls_24c95c56tugl",
-                            "number": "5.1.1:5"
-                        },
-                        {
-                            "checksum": "3ee68e9c11cc6de58983cada3e69d6e25c9096bea32debb22614bb2a25d155f0",
-                            "id": "fls_twcavjk7iquy",
-                            "link": "patterns.html#fls_twcavjk7iquy",
-                            "number": "5.1.1:6"
-                        },
-                        {
-                            "checksum": "e762d3ac05f362349d87a2a26cc37f37eaa2148eadb4ab7a97745abed9a62df2",
-                            "id": "fls_k1yBTstX7jEE",
-                            "link": "patterns.html#fls_k1yBTstX7jEE",
-                            "number": "5.1.1:7"
-                        },
-                        {
-                            "checksum": "a52f9ed5eaa2b34c018a779a37184c71defa111f92bc5a73d7642178df8e755f",
-                            "id": "fls_hw26hy33guk5",
-                            "link": "patterns.html#fls_hw26hy33guk5",
-                            "number": "5.1.1:8"
-                        },
-                        {
-                            "checksum": "b439ed8b20762b4889891571152f54745dc81b2f6b4abc45db0448e2cac4888d",
-                            "id": "fls_svfxwz4yy5i",
-                            "link": "patterns.html#fls_svfxwz4yy5i",
-                            "number": "5.1.1:9"
-                        },
-                        {
-                            "checksum": "db308f657bf02a10ddea3390b29681c6eccf4bb81b2069d5f1b2ecfbc7853dc1",
-                            "id": "fls_x6f6q22b5jpc",
-                            "link": "patterns.html#fls_x6f6q22b5jpc",
-                            "number": "5.1.1:10"
-                        },
-                        {
-                            "checksum": "dd8b86458df1b70addc97086f4ada7c7692ff5103622010059fbf0283f8ffbb3",
-                            "id": "fls_r2mb8v2lh3x0",
-                            "link": "patterns.html#fls_r2mb8v2lh3x0",
-                            "number": "5.1.1:11"
-                        },
-                        {
-                            "checksum": "0905da49ff8fceb1c24a37a019ba80b02f466cbede9db934f3506067251411de",
-                            "id": "fls_7oioaitb075g",
-                            "link": "patterns.html#fls_7oioaitb075g",
-                            "number": "5.1.1:12"
-                        },
-                        {
-                            "checksum": "11934cfbec627d51e8441eeef28fa1983d4ed59d73d9dcbff26e5d4cf4007fed",
-                            "id": "fls_40qin0ss5sqd",
-                            "link": "patterns.html#fls_40qin0ss5sqd",
-                            "number": "5.1.1:13"
-                        },
-                        {
-                            "checksum": "05ce4678c850feb8fbdc7b0bf9a65ccdd82414dec3163903b5ff487cf3cc1b8c",
-                            "id": "fls_pivz0v7ey6sw",
-                            "link": "patterns.html#fls_pivz0v7ey6sw",
-                            "number": "5.1.1:14"
-                        },
-                        {
-                            "checksum": "6827708c08fa8d7048aaf70d448f1ed456a018a5621ccbad9e38ba38eb4f001f",
-                            "id": "fls_2ahkrddxwj1n",
-                            "link": "patterns.html#fls_2ahkrddxwj1n",
-                            "number": "5.1.1:15"
-                        },
-                        {
-                            "checksum": "5938b3e5c53f5eb860f3c7aae1864e4e5b74c0a93b9460455798ee597639f3bd",
-                            "id": "fls_eucnafj3uedy",
-                            "link": "patterns.html#fls_eucnafj3uedy",
-                            "number": "5.1.1:16"
-                        },
-                        {
-                            "checksum": "25e0df417675d625d1a57e95afba6af3de12fa61abe805e4d2d81e90613250d0",
-                            "id": "fls_f8zo4scodhcr",
-                            "link": "patterns.html#fls_f8zo4scodhcr",
-                            "number": "5.1.1:17"
-                        },
-                        {
-                            "checksum": "7d886e7fba9c09e14a0789ddb951c710bb88a50cf8e06a6bcdd6629fb55562f6",
-                            "id": "fls_d3fs2h7oqjl0",
-                            "link": "patterns.html#fls_d3fs2h7oqjl0",
-                            "number": "5.1.1:18"
-                        },
-                        {
-                            "checksum": "655158cf590f06600319e8e2695db1b56219fadc4cc034888e17c53b07a84274",
-                            "id": "fls_exo8asevh5x1",
-                            "link": "patterns.html#fls_exo8asevh5x1",
-                            "number": "5.1.1:19"
-                        },
-                        {
-                            "checksum": "d3b46f205bcb595fe85d75191fcd80dd7933343080fd05b57200c0118ad6b609",
-                            "id": "fls_sfyfdxhvhk44",
-                            "link": "patterns.html#fls_sfyfdxhvhk44",
-                            "number": "5.1.1:20"
-                        },
-                        {
-                            "checksum": "b32516046ade3590c7036c2a5ecbf17d55a9f6f00da394c3d5281096f8cf26dc",
-                            "id": "fls_as0pqqmo1des",
-                            "link": "patterns.html#fls_as0pqqmo1des",
-                            "number": "5.1.1:21"
-                        }
-                    ],
-                    "title": "Identifier Patterns"
-                },
-                {
-                    "id": "fls_2krxnq8q9ef1",
-                    "informational": false,
-                    "link": "patterns.html#literal-patterns",
-                    "number": "5.1.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "7afee4377bf01eee53e398835c943ac86067eba24c1cf64551d7f801915e5ece",
-                            "id": "fls_pah15qa54irs",
-                            "link": "patterns.html#fls_pah15qa54irs",
-                            "number": "5.1.2:1"
-                        },
-                        {
-                            "checksum": "c8e3035b1a25edf2fccd9214fd3039e797d799bd22e801fdeda70976a39c68a2",
-                            "id": "fls_COQKJC0dvtNO",
-                            "link": "patterns.html#fls_COQKJC0dvtNO",
-                            "number": "5.1.2:2"
-                        },
-                        {
-                            "checksum": "279b07c6a35f3bcfed9d5bcccc78afdc28e8982a5be9e9b768dd95c2a3b0ae9c",
-                            "id": "fls_JP8YSbxSN0Ym",
-                            "link": "patterns.html#fls_JP8YSbxSN0Ym",
-                            "number": "5.1.2:3"
-                        },
-                        {
-                            "checksum": "b5e4dea23898449138503e31ca3616865806df2f2af08e0460bf75c15cfda0d0",
-                            "id": "fls_co60bzvwashg",
-                            "link": "patterns.html#fls_co60bzvwashg",
-                            "number": "5.1.2:4"
-                        },
-                        {
-                            "checksum": "617fb1beb5774f8f6685a4671e5bf2d72fd056bbe348e8236f22254e8462a51a",
-                            "id": "fls_fqclaznjgtb1",
-                            "link": "patterns.html#fls_fqclaznjgtb1",
-                            "number": "5.1.2:5"
-                        }
-                    ],
-                    "title": "Literal Patterns"
-                },
-                {
-                    "id": "fls_1xit18et4ohh",
-                    "informational": false,
-                    "link": "patterns.html#parenthesized-patterns",
-                    "number": "5.1.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "24403c83d4acc034aaa73d968a14afbfe7d9f1bfdbee90b17ef960075453aaac",
-                            "id": "fls_kvqzmt7my5dh",
-                            "link": "patterns.html#fls_kvqzmt7my5dh",
-                            "number": "5.1.3:1"
-                        },
-                        {
-                            "checksum": "5f42a52d41b664edb742dfd664f01990bf8432d041e601e283d750cb83a85f90",
-                            "id": "fls_mrjhpiq5refe",
-                            "link": "patterns.html#fls_mrjhpiq5refe",
-                            "number": "5.1.3:2"
-                        },
-                        {
-                            "checksum": "41b7c39a45d4144509bc833e84ea455b7d86c0a67c5d58960e14e6337b2c44d4",
-                            "id": "fls_pe5kh8y8u664",
-                            "link": "patterns.html#fls_pe5kh8y8u664",
-                            "number": "5.1.3:3"
-                        },
-                        {
-                            "checksum": "edcbe640bd79fa7513605658a4cc16f8d648069f3cca0dd200ee8a2224d1612e",
-                            "id": "fls_2xq8852gihn9",
-                            "link": "patterns.html#fls_2xq8852gihn9",
-                            "number": "5.1.3:4"
-                        },
-                        {
-                            "checksum": "6b2bf289b930cfce356ecbd497063fe3f045ee08dc3919d303a7a90c52eae0fb",
-                            "id": "fls_2dmeukyjqz9y",
-                            "link": "patterns.html#fls_2dmeukyjqz9y",
-                            "number": "5.1.3:5"
-                        }
-                    ],
-                    "title": "Parenthesized Patterns"
-                },
-                {
-                    "id": "fls_uloyjbaso8pz",
-                    "informational": false,
-                    "link": "patterns.html#path-patterns",
-                    "number": "5.1.4",
-                    "paragraphs": [
-                        {
-                            "checksum": "6eab6a03669622290fe084028190344d03230efeca455f6bd9e2891ac8781c05",
-                            "id": "fls_1crq0mexo5r1",
-                            "link": "patterns.html#fls_1crq0mexo5r1",
-                            "number": "5.1.4:1"
-                        },
-                        {
-                            "checksum": "6b5457b32a2fa8723c542bd4b63d6de477dfc4e8406457a6b0ec05a421fbb295",
-                            "id": "fls_xz5otkhogn31",
-                            "link": "patterns.html#fls_xz5otkhogn31",
-                            "number": "5.1.4:2"
-                        },
-                        {
-                            "checksum": "853158ce8e75116be9bf2d63bc0d49626010b9d0fa0c5ebe80a595ef4da37aa3",
-                            "id": "fls_t8sjzsif2ilf",
-                            "link": "patterns.html#fls_t8sjzsif2ilf",
-                            "number": "5.1.4:3"
-                        },
-                        {
-                            "checksum": "32107632e6d0b56902397df91b587c925c1cf6ce0a1f364dd9a3708ce1e015f6",
-                            "id": "fls_zCswsyuitexI",
-                            "link": "patterns.html#fls_zCswsyuitexI",
-                            "number": "5.1.4:4"
-                        },
-                        {
-                            "checksum": "a7a4f59c59d6e146496c10f6e1dd0db5adf148faf1242b54a905805871e1fefb",
-                            "id": "fls_wJ9f906BlBvg",
-                            "link": "patterns.html#fls_wJ9f906BlBvg",
-                            "number": "5.1.4:5"
-                        },
-                        {
-                            "checksum": "c1c27a19deb008cded1ee11e11c906c699c4a1a086d847190fd58dcc97f4785c",
-                            "id": "fls_hF19K8sWU8FF",
-                            "link": "patterns.html#fls_hF19K8sWU8FF",
-                            "number": "5.1.4:6"
-                        },
-                        {
-                            "checksum": "e3791cb88451803cd0eccbbf5f370fc3c972abe87f321825dc692aacb617742b",
-                            "id": "fls_bv9psmitxfuw",
-                            "link": "patterns.html#fls_bv9psmitxfuw",
-                            "number": "5.1.4:7"
-                        },
-                        {
-                            "checksum": "7f7d5841b9bc8e1f3eca2f3f52fb1c78bb016e93d8212e3225a673fd4bc4b053",
-                            "id": "fls_sl47k9oj5p7t",
-                            "link": "patterns.html#fls_sl47k9oj5p7t",
-                            "number": "5.1.4:8"
-                        },
-                        {
-                            "checksum": "e7dd58da27f566ab9464de185e98749b36b5c3340a8c22fed6be8e199d11dd91",
-                            "id": "fls_cfoy86mkmqa4",
-                            "link": "patterns.html#fls_cfoy86mkmqa4",
-                            "number": "5.1.4:9"
-                        },
-                        {
-                            "checksum": "2a1df52ca100bd83979fa4b150b96d836a748c8114e32462390076966acbb005",
-                            "id": "fls_rnppz6y5z8pi",
-                            "link": "patterns.html#fls_rnppz6y5z8pi",
-                            "number": "5.1.4:10"
-                        },
-                        {
-                            "checksum": "686e4dfe42f5f913ee2465c883ade027d7e59e9e065e490993681639adbc6114",
-                            "id": "fls_ag6m4mvpturw",
-                            "link": "patterns.html#fls_ag6m4mvpturw",
-                            "number": "5.1.4:11"
-                        },
-                        {
-                            "checksum": "0156b2335414d9b4db2b75d75ed55fbca446bd1b5b81604e0171ea7872fd44a2",
-                            "id": "fls_pedy2pqrvnx7",
-                            "link": "patterns.html#fls_pedy2pqrvnx7",
-                            "number": "5.1.4:12"
-                        },
-                        {
-                            "checksum": "546530c46d84a01d6017493ea2f9e61645c557cd4ca99d9d518a6145f9ec0367",
-                            "id": "fls_u59rilepu8z9",
-                            "link": "patterns.html#fls_u59rilepu8z9",
-                            "number": "5.1.4:13"
-                        }
-                    ],
-                    "title": "Path Patterns"
-                },
-                {
-                    "id": "fls_6tl1fx99yn6c",
-                    "informational": false,
-                    "link": "patterns.html#range-patterns",
-                    "number": "5.1.5",
-                    "paragraphs": [
-                        {
-                            "checksum": "959fe2ad28f3934a1ce306646ec29b82f95de36f84a5c69840957aeac1b88eb9",
-                            "id": "fls_okupyoav13rm",
-                            "link": "patterns.html#fls_okupyoav13rm",
-                            "number": "5.1.5:1"
-                        },
-                        {
-                            "checksum": "0b382770b9780b9239f762eb87f95835b03588805b1a4b3def28336d666ff7a1",
-                            "id": "fls_jhchm7dy927k",
-                            "link": "patterns.html#fls_jhchm7dy927k",
-                            "number": "5.1.5:2"
-                        },
-                        {
-                            "checksum": "1cfc9d659ff30640a5179ad40746d5c08c3c187b5271f28b88305b4de6ba138a",
-                            "id": "fls_q86j23iiqv8w",
-                            "link": "patterns.html#fls_q86j23iiqv8w",
-                            "number": "5.1.5:3"
-                        },
-                        {
-                            "checksum": "b49f2f20e78bc39e912613682452652bf00d8a9b7ad85fcbbeef325cc638e298",
-                            "id": "fls_3PyquOKjA7SI",
-                            "link": "patterns.html#fls_3PyquOKjA7SI",
-                            "number": "5.1.5:4"
-                        },
-                        {
-                            "checksum": "2730f4be7e58310acdcc2e8df0d5792b76b2437850f3bea63f0e94ad25e46eee",
-                            "id": "fls_akf9x5r6e0ta",
-                            "link": "patterns.html#fls_akf9x5r6e0ta",
-                            "number": "5.1.5:5"
-                        },
-                        {
-                            "checksum": "0ba8c1ec907ade4c15c689e735f0a5a8b187b5496f656c893968eca7e5468b54",
-                            "id": "fls_vrpr6ttpfpal",
-                            "link": "patterns.html#fls_vrpr6ttpfpal",
-                            "number": "5.1.5:6"
-                        },
-                        {
-                            "checksum": "656232ce77042076d43593f3f21939aac2c7066d0c750836345ff9ec0a42124b",
-                            "id": "fls_nk48gregn3me",
-                            "link": "patterns.html#fls_nk48gregn3me",
-                            "number": "5.1.5:7"
-                        },
-                        {
-                            "checksum": "6316acea87cf2eeeb7b2e0acb3d99f9f56716dc64ba70e167716659033b9bde4",
-                            "id": "fls_83v1xqbebs58",
-                            "link": "patterns.html#fls_83v1xqbebs58",
-                            "number": "5.1.5:8"
-                        },
-                        {
-                            "checksum": "785db35c5291babacd0f8648588325297f8f45c2eebe7fb665e52b8ac76eca68",
-                            "id": "fls_2hpuccwh2xml",
-                            "link": "patterns.html#fls_2hpuccwh2xml",
-                            "number": "5.1.5:9"
-                        },
-                        {
-                            "checksum": "0c9d1f2587c2e5d8ed9ee166a68762909b9b7936245dc9d2341c1f7df6670e6e",
-                            "id": "fls_9kk81isk0mlp",
-                            "link": "patterns.html#fls_9kk81isk0mlp",
-                            "number": "5.1.5:10"
-                        },
-                        {
-                            "checksum": "7254a7b52add01e9d7d977900c9322544a9970def2f7c73fdb9a63b417574f5c",
-                            "id": "fls_8bdOqkO1NuJW",
-                            "link": "patterns.html#fls_8bdOqkO1NuJW",
-                            "number": "5.1.5:11"
-                        },
-                        {
-                            "checksum": "88a5cfae2ddc1c38d1df4a2dc1b86e99bcced79bc5b40afef543633e7c48bce9",
-                            "id": "fls_s2b5n4snc4d7",
-                            "link": "patterns.html#fls_s2b5n4snc4d7",
-                            "number": "5.1.5:12"
-                        },
-                        {
-                            "checksum": "b55a395def7ce875a26f0fe8a3f186342864481fa72edba9c13c5d5f3f93c9e6",
-                            "id": "fls_4o4ge6x9a8rs",
-                            "link": "patterns.html#fls_4o4ge6x9a8rs",
-                            "number": "5.1.5:13"
-                        },
-                        {
-                            "checksum": "fe437f18136d4053707f9c2e3b8a79e527d78c77863abc6bfd04f4a73204d3b5",
-                            "id": "fls_6o995ak4hywq",
-                            "link": "patterns.html#fls_6o995ak4hywq",
-                            "number": "5.1.5:14"
-                        },
-                        {
-                            "checksum": "5d22fc340f1c7e324df48a970cf5ae8a4811f8a5ad3880704eda257dd3d2add8",
-                            "id": "fls_3js1645tgh31",
-                            "link": "patterns.html#fls_3js1645tgh31",
-                            "number": "5.1.5:15"
-                        },
-                        {
-                            "checksum": "d004b00ad56daa028bd112c7ad04042c90cfb4ab5ad4df095a5a9d01f32c4bba",
-                            "id": "fls_8Q6NfRx4j5V7",
-                            "link": "patterns.html#fls_8Q6NfRx4j5V7",
-                            "number": "5.1.5:16"
-                        },
-                        {
-                            "checksum": "4993d699bb304cc5b32245e03cfd7425d322876b5dc54fef12048c5874c667c0",
-                            "id": "fls_rgr7t33s0m7m",
-                            "link": "patterns.html#fls_rgr7t33s0m7m",
-                            "number": "5.1.5:17"
-                        },
-                        {
-                            "checksum": "0315d5b53fda43c91943de2a08eda96b79f469004237b8d0f02f52f4c1f35567",
-                            "id": "fls_5ey5mj8t8knd",
-                            "link": "patterns.html#fls_5ey5mj8t8knd",
-                            "number": "5.1.5:18"
-                        },
-                        {
-                            "checksum": "9f6d9020a6778f7a34629150159b8a67764f0aea6638d4f0d47a20fc22fbe70e",
-                            "id": "fls_z4js96mchcsv",
-                            "link": "patterns.html#fls_z4js96mchcsv",
-                            "number": "5.1.5:19"
-                        },
-                        {
-                            "checksum": "5dc529cd76b4f3bba978dfd0fcaf3a618fcaf8f381f22c9f5d63d39585ed34fa",
-                            "id": "fls_3wwpq8i6mo2a",
-                            "link": "patterns.html#fls_3wwpq8i6mo2a",
-                            "number": "5.1.5:20"
-                        }
-                    ],
-                    "title": "Range Patterns"
-                },
-                {
-                    "id": "fls_d2sc9hl3v0mk",
-                    "informational": false,
-                    "link": "patterns.html#reference-patterns",
-                    "number": "5.1.6",
-                    "paragraphs": [
-                        {
-                            "checksum": "0ac86e5a12c490f5eb80008b0e18cc9da39af2074dfbdc99545777192814afa3",
-                            "id": "fls_fhahcc1mz2qh",
-                            "link": "patterns.html#fls_fhahcc1mz2qh",
-                            "number": "5.1.6:1"
-                        },
-                        {
-                            "checksum": "028c5b3284521a34ff97d008866bec2c4654a464089a7da864aad3e4a4f04686",
-                            "id": "fls_x0bmzl1315gq",
-                            "link": "patterns.html#fls_x0bmzl1315gq",
-                            "number": "5.1.6:2"
-                        },
-                        {
-                            "checksum": "cdf387e98a664c3724ff90541e30f67670be603da49923fcb4e3a4ee54ba432e",
-                            "id": "fls_fedo8zhgpla5",
-                            "link": "patterns.html#fls_fedo8zhgpla5",
-                            "number": "5.1.6:3"
-                        },
-                        {
-                            "checksum": "b78639be70162116c61abcb66a81cfa0e2adb505b2a71ffb60f9639cf7a038d5",
-                            "id": "fls_30u9ij164ww3",
-                            "link": "patterns.html#fls_30u9ij164ww3",
-                            "number": "5.1.6:4"
-                        },
-                        {
-                            "checksum": "cc0ee91216508f36e23696e7ee09cd4fa77b065e4c323a2cf3610c891336fe3f",
-                            "id": "fls_d1kc73hpncpo",
-                            "link": "patterns.html#fls_d1kc73hpncpo",
-                            "number": "5.1.6:5"
-                        },
-                        {
-                            "checksum": "f829652e4b19ceb3e612e92c40aa060fe77b46424b5fc3858eccbcfcea45016c",
-                            "id": "fls_mpeuhov0umfa",
-                            "link": "patterns.html#fls_mpeuhov0umfa",
-                            "number": "5.1.6:6"
-                        }
-                    ],
-                    "title": "Reference Patterns"
-                },
-                {
-                    "id": "fls_7wpgnp4kjq82",
-                    "informational": false,
-                    "link": "patterns.html#rest-patterns",
-                    "number": "5.1.7",
-                    "paragraphs": [
-                        {
-                            "checksum": "071b1b905e799a04118d9b0fe22e82b9944ef00a527e80a327c0c4f6511fd52b",
-                            "id": "fls_eso51epfofxb",
-                            "link": "patterns.html#fls_eso51epfofxb",
-                            "number": "5.1.7:1"
-                        },
-                        {
-                            "checksum": "d787720d08f2fd60c09276b2b5be62b0bd3a0ad5aef799a71bacba9691897fda",
-                            "id": "fls_5a75a2y43uev",
-                            "link": "patterns.html#fls_5a75a2y43uev",
-                            "number": "5.1.7:2"
-                        },
-                        {
-                            "checksum": "3bf650bd8078af8405ff969b3616899e1bc80ef2ef591d2b291cf99f03008f32",
-                            "id": "fls_rsqyza99vl3x",
-                            "link": "patterns.html#fls_rsqyza99vl3x",
-                            "number": "5.1.7:3"
-                        },
-                        {
-                            "checksum": "11486a40e40c1eaa6529d06f4f52771cd804d9d0cea29d215e5e9e6748877b01",
-                            "id": "fls_w1pw40phsv2o",
-                            "link": "patterns.html#fls_w1pw40phsv2o",
-                            "number": "5.1.7:4"
-                        },
-                        {
-                            "checksum": "318a513cb1fdf4e37047eccc4975636818c7cd86126e00b5b3e132411c629003",
-                            "id": "fls_x8ylgxrf9ca",
-                            "link": "patterns.html#fls_x8ylgxrf9ca",
-                            "number": "5.1.7:5"
-                        },
-                        {
-                            "checksum": "de50b523931b5b23b262977da389190179884668be06d4b514d2908f9ad2aeab",
-                            "id": "fls_zgoke73xrhk3",
-                            "link": "patterns.html#fls_zgoke73xrhk3",
-                            "number": "5.1.7:6"
-                        },
-                        {
-                            "checksum": "3e6c88357b38cf981ef309c03b2df1cb25d9f796365ca21fbbd67f2d4571cd42",
-                            "id": "fls_bdcv6rwx0fsv",
-                            "link": "patterns.html#fls_bdcv6rwx0fsv",
-                            "number": "5.1.7:7"
-                        },
-                        {
-                            "checksum": "c6203fbb28f63565945031f16bc7f7096f16bee4c02f2c16161cb0c3cf80c7a5",
-                            "id": "fls_qz9guhlg19j3",
-                            "link": "patterns.html#fls_qz9guhlg19j3",
-                            "number": "5.1.7:8"
-                        }
-                    ],
-                    "title": "Rest Patterns"
-                },
-                {
-                    "id": "fls_qte70mgzpras",
-                    "informational": false,
-                    "link": "patterns.html#slice-patterns",
-                    "number": "5.1.8",
-                    "paragraphs": [
-                        {
-                            "checksum": "f9dbdad2eec41e1e1c60cd8c0cacf14973b904c94631089f41ca0e1bbda98a17",
-                            "id": "fls_qqiu594hki8g",
-                            "link": "patterns.html#fls_qqiu594hki8g",
-                            "number": "5.1.8:1"
-                        },
-                        {
-                            "checksum": "948b35cfd7619032dc69a5d84fa17b28a615e792a6f0e0d49e140816b136e7e9",
-                            "id": "fls_h6x9xlxi7y5n",
-                            "link": "patterns.html#fls_h6x9xlxi7y5n",
-                            "number": "5.1.8:2"
-                        },
-                        {
-                            "checksum": "b21f2e9bea39902d97b0a75bd48f584b5bcb685635cecfeab096b27a096de184",
-                            "id": "fls_jbmxu7y5fnm6",
-                            "link": "patterns.html#fls_jbmxu7y5fnm6",
-                            "number": "5.1.8:3"
-                        },
-                        {
-                            "checksum": "9ea93d82c4cebaa6550a0787f2925118cf5370ed8a0c02104b3a623c197ae9c1",
-                            "id": "fls_r78zzw7yyg34",
-                            "link": "patterns.html#fls_r78zzw7yyg34",
-                            "number": "5.1.8:4"
-                        },
-                        {
-                            "checksum": "93891609dbf9042a20ed470adda1893453d146707a716c6a05793ff9c64e10f0",
-                            "id": "fls_ndor56nou676",
-                            "link": "patterns.html#fls_ndor56nou676",
-                            "number": "5.1.8:5"
-                        },
-                        {
-                            "checksum": "b7fb9cf107baa52a1c3140dbb24ee079813601a2c74f83321a61e14127737833",
-                            "id": "fls_9yuobz1jsehf",
-                            "link": "patterns.html#fls_9yuobz1jsehf",
-                            "number": "5.1.8:6"
-                        }
-                    ],
-                    "title": "Slice Patterns"
-                },
-                {
-                    "id": "fls_7dbd5t2750ce",
-                    "informational": false,
-                    "link": "patterns.html#struct-patterns",
-                    "number": "5.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "d667b4f41510c041296f0f8c9950b33a0e697269e268024bd87aac1d04c4b450",
-                            "id": "fls_vjdkpr3zml51",
-                            "link": "patterns.html#fls_vjdkpr3zml51",
-                            "number": "5.2:1"
-                        },
-                        {
-                            "checksum": "1226159f94faa8a70839d078914f48a7ec073bb47550a83a77554fab5106550c",
-                            "id": "fls_6o3x101wo478",
-                            "link": "patterns.html#fls_6o3x101wo478",
-                            "number": "5.2:2"
-                        },
-                        {
-                            "checksum": "4951a056adbfabc5da1900d164468c7f4be7716b2094657ab9e28e53f3b985a9",
-                            "id": "fls_k9zih9s0oe5h",
-                            "link": "patterns.html#fls_k9zih9s0oe5h",
-                            "number": "5.2:3"
-                        },
-                        {
-                            "checksum": "b68597321297c9f745d6b9be53beda335702f6e28a1bb97a08c277dac931130d",
-                            "id": "fls_r8rat3qmc4hy",
-                            "link": "patterns.html#fls_r8rat3qmc4hy",
-                            "number": "5.2:4"
-                        },
-                        {
-                            "checksum": "c8b65f1ad8bbb7a147b1cfa9636cd2ebe6b61c1727898f08637df63d004a8391",
-                            "id": "fls_hUX723DmLg2a",
-                            "link": "patterns.html#fls_hUX723DmLg2a",
-                            "number": "5.2:5"
-                        },
-                        {
-                            "checksum": "83183cd23b19214bc0cd0c9da72221ac67d6ec71f26a49c5445307f86a2d7d8c",
-                            "id": "fls_p4OplpUvS04l",
-                            "link": "patterns.html#fls_p4OplpUvS04l",
-                            "number": "5.2:6"
-                        },
-                        {
-                            "checksum": "0bdc00a13a57ef1c0b6611c62de6e170f3d281e81b68d9cf86a7b8f227180905",
-                            "id": "fls_pre3YwAv01FE",
-                            "link": "patterns.html#fls_pre3YwAv01FE",
-                            "number": "5.2:7"
-                        },
-                        {
-                            "checksum": "81f1732cfd416b1abb73fa22440e8d2cd8f4406e031d6f14d72610567aac5bca",
-                            "id": "fls_MK83WE0iDqNf",
-                            "link": "patterns.html#fls_MK83WE0iDqNf",
-                            "number": "5.2:8"
-                        }
-                    ],
-                    "title": "Struct Patterns"
-                },
-                {
-                    "id": "fls_nruvg0es3kx7",
-                    "informational": false,
-                    "link": "patterns.html#record-struct-patterns",
-                    "number": "5.2.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "939f66a2cc6a712f7ec20d7536b02ec2600f18a1799b2144aea19eec95022846",
-                            "id": "fls_g6dytd6aq62d",
-                            "link": "patterns.html#fls_g6dytd6aq62d",
-                            "number": "5.2.1:1"
-                        },
-                        {
-                            "checksum": "62c9ac85366cbfb730c4705821715b95ce875f485a87b252fa3dd810128a62b6",
-                            "id": "fls_3px4oiweg9dm",
-                            "link": "patterns.html#fls_3px4oiweg9dm",
-                            "number": "5.2.1:2"
-                        },
-                        {
-                            "checksum": "e1814d800e0feb6269bf895ed95022e6deb5cc33cc635c2bb63b14baec538159",
-                            "id": "fls_mnh35ehva8tx",
-                            "link": "patterns.html#fls_mnh35ehva8tx",
-                            "number": "5.2.1:3"
-                        },
-                        {
-                            "checksum": "3e48a4f72d15cce2c39a5d3dc6ee479532f77da0b1bf93691b99fc840384f6fe",
-                            "id": "fls_p2rjnlbvifaa",
-                            "link": "patterns.html#fls_p2rjnlbvifaa",
-                            "number": "5.2.1:4"
-                        },
-                        {
-                            "checksum": "6645895b56834ed4cc394b448f835a215f06b82857dcc694fa41f1413c2e8780",
-                            "id": "fls_23be2x50at14",
-                            "link": "patterns.html#fls_23be2x50at14",
-                            "number": "5.2.1:5"
-                        },
-                        {
-                            "checksum": "a4aa45e4d07c9304ffcc9d862e913507d5000a1730b669278ac285dc603a771c",
-                            "id": "fls_46u4ddj0yf93",
-                            "link": "patterns.html#fls_46u4ddj0yf93",
-                            "number": "5.2.1:6"
-                        },
-                        {
-                            "checksum": "7df489a39e2a1942c161d32a9ce2ef5ce0e4848eab53b9ff7321c1d546572c74",
-                            "id": "fls_qu3dvfdq6oy7",
-                            "link": "patterns.html#fls_qu3dvfdq6oy7",
-                            "number": "5.2.1:7"
-                        },
-                        {
-                            "checksum": "b07b1a9330e57dc967b57e196fbc8f1a408952860995a438d3d757900c0a9bb5",
-                            "id": "fls_4b2hchdzv30u",
-                            "link": "patterns.html#fls_4b2hchdzv30u",
-                            "number": "5.2.1:8"
-                        },
-                        {
-                            "checksum": "a8132d829bf34f884995af4cb9ae77e246d14ffc39f464dfd0579841244ed1a7",
-                            "id": "fls_9wfizujx0szd",
-                            "link": "patterns.html#fls_9wfizujx0szd",
-                            "number": "5.2.1:9"
-                        },
-                        {
-                            "checksum": "6e903cc0782eee63efea8b0c7d9bd83aaeca3c3659c72b4f1b64b24dbae63273",
-                            "id": "fls_jTh9Hur0qsIb",
-                            "link": "patterns.html#fls_jTh9Hur0qsIb",
-                            "number": "5.2.1:10"
-                        },
-                        {
-                            "checksum": "c8519c37bf9a85c68075db3cb98c5ff8ab8db77174740ac05497368044b20534",
-                            "id": "fls_as54u97xis8z",
-                            "link": "patterns.html#fls_as54u97xis8z",
-                            "number": "5.2.1:11"
-                        },
-                        {
-                            "checksum": "3515e0658c65c83d72e0dd7ad0e82d86216d338c31040d3e27832951a2aa83b5",
-                            "id": "fls_8364ueejn5y3",
-                            "link": "patterns.html#fls_8364ueejn5y3",
-                            "number": "5.2.1:12"
-                        },
-                        {
-                            "checksum": "f951f3c203a03b558cf318fb35a3313fa155405830ed6d804fcdea0b828eb716",
-                            "id": "fls_7t0be1w2hq3c",
-                            "link": "patterns.html#fls_7t0be1w2hq3c",
-                            "number": "5.2.1:13"
-                        },
-                        {
-                            "checksum": "6103ce2aaa63552db1ddd1712d330355e209efd8b3f05e2ee118128d79c0f57a",
-                            "id": "fls_3vgmkm2mzwwy",
-                            "link": "patterns.html#fls_3vgmkm2mzwwy",
-                            "number": "5.2.1:14"
-                        },
-                        {
-                            "checksum": "b94ca5c69e41ecdd7da89cf82764d0e4561528548bd0a3491afd0dcc1dc27452",
-                            "id": "fls_m91ith3rjy79",
-                            "link": "patterns.html#fls_m91ith3rjy79",
-                            "number": "5.2.1:15"
-                        },
-                        {
-                            "checksum": "b71b81a6c560dbce28bfa29908e6476ea8fd75a9b27df354ac6d310149124194",
-                            "id": "fls_c09jf2vpcr58",
-                            "link": "patterns.html#fls_c09jf2vpcr58",
-                            "number": "5.2.1:16"
-                        },
-                        {
-                            "checksum": "cb358844aa1dd3a9c5395b092c62c4e62c28a58e0b909d2c9d99344e409fafac",
-                            "id": "fls_4h00oqypa8qg",
-                            "link": "patterns.html#fls_4h00oqypa8qg",
-                            "number": "5.2.1:17"
-                        },
-                        {
-                            "checksum": "2406df736b1c1b7e052beb8d6a704041b3804de21cf83ac7e64bb84ea5c0180f",
-                            "id": "fls_195mqijyrnam",
-                            "link": "patterns.html#fls_195mqijyrnam",
-                            "number": "5.2.1:18"
-                        },
-                        {
-                            "checksum": "685de37c2ee81a66dccabb7f81942c82479d896f00e1e1334d4a60a9ea3b6bdc",
-                            "id": "fls_ta0vdoqmt2k1",
-                            "link": "patterns.html#fls_ta0vdoqmt2k1",
-                            "number": "5.2.1:19"
-                        },
-                        {
-                            "checksum": "c02d71a02dfad46132450d2be620a7cabbd2eabf47c6bd9b01945121cd5d3aa0",
-                            "id": "fls_f0u0j4q90lpl",
-                            "link": "patterns.html#fls_f0u0j4q90lpl",
-                            "number": "5.2.1:20"
-                        },
-                        {
-                            "checksum": "b0f4dad87afccd06af733d465607f36dcde450f57438e710856d594b3dfb6e8d",
-                            "id": "fls_8bi8q3usubby",
-                            "link": "patterns.html#fls_8bi8q3usubby",
-                            "number": "5.2.1:21"
-                        },
-                        {
-                            "checksum": "da482f0aac1389101e1acc7d29df971ea52cbb5a914a549589717f367179ec59",
-                            "id": "fls_1x0o71kxj3yq",
-                            "link": "patterns.html#fls_1x0o71kxj3yq",
-                            "number": "5.2.1:22"
-                        },
-                        {
-                            "checksum": "d75c1d570151a0c0add5bd9dbd8879ab364860d21ddd5a1981f20b5a358d8ac6",
-                            "id": "fls_1thgpx95lfg5",
-                            "link": "patterns.html#fls_1thgpx95lfg5",
-                            "number": "5.2.1:23"
-                        },
-                        {
-                            "checksum": "014416678ebb189d6688fb5242e5205e11770c286ca59a48f79dda7f6ae4a8b1",
-                            "id": "fls_rpo1wimbmzhc",
-                            "link": "patterns.html#fls_rpo1wimbmzhc",
-                            "number": "5.2.1:24"
-                        },
-                        {
-                            "checksum": "5dfa02c07c1e043d1fbc3b8eab7d4555147d7e61752f59b311c2486f4a53c2ef",
-                            "id": "fls_brhtaaxt1s3s",
-                            "link": "patterns.html#fls_brhtaaxt1s3s",
-                            "number": "5.2.1:25"
-                        },
-                        {
-                            "checksum": "bc8d158c05838e267c985dd76e4808b795b9c9b82d65690a8d2744bf8753e87e",
-                            "id": "fls_jwz3arnfkxwn",
-                            "link": "patterns.html#fls_jwz3arnfkxwn",
-                            "number": "5.2.1:26"
-                        },
-                        {
-                            "checksum": "cd32c48d96ca8821d8b097e61f7031858e9955ae4cb198bb1001a71624f77a7f",
-                            "id": "fls_pfz8xlwezbw1",
-                            "link": "patterns.html#fls_pfz8xlwezbw1",
-                            "number": "5.2.1:27"
-                        },
-                        {
-                            "checksum": "892be146ad066dad2bd25128cc3091054cbd49abdf7268f54e6f21339362e750",
-                            "id": "fls_XFKBJZe6k1o2",
-                            "link": "patterns.html#fls_XFKBJZe6k1o2",
-                            "number": "5.2.1:28"
-                        },
-                        {
-                            "checksum": "3dda2685fefad7736c09572d77850f39aea37aff6a75b4775df949965c478004",
-                            "id": "fls_mu166csowj71",
-                            "link": "patterns.html#fls_mu166csowj71",
-                            "number": "5.2.1:29"
-                        },
-                        {
-                            "checksum": "ae7dbf4db5d0804bb1b4f47f1a3d6ac4f752d00aacb5fd25e7d8f748f4760adc",
-                            "id": "fls_y09fygnglu3n",
-                            "link": "patterns.html#fls_y09fygnglu3n",
-                            "number": "5.2.1:30"
-                        },
-                        {
-                            "checksum": "b61a46d5ed3d3618df19128c327bc64de735101d00f7fc3b645d60b73ded72dd",
-                            "id": "fls_2tadaatmauzk",
-                            "link": "patterns.html#fls_2tadaatmauzk",
-                            "number": "5.2.1:31"
-                        },
-                        {
-                            "checksum": "d75819f44a8d7f85c50196f3a44487fcbfdaa07c19627675b6bb09b4f2fc97c4",
-                            "id": "fls_oq30xkmvyz72",
-                            "link": "patterns.html#fls_oq30xkmvyz72",
-                            "number": "5.2.1:32"
-                        },
-                        {
-                            "checksum": "5f55bfd0214be05b8229314e347c9671c485811ab7606a2c8c5a06c39aa89aae",
-                            "id": "fls_9y1gbv47z23o",
-                            "link": "patterns.html#fls_9y1gbv47z23o",
-                            "number": "5.2.1:33"
-                        },
-                        {
-                            "checksum": "013fca3143fcb9507c780ebe41cc1f74a40222e55f6c4b695758e3b78c605d12",
-                            "id": "fls_dHtV2BPRFVBB",
-                            "link": "patterns.html#fls_dHtV2BPRFVBB",
-                            "number": "5.2.1:34"
-                        },
-                        {
-                            "checksum": "af8c99976d128dfd24b2788359de45493a9f94be7c7f89b9a4f4f5864bdbf1b0",
-                            "id": "fls_zRCiKnhQebyp",
-                            "link": "patterns.html#fls_zRCiKnhQebyp",
-                            "number": "5.2.1:35"
-                        },
-                        {
-                            "checksum": "c268e10c795ada4873656e9f0fab449fea0c4a36994b5b024693b3b6bb4ee3a7",
-                            "id": "fls_D5tAGzrjXFTu",
-                            "link": "patterns.html#fls_D5tAGzrjXFTu",
-                            "number": "5.2.1:36"
-                        },
-                        {
-                            "checksum": "16873908fc7b0e081b3a93d248479b79ce08a2c8d800fe5b80a55f81b3507300",
-                            "id": "fls_FhvMzLPRlY7p",
-                            "link": "patterns.html#fls_FhvMzLPRlY7p",
-                            "number": "5.2.1:37"
-                        }
-                    ],
-                    "title": "Record Struct Patterns"
-                },
-                {
-                    "id": "fls_vlrto778v49m",
-                    "informational": false,
-                    "link": "patterns.html#tuple-struct-patterns",
-                    "number": "5.2.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "398db4748805660067dff91c2d8c07f0ce9a02f750eedab4d786b7097ea8a772",
-                            "id": "fls_ks6y1syab2bp",
-                            "link": "patterns.html#fls_ks6y1syab2bp",
-                            "number": "5.2.2:1"
-                        },
-                        {
-                            "checksum": "c49ac22e3f94f28c61a3b041503608d3e3f6a337ad9fdd9162106b3e8a729ddd",
-                            "id": "fls_t1mrijw16k9a",
-                            "link": "patterns.html#fls_t1mrijw16k9a",
-                            "number": "5.2.2:2"
-                        },
-                        {
-                            "checksum": "caed82759506953820cc05207e2ff166b8c73479f82882f1d52cec340b5ea5f2",
-                            "id": "fls_ryfcrqrkp28y",
-                            "link": "patterns.html#fls_ryfcrqrkp28y",
-                            "number": "5.2.2:3"
-                        },
-                        {
-                            "checksum": "52efa16e2d2072309e596e1e678e1ed4c435a2a10a044d200823d457ae75c86b",
-                            "id": "fls_ehf9r6halgh1",
-                            "link": "patterns.html#fls_ehf9r6halgh1",
-                            "number": "5.2.2:4"
-                        },
-                        {
-                            "checksum": "88a50cbe98942f52e03b0825ff7e25f2b0c89e3c3a66979381da5376a170cee7",
-                            "id": "fls_5lo1hs8wzz0t",
-                            "link": "patterns.html#fls_5lo1hs8wzz0t",
-                            "number": "5.2.2:5"
-                        },
-                        {
-                            "checksum": "3dc2817ca063542426c88f985729203dbe054c09d6efe49d7eb52097ec52bca6",
-                            "id": "fls_gwuc2xffosu",
-                            "link": "patterns.html#fls_gwuc2xffosu",
-                            "number": "5.2.2:6"
-                        },
-                        {
-                            "checksum": "541bd9b4e34b9b13bac861950cbc1ff7a06f887ca4d3a08d65ca538b08a21639",
-                            "id": "fls_w369n8lmwr7g",
-                            "link": "patterns.html#fls_w369n8lmwr7g",
-                            "number": "5.2.2:7"
-                        },
-                        {
-                            "checksum": "ca44a0d983f6a2c58de0d0da866f70042fb1589545be9d179d6b19542bf94f4f",
-                            "id": "fls_4is6h95jj3gd",
-                            "link": "patterns.html#fls_4is6h95jj3gd",
-                            "number": "5.2.2:8"
-                        },
-                        {
-                            "checksum": "d8b0cbea39dac23dc53d3b24c98a4832ca33e84bd17e7a35598838c1ec69d58b",
-                            "id": "fls_budf0rpsa4lx",
-                            "link": "patterns.html#fls_budf0rpsa4lx",
-                            "number": "5.2.2:9"
-                        },
-                        {
-                            "checksum": "f47bc7199534d69e8491c54e3507a6dab7fa624a91bc061b87c451e8ed8af807",
-                            "id": "fls_vo6mtauh4qhb",
-                            "link": "patterns.html#fls_vo6mtauh4qhb",
-                            "number": "5.2.2:10"
-                        },
-                        {
-                            "checksum": "9e91b8f7ea80554c6c9d801b284fd737f8072273ca2869a7a1a7c23f6cba1e10",
-                            "id": "fls_rco3fwlx2a76",
-                            "link": "patterns.html#fls_rco3fwlx2a76",
-                            "number": "5.2.2:11"
-                        },
-                        {
-                            "checksum": "435aadfae6890acd5b2f7c089d2bf6c6bde46b865278bc446f816f2900ad444d",
-                            "id": "fls_4vrnxslad09e",
-                            "link": "patterns.html#fls_4vrnxslad09e",
-                            "number": "5.2.2:12"
-                        },
-                        {
-                            "checksum": "c18b1eaabbf21d6d906c4d4255fe8e1efcf58af3fbebbfffa7348ac6b6edf3c5",
-                            "id": "fls_qgilaqy5zx7q",
-                            "link": "patterns.html#fls_qgilaqy5zx7q",
-                            "number": "5.2.2:13"
-                        },
-                        {
-                            "checksum": "2d585002f71b603779602116d0639fd90c72f6c4832288b134b5a2c57dc36717",
-                            "id": "fls_2u99arsbnlnk",
-                            "link": "patterns.html#fls_2u99arsbnlnk",
-                            "number": "5.2.2:14"
-                        }
-                    ],
-                    "title": "Tuple Struct Patterns"
-                },
-                {
-                    "id": "fls_urbr5rg9206v",
-                    "informational": false,
-                    "link": "patterns.html#tuple-patterns",
-                    "number": "5.2.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "86e5cf86cc1727a1ec3d2c9b3c7770ba2d5a0a0be11e05f181cf89208cef7e8f",
-                            "id": "fls_e2manugp4e0b",
-                            "link": "patterns.html#fls_e2manugp4e0b",
-                            "number": "5.2.3:1"
-                        },
-                        {
-                            "checksum": "968065a0acde4dc1fc6772c9a80d889371d997d4d812bece3bb143b855b791f3",
-                            "id": "fls_xk8udu4k61kj",
-                            "link": "patterns.html#fls_xk8udu4k61kj",
-                            "number": "5.2.3:2"
-                        },
-                        {
-                            "checksum": "c046f561eb355602680f839ad87e202a633dd889397bbc12f7027ffc7b5a284a",
-                            "id": "fls_yhcaz6v49ub2",
-                            "link": "patterns.html#fls_yhcaz6v49ub2",
-                            "number": "5.2.3:3"
-                        },
-                        {
-                            "checksum": "208f90ce72da5d32c30755d34df67702194f5fe887e9c7a1bd0554c4718eeede",
-                            "id": "fls_6WCm0Ra8NQl4",
-                            "link": "patterns.html#fls_6WCm0Ra8NQl4",
-                            "number": "5.2.3:4"
-                        },
-                        {
-                            "checksum": "d4a0b43d9d6a5e0b17d67fcdf081a940f340d1b85d971f31c684778d9986fb2b",
-                            "id": "fls_a3qvQjyilORx",
-                            "link": "patterns.html#fls_a3qvQjyilORx",
-                            "number": "5.2.3:5"
-                        },
-                        {
-                            "checksum": "289e79602b945e44a6b259d8d0c1e225e914afa943874c7698ef97f89f8f3def",
-                            "id": "fls_KmIHFxlBYelZ",
-                            "link": "patterns.html#fls_KmIHFxlBYelZ",
-                            "number": "5.2.3:6"
-                        },
-                        {
-                            "checksum": "bd944455b4e5b2992d60a0276dd284685483fbdb2ce0a6e8b861676e3d2069b7",
-                            "id": "fls_5bXqIaKiFcLg",
-                            "link": "patterns.html#fls_5bXqIaKiFcLg",
-                            "number": "5.2.3:7"
-                        },
-                        {
-                            "checksum": "47877ba9b3984b4661b6db0b34526c8edb770ea1f800c33d64c5523a6d44b8f2",
-                            "id": "fls_soHCAVfGlv5f",
-                            "link": "patterns.html#fls_soHCAVfGlv5f",
-                            "number": "5.2.3:8"
-                        },
-                        {
-                            "checksum": "325628fddc5edcfee5dde126d580262949d54d516c4f6d9243baff7c4f607da9",
-                            "id": "fls_iiKvYs61959S",
-                            "link": "patterns.html#fls_iiKvYs61959S",
-                            "number": "5.2.3:9"
-                        },
-                        {
-                            "checksum": "80b589c7aaacf22228397ab8de7f859870551fa23bbc58316341c4fe297455b0",
-                            "id": "fls_F4k6ljuP8Amf",
-                            "link": "patterns.html#fls_F4k6ljuP8Amf",
-                            "number": "5.2.3:10"
-                        },
-                        {
-                            "checksum": "d0a0133555000675455b2bf5ab37681e6e7bb93783c7e8ebd5178f80704e6ce1",
-                            "id": "fls_GjjCDkVJPQS8",
-                            "link": "patterns.html#fls_GjjCDkVJPQS8",
-                            "number": "5.2.3:11"
-                        },
-                        {
-                            "checksum": "46bd974ba3f88ec8c528de9c9907e74139719b19f51d32a06f37cede033afd44",
-                            "id": "fls_9Qw9N87swwNe",
-                            "link": "patterns.html#fls_9Qw9N87swwNe",
-                            "number": "5.2.3:12"
-                        },
-                        {
-                            "checksum": "f1887b73be484d54fe02b6a04ea8aee012209872ae40fb9179a705c3f4856242",
-                            "id": "fls_CQ84wkLyrAJv",
-                            "link": "patterns.html#fls_CQ84wkLyrAJv",
-                            "number": "5.2.3:13"
-                        },
-                        {
-                            "checksum": "176644151cc57b936a43b35578e7182a3c89ac881b62ba4e3aa5bfede1008ecf",
-                            "id": "fls_cC6ohNuiltfL",
-                            "link": "patterns.html#fls_cC6ohNuiltfL",
-                            "number": "5.2.3:14"
-                        },
-                        {
-                            "checksum": "c479906bca39314417e1caa942e7ef8efbb0987857a2c5ea2e3dc30d69cc4a20",
-                            "id": "fls_8r81vtv5hnrd",
-                            "link": "patterns.html#fls_8r81vtv5hnrd",
-                            "number": "5.2.3:15"
-                        }
-                    ],
-                    "title": "Tuple Patterns"
-                },
-                {
-                    "id": "fls_qfsfnql1t7m",
-                    "informational": false,
-                    "link": "patterns.html#underscore-patterns",
-                    "number": "5.2.4",
-                    "paragraphs": [
-                        {
-                            "checksum": "ffe05e2b6f44aab3204db8f037bcbabda722b0b2a4c36233bd344165b0915664",
-                            "id": "fls_dreny9e0ei6r",
-                            "link": "patterns.html#fls_dreny9e0ei6r",
-                            "number": "5.2.4:1"
-                        },
-                        {
-                            "checksum": "512af904f1afbc0ae83e21197bac2017c65eb4d2820eb33ef0e964251753ac99",
-                            "id": "fls_42fye1v0th8l",
-                            "link": "patterns.html#fls_42fye1v0th8l",
-                            "number": "5.2.4:2"
-                        },
-                        {
-                            "checksum": "4df12d4b4abe0cd1029651c34033e70582bd69ad83cfc6a3a733e4bf20d8da0a",
-                            "id": "fls_b87mvrcc13f2",
-                            "link": "patterns.html#fls_b87mvrcc13f2",
-                            "number": "5.2.4:3"
-                        },
-                        {
-                            "checksum": "7dd5b2d964186c34d5eb0d46902b5bcc8cef29ddc8f75425c634837f9354dbcd",
-                            "id": "fls_j3u6x1ensrbe",
-                            "link": "patterns.html#fls_j3u6x1ensrbe",
-                            "number": "5.2.4:4"
-                        }
-                    ],
-                    "title": "Underscore Patterns"
-                },
-                {
-                    "id": "fls_qssijtofa9i8",
-                    "informational": false,
-                    "link": "patterns.html#binding-modes",
-                    "number": "5.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "ce737fd6a8e0011aa5361836e179e7da00b62d001685d8a3099eda2e5f94ff52",
-                            "id": "fls_7xby6d1903kw",
-                            "link": "patterns.html#fls_7xby6d1903kw",
-                            "number": "5.3:1"
-                        },
-                        {
-                            "checksum": "ee24110781d1935c43cf0567d764e1aadf2cc3db7f17740efe4e767ac0ee9632",
-                            "id": "fls_vnh9wfrvumdz",
-                            "link": "patterns.html#fls_vnh9wfrvumdz",
-                            "number": "5.3:2"
-                        },
-                        {
-                            "checksum": "3689001f3e5a3fadb5bce3f16c76e8babf3aa8a1b12b24dc1d08cc2709b6336c",
-                            "id": "fls_RViC5UEZPQUV",
-                            "link": "patterns.html#fls_RViC5UEZPQUV",
-                            "number": "5.3:3"
-                        },
-                        {
-                            "checksum": "1a8541da9715b497aff0fb8fd6116cd249a0350898d3dd89d00b2c30c7e82671",
-                            "id": "fls_6lXtoxebD5It",
-                            "link": "patterns.html#fls_6lXtoxebD5It",
-                            "number": "5.3:4"
-                        },
-                        {
-                            "checksum": "0b306a42847f796ecf6339eefc0af21e5781a2cde421ae3141018b146e11ffb0",
-                            "id": "fls_xNxQN8sgpZ3O",
-                            "link": "patterns.html#fls_xNxQN8sgpZ3O",
-                            "number": "5.3:5"
-                        },
-                        {
-                            "checksum": "0871ae0bb0826a8d223e8c2cee52f184b7c0e39f86c5063fcd676f7fbc614365",
-                            "id": "fls_dqe75i8h2fie",
-                            "link": "patterns.html#fls_dqe75i8h2fie",
-                            "number": "5.3:6"
-                        },
-                        {
-                            "checksum": "959846317dd64ecd23fd6c93f96608048d818682c7cd48599dfffcd231a8557a",
-                            "id": "fls_y3wuvj1y5j20",
-                            "link": "patterns.html#fls_y3wuvj1y5j20",
-                            "number": "5.3:7"
-                        },
-                        {
-                            "checksum": "edc7cf534c55c29625cd191432a05763797465d54cbd387fee8127a17ad0f1ed",
-                            "id": "fls_55jtzh6a292x",
-                            "link": "patterns.html#fls_55jtzh6a292x",
-                            "number": "5.3:8"
-                        },
-                        {
-                            "checksum": "174692122d916648a54e197fff15a1e7bf17984b9523fd06224c71a7484e0445",
-                            "id": "fls_qcaf2kup7zn0",
-                            "link": "patterns.html#fls_qcaf2kup7zn0",
-                            "number": "5.3:9"
-                        },
-                        {
-                            "checksum": "c9dfbc0519fed7bb3f112777102c928f15a4d5c3cfc13d4d3017e9c15259ce08",
-                            "id": "fls_6acdqz8rwnn",
-                            "link": "patterns.html#fls_6acdqz8rwnn",
-                            "number": "5.3:10"
-                        },
-                        {
-                            "checksum": "61b076c4aa153ed7b1ed996845d08b881a2327bfe131501f20b3ae9b3a2c042d",
-                            "id": "fls_tv0avib387bv",
-                            "link": "patterns.html#fls_tv0avib387bv",
-                            "number": "5.3:11"
-                        },
-                        {
-                            "checksum": "a30925ea032d35a24204cb5c81fc5ad636e77d19ce00fb38615985b1bec396d6",
-                            "id": "fls_dbgmwldye42e",
-                            "link": "patterns.html#fls_dbgmwldye42e",
-                            "number": "5.3:12"
-                        },
-                        {
-                            "checksum": "e9940ece8b67430f6507527efb4e0837eea8ecd615884b2d4a3773018ca5df88",
-                            "id": "fls_t34oqarwcusu",
-                            "link": "patterns.html#fls_t34oqarwcusu",
-                            "number": "5.3:13"
-                        },
-                        {
-                            "checksum": "94de4c12fad70f9cac54c2a50a2c65b9a5d0f42b1847bddbbb2e5c23d1e9917c",
-                            "id": "fls_7gxb74u1np36",
-                            "link": "patterns.html#fls_7gxb74u1np36",
-                            "number": "5.3:14"
-                        },
-                        {
-                            "checksum": "7b6cefba0ed64069e11e48d9eddf7bdab4f5ec7b32d73b3a9c0c92d7fd078d3a",
-                            "id": "fls_7y56d0ulxomf",
-                            "link": "patterns.html#fls_7y56d0ulxomf",
-                            "number": "5.3:15"
-                        },
-                        {
-                            "checksum": "7a06ffc02f7927cd15e2513d53f8a618b2100301b066a92e111ba6ce488b6941",
-                            "id": "fls_pxvtqxke1enp",
-                            "link": "patterns.html#fls_pxvtqxke1enp",
-                            "number": "5.3:16"
-                        }
-                    ],
-                    "title": "Binding Modes"
-                },
-                {
-                    "id": "fls_jm6l7b90h6wa",
-                    "informational": false,
-                    "link": "patterns.html#pattern-matching",
-                    "number": "5.4",
-                    "paragraphs": [
-                        {
-                            "checksum": "6b0c9b448ffa1317860d5ce72327a183542c035ca71f57b637fe069226784ff8",
-                            "id": "fls_tlwr4u7bjhh5",
-                            "link": "patterns.html#fls_tlwr4u7bjhh5",
-                            "number": "5.4:1"
-                        },
-                        {
-                            "checksum": "b6d21ac4978904629594c63e865c13ff0e8188557a1ee1fc16bf38d292273905",
-                            "id": "fls_67ajub7d2b4c",
-                            "link": "patterns.html#fls_67ajub7d2b4c",
-                            "number": "5.4:2"
-                        },
-                        {
-                            "checksum": "d6e77f76c3b70cd441241b2ddcb2ece4258490b36edc54866617c3d56b1d1db9",
-                            "id": "fls_62626ws222op",
-                            "link": "patterns.html#fls_62626ws222op",
-                            "number": "5.4:3"
-                        },
-                        {
-                            "checksum": "6867ae30832eda7ee1fee559e718d1cc657447cfdb727917e47a405431cbb8fc",
-                            "id": "fls_q0z46h1gnzez",
-                            "link": "patterns.html#fls_q0z46h1gnzez",
-                            "number": "5.4:4"
-                        },
-                        {
-                            "checksum": "b919a4d8d9ed226bbf402a3d3d51992d55a4159a5723b7534992db054a299aa0",
-                            "id": "fls_1r0vm6rg13o9",
-                            "link": "patterns.html#fls_1r0vm6rg13o9",
-                            "number": "5.4:5"
-                        },
-                        {
-                            "checksum": "7a5e47b54e578d0454d02d99d9d1735d8480757b894acfedb724f6f4945d4557",
-                            "id": "fls_am5h8r887bz5",
-                            "link": "patterns.html#fls_am5h8r887bz5",
-                            "number": "5.4:6"
-                        },
-                        {
-                            "checksum": "0261db6dc821115e2d72a8963d41e3816c27ff5dec58ab612b4b0043bab2628c",
-                            "id": "fls_eppmiloh7bgg",
-                            "link": "patterns.html#fls_eppmiloh7bgg",
-                            "number": "5.4:7"
-                        },
-                        {
-                            "checksum": "d8bde8dafa190be72dc04dbd04f9dcc381ba9e56fc7c59ef14e0adf12d08da99",
-                            "id": "fls_gwc08xayno7q",
-                            "link": "patterns.html#fls_gwc08xayno7q",
-                            "number": "5.4:8"
-                        },
-                        {
-                            "checksum": "5b38e89f8e8e644db16464772877616b08bec8b5dc081183f140b1944cd02d7d",
-                            "id": "fls_19iygu12s315",
-                            "link": "patterns.html#fls_19iygu12s315",
-                            "number": "5.4:9"
-                        },
-                        {
-                            "checksum": "e7cdc075b361ca70248b735173fd1ae43a881787197759e135ebe311f34f316a",
-                            "id": "fls_r307spfk6cs9",
-                            "link": "patterns.html#fls_r307spfk6cs9",
-                            "number": "5.4:10"
-                        },
-                        {
-                            "checksum": "7e28619896a113dc0b4fcbbfbc7c0e60f3fbe58465cdd9e0c57ae6883ca75849",
-                            "id": "fls_qhdofvbso3gl",
-                            "link": "patterns.html#fls_qhdofvbso3gl",
-                            "number": "5.4:11"
-                        },
-                        {
-                            "checksum": "0f085b2b200d131b0f3ad93e901232589ae5185e8b937688595401a2281802f1",
-                            "id": "fls_drb114dtvlpt",
-                            "link": "patterns.html#fls_drb114dtvlpt",
-                            "number": "5.4:12"
-                        },
-                        {
-                            "checksum": "1b7c6f4e677eefe1fb3db44988440585f0a06c492b2c55de71cbc12e1ee26149",
-                            "id": "fls_uxysntb3u03j",
-                            "link": "patterns.html#fls_uxysntb3u03j",
-                            "number": "5.4:13"
-                        },
-                        {
-                            "checksum": "8bd4950f12c3fc2761c334a84cb412e80a671197a21ca640ebe447e01836d826",
-                            "id": "fls_wh201rmh6u6d",
-                            "link": "patterns.html#fls_wh201rmh6u6d",
-                            "number": "5.4:14"
-                        },
-                        {
-                            "checksum": "fd13d0bd953b8f054714e974f43ba2b7fa374ed3ffd288303907a4242b346c4e",
-                            "id": "fls_vstdqifqipbh",
-                            "link": "patterns.html#fls_vstdqifqipbh",
-                            "number": "5.4:15"
-                        }
-                    ],
-                    "title": "Pattern Matching"
-                },
-                {
-                    "id": "fls_vnai6ag4qrdb",
-                    "informational": false,
-                    "link": "patterns.html#identifier-pattern-matching",
-                    "number": "5.4.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "dd60a44dea7a972ddea069491ecd9f406558f404e901527ddd0d2149eeb48ebd",
-                            "id": "fls_4f3lzw64myhk",
-                            "link": "patterns.html#fls_4f3lzw64myhk",
-                            "number": "5.4.1:1"
-                        },
-                        {
-                            "checksum": "aa285e853a6324a841c40d2b74e066fb6002f1fb6707b20a81ff680616eae3fc",
-                            "id": "fls_wauqwmdbcpna",
-                            "link": "patterns.html#fls_wauqwmdbcpna",
-                            "number": "5.4.1:2"
-                        },
-                        {
-                            "checksum": "4aef617035a62c693b0db6e84d556a1afe10c28af4f9b0ca18065503767f6015",
-                            "id": "fls_3jyog8n6x2aa",
-                            "link": "patterns.html#fls_3jyog8n6x2aa",
-                            "number": "5.4.1:3"
-                        },
-                        {
-                            "checksum": "0db8e23416d53e90ad73fa4df5b10d7e3ef8d53418d42a8860380a85d5d1163a",
-                            "id": "fls_w637uvlbzsyo",
-                            "link": "patterns.html#fls_w637uvlbzsyo",
-                            "number": "5.4.1:4"
-                        },
-                        {
-                            "checksum": "1cf4f4074ffc3e6745944b1dcd726ac4b7d65f44568c669f04ddfcbe8068d57e",
-                            "id": "fls_arz8ik3gf6u4",
-                            "link": "patterns.html#fls_arz8ik3gf6u4",
-                            "number": "5.4.1:5"
-                        },
-                        {
-                            "checksum": "5003a32c5e8a49a9e7d778d70ff05edcf2411bd284272a8bf7bd04d2df3a40fe",
-                            "id": "fls_u6o5ndnezwbe",
-                            "link": "patterns.html#fls_u6o5ndnezwbe",
-                            "number": "5.4.1:6"
-                        },
-                        {
-                            "checksum": "de66751e709611b36e4517f705acf75d052724e2501a8c5ee5ab8c40757115e5",
-                            "id": "fls_h1er04t0yta7",
-                            "link": "patterns.html#fls_h1er04t0yta7",
-                            "number": "5.4.1:7"
-                        }
-                    ],
-                    "title": "Identifier Pattern Matching"
-                },
-                {
-                    "id": "fls_azzf1llv3wf",
-                    "informational": false,
-                    "link": "patterns.html#literal-pattern-matching",
-                    "number": "5.4.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "ffb06275d46d70835ab2e118cff4b0071d02544ee94a260f428fd2b5533bed1c",
-                            "id": "fls_fqkhhgushje9",
-                            "link": "patterns.html#fls_fqkhhgushje9",
-                            "number": "5.4.2:1"
-                        },
-                        {
-                            "checksum": "d04dcff15efbb13e790e1f78948bf446426570ec9618c3b921293adfc2012199",
-                            "id": "fls_m01eo9sa55s",
-                            "link": "patterns.html#fls_m01eo9sa55s",
-                            "number": "5.4.2:2"
-                        },
-                        {
-                            "checksum": "fe6504c691ded75e993e4d66b216f7260d30ac52c0a60e35151af31c01905992",
-                            "id": "fls_294jtwbfq3p9",
-                            "link": "patterns.html#fls_294jtwbfq3p9",
-                            "number": "5.4.2:3"
-                        }
-                    ],
-                    "title": "Literal Pattern Matching"
-                },
-                {
-                    "id": "fls_5loglxds6zik",
-                    "informational": false,
-                    "link": "patterns.html#parenthesized-pattern-matching",
-                    "number": "5.4.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "7f3d87f0e2bf7a6dc15e6e0bcda2506008be955f016459a792ea2b99d16bacbf",
-                            "id": "fls_jajvvwoy3399",
-                            "link": "patterns.html#fls_jajvvwoy3399",
-                            "number": "5.4.3:1"
-                        }
-                    ],
-                    "title": "Parenthesized Pattern Matching"
-                },
-                {
-                    "id": "fls_d44aflefat88",
-                    "informational": false,
-                    "link": "patterns.html#path-pattern-matching",
-                    "number": "5.4.4",
-                    "paragraphs": [
-                        {
-                            "checksum": "b62c95bf3039a32f793c95cd983bcc5cd80b8faeb5d469cc963c3a487f437fae",
-                            "id": "fls_4faltss0xbn4",
-                            "link": "patterns.html#fls_4faltss0xbn4",
-                            "number": "5.4.4:1"
-                        },
-                        {
-                            "checksum": "ee205e802f76cf743647cd0b8c7be7f9d118ea51ef62a9f8ccd237ee2a7c874c",
-                            "id": "fls_fqt5w3qsykca",
-                            "link": "patterns.html#fls_fqt5w3qsykca",
-                            "number": "5.4.4:2"
-                        },
-                        {
-                            "checksum": "10a9ff549fbafbc317a299a46f8f61ed3ec121a3f1c97d94c1a3ae2aeee961f7",
-                            "id": "fls_h3y8r4298s53",
-                            "link": "patterns.html#fls_h3y8r4298s53",
-                            "number": "5.4.4:3"
-                        }
-                    ],
-                    "title": "Path Pattern Matching"
-                },
-                {
-                    "id": "fls_fyskeih6twyb",
-                    "informational": false,
-                    "link": "patterns.html#range-pattern-matching",
-                    "number": "5.4.5",
-                    "paragraphs": [
-                        {
-                            "checksum": "74c808f389212d771098798db71f913b01fad773d198d3babf0a21ae6f4ce792",
-                            "id": "fls_mrh9vfdek5fi",
-                            "link": "patterns.html#fls_mrh9vfdek5fi",
-                            "number": "5.4.5:1"
-                        },
-                        {
-                            "checksum": "4e77c3805f9c1fde39877a54a3b99be7582ff7dde64d6f8b033465fcfb625c8c",
-                            "id": "fls_7nxkgls0a5os",
-                            "link": "patterns.html#fls_7nxkgls0a5os",
-                            "number": "5.4.5:2"
-                        },
-                        {
-                            "checksum": "fd8fba85c57e8cde11619040e0cf63b8bee10a4ad77a5a663655cf44f7527d00",
-                            "id": "fls_6kgj2fjccoig",
-                            "link": "patterns.html#fls_6kgj2fjccoig",
-                            "number": "5.4.5:3"
-                        },
-                        {
-                            "checksum": "6ceef4a4fb5e7197f8e4fbeea43c666aa1ee532e0e198a0242be6ab5dca9d26c",
-                            "id": "fls_EDL1Pi56KQ2H",
-                            "link": "patterns.html#fls_EDL1Pi56KQ2H",
-                            "number": "5.4.5:4"
-                        },
-                        {
-                            "checksum": "7ee404fd4fb97fe0f1daafdb86a76994a1056bc3cbc4571522f37b405f651572",
-                            "id": "fls_n4t3xah1pk7i",
-                            "link": "patterns.html#fls_n4t3xah1pk7i",
-                            "number": "5.4.5:5"
-                        }
-                    ],
-                    "title": "Range Pattern Matching"
-                },
-                {
-                    "id": "fls_org6hqv397fp",
-                    "informational": false,
-                    "link": "patterns.html#reference-pattern-matching",
-                    "number": "5.4.6",
-                    "paragraphs": [
-                        {
-                            "checksum": "b6dad8a8eb45a793423595800323ed5f357d864241174e7198f4101b4d5c9c9b",
-                            "id": "fls_ysfgdzaiww8z",
-                            "link": "patterns.html#fls_ysfgdzaiww8z",
-                            "number": "5.4.6:1"
-                        },
-                        {
-                            "checksum": "9932447e7ad4cb062a332bea07f5eb902fa9f0482de8917d2a3bee05f86c2fdf",
-                            "id": "fls_7rxnxd4ybxbt",
-                            "link": "patterns.html#fls_7rxnxd4ybxbt",
-                            "number": "5.4.6:2"
-                        },
-                        {
-                            "checksum": "b76bff46c3fb725fb95fd036da6eec2951e358e24662e16fe7a2b277948422eb",
-                            "id": "fls_l2nwz166curc",
-                            "link": "patterns.html#fls_l2nwz166curc",
-                            "number": "5.4.6:3"
-                        }
-                    ],
-                    "title": "Reference Pattern Matching"
-                },
-                {
-                    "id": "fls_57ic33pwdvp3",
-                    "informational": false,
-                    "link": "patterns.html#slice-pattern-matching",
-                    "number": "5.4.7",
-                    "paragraphs": [
-                        {
-                            "checksum": "545a7b4ddaf1e7bfb2237db616a2cf9a24e53676e02591cec035c44ace0b0fd1",
-                            "id": "fls_hzyv4ofu0ny",
-                            "link": "patterns.html#fls_hzyv4ofu0ny",
-                            "number": "5.4.7:1"
-                        },
-                        {
-                            "checksum": "a08c2a45fe77ae5f047f5e6cf64b8f743c4433b940e5f5fb0245051c079e7e8a",
-                            "id": "fls_x10AKxoXXbs8",
-                            "link": "patterns.html#fls_x10AKxoXXbs8",
-                            "number": "5.4.7:2"
-                        },
-                        {
-                            "checksum": "00b9a97b9280c3716ddfa172c721a2bf0e2081a9fa912cffde3cda55d1197952",
-                            "id": "fls_69bnxrtj0nar",
-                            "link": "patterns.html#fls_69bnxrtj0nar",
-                            "number": "5.4.7:3"
-                        },
-                        {
-                            "checksum": "c48b717f055594a928a658edaf02b1fabf8a096bdefdb3fbc8f24437462635da",
-                            "id": "fls_twhwiy213ibf",
-                            "link": "patterns.html#fls_twhwiy213ibf",
-                            "number": "5.4.7:4"
-                        },
-                        {
-                            "checksum": "3f7ea24067807e7941333db26d088679f21fbd2c64a2407cf545ff6861841872",
-                            "id": "fls_ei7y4ul6n6hu",
-                            "link": "patterns.html#fls_ei7y4ul6n6hu",
-                            "number": "5.4.7:5"
-                        },
-                        {
-                            "checksum": "4925bc389627a9c0258c8b5aa732c62f27ea3c62e2b3c0bbfd6e8f9c1350920e",
-                            "id": "fls_ad2jud5h1rfp",
-                            "link": "patterns.html#fls_ad2jud5h1rfp",
-                            "number": "5.4.7:6"
-                        },
-                        {
-                            "checksum": "0a3498e1551afa3c7f492391c8187746fccf5ebb43ae48f55741d4dd39aaceab",
-                            "id": "fls_pc97m47p34wq",
-                            "link": "patterns.html#fls_pc97m47p34wq",
-                            "number": "5.4.7:7"
-                        },
-                        {
-                            "checksum": "ff3c524edac17baef16b63f1da2eead531f9c065f671838de8c437b87e87f859",
-                            "id": "fls_kwQyiSoyAwZ8",
-                            "link": "patterns.html#fls_kwQyiSoyAwZ8",
-                            "number": "5.4.7:8"
-                        },
-                        {
-                            "checksum": "624d69de485ef8707d6d98a26dcdfd92081861894d0c06dba07882fe19de3ee2",
-                            "id": "fls_zAdtysiuUwBX",
-                            "link": "patterns.html#fls_zAdtysiuUwBX",
-                            "number": "5.4.7:9"
-                        },
-                        {
-                            "checksum": "8f94a20f9d18e18084cc5e7931d668de6254cce6b14813fce2f2a16d4a699598",
-                            "id": "fls_SezcYXcSlEq7",
-                            "link": "patterns.html#fls_SezcYXcSlEq7",
-                            "number": "5.4.7:10"
-                        },
-                        {
-                            "checksum": "f14008365b9b2173763090e4ac8e371acae7932276efa64dd5c4bef234a9b625",
-                            "id": "fls_6xRXEt2pGnZi",
-                            "link": "patterns.html#fls_6xRXEt2pGnZi",
-                            "number": "5.4.7:11"
-                        }
-                    ],
-                    "title": "Slice Pattern Matching"
-                },
-                {
-                    "id": "fls_asj8rgccvkoe",
-                    "informational": false,
-                    "link": "patterns.html#record-struct-pattern-matching",
-                    "number": "5.4.8",
-                    "paragraphs": [
-                        {
-                            "checksum": "a64d7a8315d7d5f47ec10463a26465d1b20225bc5c426030b5af68285a662722",
-                            "id": "fls_evuhau2rwm8i",
-                            "link": "patterns.html#fls_evuhau2rwm8i",
-                            "number": "5.4.8:1"
-                        },
-                        {
-                            "checksum": "202123ed4c141cd00114f671cc7b4a9caaafd86ff150c865e93c8e9dad4257fc",
-                            "id": "fls_bde1hpvrosui",
-                            "link": "patterns.html#fls_bde1hpvrosui",
-                            "number": "5.4.8:2"
-                        },
-                        {
-                            "checksum": "d0da6696f0030559710cd9ee013efb4dbfb95b1df235fe5f469bfcd2d24034c4",
-                            "id": "fls_447s4hc07ozn",
-                            "link": "patterns.html#fls_447s4hc07ozn",
-                            "number": "5.4.8:3"
-                        },
-                        {
-                            "checksum": "b11dc2c5dfcaf758c45e4029e582f72a53c74e7c2c98575fb2b7461ae1e7d805",
-                            "id": "fls_vfdb1i5l41yk",
-                            "link": "patterns.html#fls_vfdb1i5l41yk",
-                            "number": "5.4.8:4"
-                        },
-                        {
-                            "checksum": "36081581a365a6503d56139e07b8e1749757cf878634d805e84663d3172cb005",
-                            "id": "fls_yfk52fr7trw3",
-                            "link": "patterns.html#fls_yfk52fr7trw3",
-                            "number": "5.4.8:5"
-                        },
-                        {
-                            "checksum": "8b8f1725d0cf2ef6489bd548eec9d59fab537eca1f33a509f8141751325cba76",
-                            "id": "fls_6sdcykdrpe5d",
-                            "link": "patterns.html#fls_6sdcykdrpe5d",
-                            "number": "5.4.8:6"
-                        }
-                    ],
-                    "title": "Record Struct Pattern Matching"
-                },
-                {
-                    "id": "fls_eexupzdsu7f",
-                    "informational": false,
-                    "link": "patterns.html#tuple-struct-pattern-matching",
-                    "number": "5.4.9",
-                    "paragraphs": [
-                        {
-                            "checksum": "ed45c176d905341bee988af8640b3011dd6a97d9c8fe53b45410925a79d5e056",
-                            "id": "fls_dexg9g9cct30",
-                            "link": "patterns.html#fls_dexg9g9cct30",
-                            "number": "5.4.9:1"
-                        },
-                        {
-                            "checksum": "03c31f4e25eebbe78169c4bc173609effc1e8269dfe4f263b29363409e316dab",
-                            "id": "fls_boc7juqj69hw",
-                            "link": "patterns.html#fls_boc7juqj69hw",
-                            "number": "5.4.9:2"
-                        },
-                        {
-                            "checksum": "6b75afdc8b9b09fcd7df94b0c730c87e30d4bb2de200714adf3a08575e90a90a",
-                            "id": "fls_4dr1stiw82v9",
-                            "link": "patterns.html#fls_4dr1stiw82v9",
-                            "number": "5.4.9:3"
-                        },
-                        {
-                            "checksum": "13343ca1b2a108f58c91e7fcdb4c9e4c975f5fa11d841db4951a8883a4bcc7d5",
-                            "id": "fls_h14emtt6iyk3",
-                            "link": "patterns.html#fls_h14emtt6iyk3",
-                            "number": "5.4.9:4"
-                        }
-                    ],
-                    "title": "Tuple Struct Pattern Matching"
-                },
-                {
-                    "id": "fls_rce8bb7nz2jy",
-                    "informational": false,
-                    "link": "patterns.html#tuple-pattern-matching",
-                    "number": "5.4.10",
-                    "paragraphs": [
-                        {
-                            "checksum": "746ffe5085ba7cfbb59d3c44688b6f8584fa574128327bb37f2f051173efb07d",
-                            "id": "fls_w4xypnrnhycb",
-                            "link": "patterns.html#fls_w4xypnrnhycb",
-                            "number": "5.4.10:1"
-                        },
-                        {
-                            "checksum": "5f1c0e7fad583c2e4331c5805f1dbf89717118d493a01549a42dfeaa3f0279ca",
-                            "id": "fls_vnx1bpval595",
-                            "link": "patterns.html#fls_vnx1bpval595",
-                            "number": "5.4.10:2"
-                        },
-                        {
-                            "checksum": "e86a7e2ae632d8ce6ffaeb404902846bb48e160aab297c2c2652d9b985f7982e",
-                            "id": "fls_dzf32f40y7fr",
-                            "link": "patterns.html#fls_dzf32f40y7fr",
-                            "number": "5.4.10:3"
-                        },
-                        {
-                            "checksum": "37eed365431808077ba3f82d504515f343520002fd244c7649305e39f6c96d7e",
-                            "id": "fls_krl32txvxxkz",
-                            "link": "patterns.html#fls_krl32txvxxkz",
-                            "number": "5.4.10:4"
-                        }
-                    ],
-                    "title": "Tuple Pattern Matching"
-                },
-                {
-                    "id": "fls_yc4xm4hrfyw7",
-                    "informational": false,
-                    "link": "patterns.html#underscore-pattern-matching",
-                    "number": "5.4.11",
-                    "paragraphs": [
-                        {
-                            "checksum": "b9ccebce07421997dfd958ff40f0aef3a1b9e546fb3bcf0c2cefe7fbfdd64d01",
-                            "id": "fls_dvk7r1gf7pwp",
-                            "link": "patterns.html#fls_dvk7r1gf7pwp",
-                            "number": "5.4.11:1"
-                        },
-                        {
-                            "checksum": "33c34bf81e9f7a3651a3718b8ab5b88c0ba416ea85e283b4fbd4a7e30e78b48a",
-                            "id": "fls_e0uprihqn1y6",
-                            "link": "patterns.html#fls_e0uprihqn1y6",
-                            "number": "5.4.11:2"
-                        },
-                        {
-                            "checksum": "8e3a3ff978133c3bfffe09986eace47f5b4afb21f6c71af39fd93f4f27ad2860",
-                            "id": "fls_ljcq2vyo052q",
-                            "link": "patterns.html#fls_ljcq2vyo052q",
-                            "number": "5.4.11:3"
-                        }
-                    ],
-                    "title": "Underscore Pattern Matching"
-                }
-            ],
-            "title": "Patterns"
-        },
-        {
-            "informational": false,
-            "link": "statements.html",
-            "sections": [
-                {
-                    "id": "fls_wdicg3sqa98e",
-                    "informational": false,
-                    "link": "statements.html",
-                    "number": "8",
-                    "paragraphs": [
-                        {
-                            "checksum": "03f55779646bda5f8b813a0bda5a8000aaa7a3f7df2147c58d37a6a19d213825",
-                            "id": "fls_7zh6ziglo5iy",
-                            "link": "statements.html#fls_7zh6ziglo5iy",
-                            "number": "8:1"
-                        },
-                        {
-                            "checksum": "857eb6f6081f30de98150db89a25a25467c0e180b1c3eb19f2786475a5a6e424",
-                            "id": "fls_kdxe1ukmgl1",
-                            "link": "statements.html#fls_kdxe1ukmgl1",
-                            "number": "8:2"
-                        },
-                        {
-                            "checksum": "1ea74f2f77df136dd43cf45552f12fb2f6c366bcf10505917c84e5c9f9fd5fd8",
-                            "id": "fls_fftdnwe22xrb",
-                            "link": "statements.html#fls_fftdnwe22xrb",
-                            "number": "8:3"
-                        },
-                        {
-                            "checksum": "36cd13cda4653f00db550d04d91838c3dc10bfcbbf15d67f8ba19c0d5ddc297b",
-                            "id": "fls_or125cqtxg9j",
-                            "link": "statements.html#fls_or125cqtxg9j",
-                            "number": "8:4"
-                        },
-                        {
-                            "checksum": "82751916e76e8a528dd974fcf8f394553a002d42480c43ef8ca7bd23dec0d51a",
-                            "id": "fls_estqu395zxgk",
-                            "link": "statements.html#fls_estqu395zxgk",
-                            "number": "8:5"
-                        },
-                        {
-                            "checksum": "085c0b250339d5488037ef839a9f6dd3672026ab75232f7a43c422bca728726c",
-                            "id": "fls_dl763ssb54q1",
-                            "link": "statements.html#fls_dl763ssb54q1",
-                            "number": "8:6"
-                        }
-                    ],
-                    "title": "Statements"
-                },
-                {
-                    "id": "fls_yivm43r5wnp1",
-                    "informational": false,
-                    "link": "statements.html#let-statements",
-                    "number": "8.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "fa270e107510c6e1cbbd96841a51e304e617eb94f030aaa20c17913ff260d725",
-                            "id": "fls_ct7pp7jnfr86",
-                            "link": "statements.html#fls_ct7pp7jnfr86",
-                            "number": "8.1:1"
-                        },
-                        {
-                            "checksum": "d10976aa00e76b2bd9ae4e6118e2bb91d70d4093d2416f3c38179f5e2786f112",
-                            "id": "fls_SR3dIgR5K0Kq",
-                            "link": "statements.html#fls_SR3dIgR5K0Kq",
-                            "number": "8.1:2"
-                        },
-                        {
-                            "checksum": "be1f15f55c52d38164795fc8324e4f7a5b3ca997e5de0de3c0c4ebe283e2d68e",
-                            "id": "fls_iqar7vvtw22c",
-                            "link": "statements.html#fls_iqar7vvtw22c",
-                            "number": "8.1:3"
-                        },
-                        {
-                            "checksum": "9e23e5768ee96bddd83192456f161ce9e1ff1c043dfeb8c0a8d59713108c1f50",
-                            "id": "fls_1s1UikGU5YQb",
-                            "link": "statements.html#fls_1s1UikGU5YQb",
-                            "number": "8.1:4"
-                        },
-                        {
-                            "checksum": "925e4f38b1fdb1037706134fa36069b0e1bf99946535bcf9436afefb7f125751",
-                            "id": "fls_iB25BeFys0j8",
-                            "link": "statements.html#fls_iB25BeFys0j8",
-                            "number": "8.1:5"
-                        },
-                        {
-                            "checksum": "65cba8734e75668ea9ff7e09a1d7c86536c79970652b19d3888805207b40c3b2",
-                            "id": "fls_zObyLdya4DYc",
-                            "link": "statements.html#fls_zObyLdya4DYc",
-                            "number": "8.1:6"
-                        },
-                        {
-                            "checksum": "14989244832f8c7b3fd3884340df2f4df49e5f8442fe0aa7848cc011cb94a6f6",
-                            "id": "fls_r38TXWKQPjxv",
-                            "link": "statements.html#fls_r38TXWKQPjxv",
-                            "number": "8.1:7"
-                        },
-                        {
-                            "checksum": "1635f6e94205f0755cc45a4da9f7272940034fa7496b94ccdff8a2284b0b8e38",
-                            "id": "fls_6QSdwF4pzjoe",
-                            "link": "statements.html#fls_6QSdwF4pzjoe",
-                            "number": "8.1:8"
-                        },
-                        {
-                            "checksum": "6e23f656fcfe54a647a2278c5484a3fc80ed08112e18b6d4d6a5f11a8c2f6b5f",
-                            "id": "fls_1prqh1trybwz",
-                            "link": "statements.html#fls_1prqh1trybwz",
-                            "number": "8.1:9"
-                        },
-                        {
-                            "checksum": "271df8c51d41c031901cb4d22bea984e6f6a8e260e878213b8ed7c580900eabc",
-                            "id": "fls_djkm8r2iuu6u",
-                            "link": "statements.html#fls_djkm8r2iuu6u",
-                            "number": "8.1:10"
-                        },
-                        {
-                            "checksum": "5c3b2ab8a0b6d48dff5c50e3ca9743ba453c77aadcaa49d6a9485a5fc393c244",
-                            "id": "fls_ppj9gvhp8wcj",
-                            "link": "statements.html#fls_ppj9gvhp8wcj",
-                            "number": "8.1:11"
-                        },
-                        {
-                            "checksum": "9fc5558523a5dc96084b645182a9748a4ea46e67b31afc2341107cee0b0121aa",
-                            "id": "fls_1eBQDZdBuDsN",
-                            "link": "statements.html#fls_1eBQDZdBuDsN",
-                            "number": "8.1:12"
-                        },
-                        {
-                            "checksum": "99c4feb3265bf0e6b3a0c606397811171dba2b964d2471c4ccefa87af19ab501",
-                            "id": "fls_m8a7gesa4oim",
-                            "link": "statements.html#fls_m8a7gesa4oim",
-                            "number": "8.1:13"
-                        },
-                        {
-                            "checksum": "ed71cf991f9a7542c7a7106e4754bb01cdd386dcf21b1c27e7f21519ac4a12cc",
-                            "id": "fls_oaxnre7m9s10",
-                            "link": "statements.html#fls_oaxnre7m9s10",
-                            "number": "8.1:14"
-                        },
-                        {
-                            "checksum": "24c8c95a02e8ee0e3828c7b00c71b666881c4ac437e3c018d06b7d83ad58b70d",
-                            "id": "fls_t5bjwluyv8za",
-                            "link": "statements.html#fls_t5bjwluyv8za",
-                            "number": "8.1:15"
-                        },
-                        {
-                            "checksum": "017c4fc4f03e296f8d96a0a62fc006c647bf0a9faaa94ad561061c93e9402928",
-                            "id": "fls_4j9riqyf4p9",
-                            "link": "statements.html#fls_4j9riqyf4p9",
-                            "number": "8.1:16"
-                        },
-                        {
-                            "checksum": "ab96a34396479306ef71b507703ffdd2fe9dd68512c87538bc972ad910a8d508",
-                            "id": "fls_t53g5hlabqw1",
-                            "link": "statements.html#fls_t53g5hlabqw1",
-                            "number": "8.1:17"
-                        },
-                        {
-                            "checksum": "3c6ccdcf4fec0d1389605503a83c401562b7c707fe92ad33814c8cd10b1d3b1e",
-                            "id": "fls_7j4qlwg72ege",
-                            "link": "statements.html#fls_7j4qlwg72ege",
-                            "number": "8.1:18"
-                        },
-                        {
-                            "checksum": "14d436071a7dda876a858e8877ad564c71299dacb6239d9bff7ea3299d8d6a65",
-                            "id": "fls_ea9bRFZjH8Im",
-                            "link": "statements.html#fls_ea9bRFZjH8Im",
-                            "number": "8.1:19"
-                        }
-                    ],
-                    "title": "Let Statements"
-                },
-                {
-                    "id": "fls_1pg5ig740tg1",
-                    "informational": false,
-                    "link": "statements.html#expression-statements",
-                    "number": "8.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "990f51f353986bd884828681d0f82474e27e8ff3042cd1c0b1908f048e7c7315",
-                            "id": "fls_xmdj8uj7ixoe",
-                            "link": "statements.html#fls_xmdj8uj7ixoe",
-                            "number": "8.2:1"
-                        },
-                        {
-                            "checksum": "0c5f0f107d5b1e196ef1a3003b0eb3d235bc6cbebd98a9537e5a9caf9df0c146",
-                            "id": "fls_gzzmudc1hl6s",
-                            "link": "statements.html#fls_gzzmudc1hl6s",
-                            "number": "8.2:2"
-                        },
-                        {
-                            "checksum": "28b62503095184fa5c0dc9898c27c50ecaeebfef606f663370bdcaefa1c68cea",
-                            "id": "fls_kc99n8qrszxh",
-                            "link": "statements.html#fls_kc99n8qrszxh",
-                            "number": "8.2:3"
-                        },
-                        {
-                            "checksum": "f02ee18552936ea98c3764181f5651c46b54e5af37f3149b17bd6906ecb33556",
-                            "id": "fls_r8poocwqaglf",
-                            "link": "statements.html#fls_r8poocwqaglf",
-                            "number": "8.2:4"
-                        },
-                        {
-                            "checksum": "cf7b0c182db5007a86bf5c05bdfb68e63de338e95ef2e377bafa1708a7c00738",
-                            "id": "fls_88e6s3erk8tj",
-                            "link": "statements.html#fls_88e6s3erk8tj",
-                            "number": "8.2:5"
-                        },
-                        {
-                            "checksum": "fe5fb38b0a811437c9b5e6e9f70af727c9013f79573eee3673146cf030c660c4",
-                            "id": "fls_4q90jb39apwr",
-                            "link": "statements.html#fls_4q90jb39apwr",
-                            "number": "8.2:6"
-                        },
-                        {
-                            "checksum": "737bef4656101e6322af305e26b7c23b0c56fe07e9b5404ed0fe6daff16a8d02",
-                            "id": "fls_xqtztcu8ibwq",
-                            "link": "statements.html#fls_xqtztcu8ibwq",
-                            "number": "8.2:7"
-                        },
-                        {
-                            "checksum": "93c30bb9a1f379d6fce63a4b7aded720c5328d70432fdb6c05a7aa2312426a73",
-                            "id": "fls_2p9xnt519nbw",
-                            "link": "statements.html#fls_2p9xnt519nbw",
-                            "number": "8.2:8"
-                        }
-                    ],
-                    "title": "Expression Statements"
-                }
-            ],
-            "title": "Statements"
         },
         {
             "informational": false,
@@ -14720,13 +12663,13 @@
                             "number": "4.8.1:3"
                         },
                         {
-                            "checksum": "64f8361944319957c75fe0ffca3b34a6f0ba3ba81b3bffb0af7b006670e0eabc",
+                            "checksum": "637383dc4d1660eea32118dd12d2223bac4c904a62d1b6362ee20154a1fd8a9c",
                             "id": "fls_Xo1ODwOyX7Vm",
                             "link": "types-and-traits.html#fls_Xo1ODwOyX7Vm",
                             "number": "4.8.1:4"
                         },
                         {
-                            "checksum": "d7db4839a1e87feaaecb8e893c0b2cc853f2efed9f5d6ed5a9db4275e5c4b785",
+                            "checksum": "05a4175995d776a46a98e4d297c0a67cfb2ed6dcef4796010a1d0cc829263bce",
                             "id": "fls_kTGFLFymTWch",
                             "link": "types-and-traits.html#fls_kTGFLFymTWch",
                             "number": "4.8.1:5"
@@ -14750,7 +12693,7 @@
                             "number": "4.8.1:8"
                         },
                         {
-                            "checksum": "f69eaaaf1d139fae4f084cd58b82bea52933adc8eda9523d725d2ad7ee3dca2f",
+                            "checksum": "33a093516df193a7fdc2815dbd081c61f7afc3126d1c8442b5009786e41ad74f",
                             "id": "fls_iT9WCNfUZQnC",
                             "link": "types-and-traits.html#fls_iT9WCNfUZQnC",
                             "number": "4.8.1:9"
@@ -17270,7 +15213,7 @@
                             "number": "4.14.1:2"
                         },
                         {
-                            "checksum": "cc5e873584087c6b48aba80dcf3395e1894ebc0edb4d4288a12af42c395f838e",
+                            "checksum": "cb7a8e0c24c9740e97f2f5acc1326c7e1f22108d641e9cc3a0ce60f0f8be917c",
                             "id": "fls_gcszhqg6hnva",
                             "link": "types-and-traits.html#fls_gcszhqg6hnva",
                             "number": "4.14.1:3"
@@ -17919,6 +15862,574 @@
         },
         {
             "informational": false,
+            "link": "statements.html",
+            "sections": [
+                {
+                    "id": "fls_wdicg3sqa98e",
+                    "informational": false,
+                    "link": "statements.html",
+                    "number": "8",
+                    "paragraphs": [
+                        {
+                            "checksum": "03f55779646bda5f8b813a0bda5a8000aaa7a3f7df2147c58d37a6a19d213825",
+                            "id": "fls_7zh6ziglo5iy",
+                            "link": "statements.html#fls_7zh6ziglo5iy",
+                            "number": "8:1"
+                        },
+                        {
+                            "checksum": "857eb6f6081f30de98150db89a25a25467c0e180b1c3eb19f2786475a5a6e424",
+                            "id": "fls_kdxe1ukmgl1",
+                            "link": "statements.html#fls_kdxe1ukmgl1",
+                            "number": "8:2"
+                        },
+                        {
+                            "checksum": "1ea74f2f77df136dd43cf45552f12fb2f6c366bcf10505917c84e5c9f9fd5fd8",
+                            "id": "fls_fftdnwe22xrb",
+                            "link": "statements.html#fls_fftdnwe22xrb",
+                            "number": "8:3"
+                        },
+                        {
+                            "checksum": "36cd13cda4653f00db550d04d91838c3dc10bfcbbf15d67f8ba19c0d5ddc297b",
+                            "id": "fls_or125cqtxg9j",
+                            "link": "statements.html#fls_or125cqtxg9j",
+                            "number": "8:4"
+                        },
+                        {
+                            "checksum": "82751916e76e8a528dd974fcf8f394553a002d42480c43ef8ca7bd23dec0d51a",
+                            "id": "fls_estqu395zxgk",
+                            "link": "statements.html#fls_estqu395zxgk",
+                            "number": "8:5"
+                        },
+                        {
+                            "checksum": "085c0b250339d5488037ef839a9f6dd3672026ab75232f7a43c422bca728726c",
+                            "id": "fls_dl763ssb54q1",
+                            "link": "statements.html#fls_dl763ssb54q1",
+                            "number": "8:6"
+                        }
+                    ],
+                    "title": "Statements"
+                },
+                {
+                    "id": "fls_yivm43r5wnp1",
+                    "informational": false,
+                    "link": "statements.html#let-statements",
+                    "number": "8.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "fa270e107510c6e1cbbd96841a51e304e617eb94f030aaa20c17913ff260d725",
+                            "id": "fls_ct7pp7jnfr86",
+                            "link": "statements.html#fls_ct7pp7jnfr86",
+                            "number": "8.1:1"
+                        },
+                        {
+                            "checksum": "d10976aa00e76b2bd9ae4e6118e2bb91d70d4093d2416f3c38179f5e2786f112",
+                            "id": "fls_SR3dIgR5K0Kq",
+                            "link": "statements.html#fls_SR3dIgR5K0Kq",
+                            "number": "8.1:2"
+                        },
+                        {
+                            "checksum": "be1f15f55c52d38164795fc8324e4f7a5b3ca997e5de0de3c0c4ebe283e2d68e",
+                            "id": "fls_iqar7vvtw22c",
+                            "link": "statements.html#fls_iqar7vvtw22c",
+                            "number": "8.1:3"
+                        },
+                        {
+                            "checksum": "9e23e5768ee96bddd83192456f161ce9e1ff1c043dfeb8c0a8d59713108c1f50",
+                            "id": "fls_1s1UikGU5YQb",
+                            "link": "statements.html#fls_1s1UikGU5YQb",
+                            "number": "8.1:4"
+                        },
+                        {
+                            "checksum": "925e4f38b1fdb1037706134fa36069b0e1bf99946535bcf9436afefb7f125751",
+                            "id": "fls_iB25BeFys0j8",
+                            "link": "statements.html#fls_iB25BeFys0j8",
+                            "number": "8.1:5"
+                        },
+                        {
+                            "checksum": "65cba8734e75668ea9ff7e09a1d7c86536c79970652b19d3888805207b40c3b2",
+                            "id": "fls_zObyLdya4DYc",
+                            "link": "statements.html#fls_zObyLdya4DYc",
+                            "number": "8.1:6"
+                        },
+                        {
+                            "checksum": "14989244832f8c7b3fd3884340df2f4df49e5f8442fe0aa7848cc011cb94a6f6",
+                            "id": "fls_r38TXWKQPjxv",
+                            "link": "statements.html#fls_r38TXWKQPjxv",
+                            "number": "8.1:7"
+                        },
+                        {
+                            "checksum": "1635f6e94205f0755cc45a4da9f7272940034fa7496b94ccdff8a2284b0b8e38",
+                            "id": "fls_6QSdwF4pzjoe",
+                            "link": "statements.html#fls_6QSdwF4pzjoe",
+                            "number": "8.1:8"
+                        },
+                        {
+                            "checksum": "6e23f656fcfe54a647a2278c5484a3fc80ed08112e18b6d4d6a5f11a8c2f6b5f",
+                            "id": "fls_1prqh1trybwz",
+                            "link": "statements.html#fls_1prqh1trybwz",
+                            "number": "8.1:9"
+                        },
+                        {
+                            "checksum": "271df8c51d41c031901cb4d22bea984e6f6a8e260e878213b8ed7c580900eabc",
+                            "id": "fls_djkm8r2iuu6u",
+                            "link": "statements.html#fls_djkm8r2iuu6u",
+                            "number": "8.1:10"
+                        },
+                        {
+                            "checksum": "5c3b2ab8a0b6d48dff5c50e3ca9743ba453c77aadcaa49d6a9485a5fc393c244",
+                            "id": "fls_ppj9gvhp8wcj",
+                            "link": "statements.html#fls_ppj9gvhp8wcj",
+                            "number": "8.1:11"
+                        },
+                        {
+                            "checksum": "9fc5558523a5dc96084b645182a9748a4ea46e67b31afc2341107cee0b0121aa",
+                            "id": "fls_1eBQDZdBuDsN",
+                            "link": "statements.html#fls_1eBQDZdBuDsN",
+                            "number": "8.1:12"
+                        },
+                        {
+                            "checksum": "99c4feb3265bf0e6b3a0c606397811171dba2b964d2471c4ccefa87af19ab501",
+                            "id": "fls_m8a7gesa4oim",
+                            "link": "statements.html#fls_m8a7gesa4oim",
+                            "number": "8.1:13"
+                        },
+                        {
+                            "checksum": "ed71cf991f9a7542c7a7106e4754bb01cdd386dcf21b1c27e7f21519ac4a12cc",
+                            "id": "fls_oaxnre7m9s10",
+                            "link": "statements.html#fls_oaxnre7m9s10",
+                            "number": "8.1:14"
+                        },
+                        {
+                            "checksum": "24c8c95a02e8ee0e3828c7b00c71b666881c4ac437e3c018d06b7d83ad58b70d",
+                            "id": "fls_t5bjwluyv8za",
+                            "link": "statements.html#fls_t5bjwluyv8za",
+                            "number": "8.1:15"
+                        },
+                        {
+                            "checksum": "017c4fc4f03e296f8d96a0a62fc006c647bf0a9faaa94ad561061c93e9402928",
+                            "id": "fls_4j9riqyf4p9",
+                            "link": "statements.html#fls_4j9riqyf4p9",
+                            "number": "8.1:16"
+                        },
+                        {
+                            "checksum": "ab96a34396479306ef71b507703ffdd2fe9dd68512c87538bc972ad910a8d508",
+                            "id": "fls_t53g5hlabqw1",
+                            "link": "statements.html#fls_t53g5hlabqw1",
+                            "number": "8.1:17"
+                        },
+                        {
+                            "checksum": "3c6ccdcf4fec0d1389605503a83c401562b7c707fe92ad33814c8cd10b1d3b1e",
+                            "id": "fls_7j4qlwg72ege",
+                            "link": "statements.html#fls_7j4qlwg72ege",
+                            "number": "8.1:18"
+                        },
+                        {
+                            "checksum": "14d436071a7dda876a858e8877ad564c71299dacb6239d9bff7ea3299d8d6a65",
+                            "id": "fls_ea9bRFZjH8Im",
+                            "link": "statements.html#fls_ea9bRFZjH8Im",
+                            "number": "8.1:19"
+                        }
+                    ],
+                    "title": "Let Statements"
+                },
+                {
+                    "id": "fls_1pg5ig740tg1",
+                    "informational": false,
+                    "link": "statements.html#expression-statements",
+                    "number": "8.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "990f51f353986bd884828681d0f82474e27e8ff3042cd1c0b1908f048e7c7315",
+                            "id": "fls_xmdj8uj7ixoe",
+                            "link": "statements.html#fls_xmdj8uj7ixoe",
+                            "number": "8.2:1"
+                        },
+                        {
+                            "checksum": "0c5f0f107d5b1e196ef1a3003b0eb3d235bc6cbebd98a9537e5a9caf9df0c146",
+                            "id": "fls_gzzmudc1hl6s",
+                            "link": "statements.html#fls_gzzmudc1hl6s",
+                            "number": "8.2:2"
+                        },
+                        {
+                            "checksum": "28b62503095184fa5c0dc9898c27c50ecaeebfef606f663370bdcaefa1c68cea",
+                            "id": "fls_kc99n8qrszxh",
+                            "link": "statements.html#fls_kc99n8qrszxh",
+                            "number": "8.2:3"
+                        },
+                        {
+                            "checksum": "f02ee18552936ea98c3764181f5651c46b54e5af37f3149b17bd6906ecb33556",
+                            "id": "fls_r8poocwqaglf",
+                            "link": "statements.html#fls_r8poocwqaglf",
+                            "number": "8.2:4"
+                        },
+                        {
+                            "checksum": "cf7b0c182db5007a86bf5c05bdfb68e63de338e95ef2e377bafa1708a7c00738",
+                            "id": "fls_88e6s3erk8tj",
+                            "link": "statements.html#fls_88e6s3erk8tj",
+                            "number": "8.2:5"
+                        },
+                        {
+                            "checksum": "fe5fb38b0a811437c9b5e6e9f70af727c9013f79573eee3673146cf030c660c4",
+                            "id": "fls_4q90jb39apwr",
+                            "link": "statements.html#fls_4q90jb39apwr",
+                            "number": "8.2:6"
+                        },
+                        {
+                            "checksum": "737bef4656101e6322af305e26b7c23b0c56fe07e9b5404ed0fe6daff16a8d02",
+                            "id": "fls_xqtztcu8ibwq",
+                            "link": "statements.html#fls_xqtztcu8ibwq",
+                            "number": "8.2:7"
+                        },
+                        {
+                            "checksum": "93c30bb9a1f379d6fce63a4b7aded720c5328d70432fdb6c05a7aa2312426a73",
+                            "id": "fls_2p9xnt519nbw",
+                            "link": "statements.html#fls_2p9xnt519nbw",
+                            "number": "8.2:8"
+                        }
+                    ],
+                    "title": "Expression Statements"
+                }
+            ],
+            "title": "Statements"
+        },
+        {
+            "informational": false,
+            "link": "program-structure-and-compilation.html",
+            "sections": [
+                {
+                    "id": "fls_hdwwrsyunir",
+                    "informational": false,
+                    "link": "program-structure-and-compilation.html",
+                    "number": "18",
+                    "paragraphs": [],
+                    "title": "Program Structure and Compilation"
+                },
+                {
+                    "id": "fls_s35hob3i7lr",
+                    "informational": false,
+                    "link": "program-structure-and-compilation.html#source-files",
+                    "number": "18.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "55f6d3282e08235092b6157374cbc8fad302ec5965229b94dca69fbf5a239934",
+                            "id": "fls_4vicosdeaqmp",
+                            "link": "program-structure-and-compilation.html#fls_4vicosdeaqmp",
+                            "number": "18.1:1"
+                        },
+                        {
+                            "checksum": "7555cb7065456e8c9abbac7b69fc1d5e7a6e631762739806e629635a718a19ac",
+                            "id": "fls_ann3cha1xpek",
+                            "link": "program-structure-and-compilation.html#fls_ann3cha1xpek",
+                            "number": "18.1:2"
+                        }
+                    ],
+                    "title": "Source Files"
+                },
+                {
+                    "id": "fls_e9hwvqsib5d5",
+                    "informational": false,
+                    "link": "program-structure-and-compilation.html#modules",
+                    "number": "18.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "ec4163446ba1d6053faea2c9be55ae44b49f9e489b2fb4266106708fe16bdda3",
+                            "id": "fls_odd1hj3y1mgu",
+                            "link": "program-structure-and-compilation.html#fls_odd1hj3y1mgu",
+                            "number": "18.2:1"
+                        },
+                        {
+                            "checksum": "a552ab77145836cc109d96b376f5e785089d1f7d95d6d51c25ecfddb3708b512",
+                            "id": "fls_whgv72emrm47",
+                            "link": "program-structure-and-compilation.html#fls_whgv72emrm47",
+                            "number": "18.2:2"
+                        },
+                        {
+                            "checksum": "1233b4977ef4e5fd6c5969530904ff70690f361cc5fccddbf8952e1cc7d299f8",
+                            "id": "fls_qypjjpcf8uwq",
+                            "link": "program-structure-and-compilation.html#fls_qypjjpcf8uwq",
+                            "number": "18.2:3"
+                        },
+                        {
+                            "checksum": "f54b92d3867600666f831b9a1ca07de6acba61ac72937335bd0451a3de4cbb27",
+                            "id": "fls_cavwpr1ybk37",
+                            "link": "program-structure-and-compilation.html#fls_cavwpr1ybk37",
+                            "number": "18.2:4"
+                        },
+                        {
+                            "checksum": "ddcd4deef3d419dcbf8b2c18aaa5d8bb453229bce34e4d7180d9e8f93d2bf303",
+                            "id": "fls_plepew2319g4",
+                            "link": "program-structure-and-compilation.html#fls_plepew2319g4",
+                            "number": "18.2:5"
+                        },
+                        {
+                            "checksum": "fa07c91c0b0de63411270c072bdc923db3f1db860082d3eddad31ca6eed189c5",
+                            "id": "fls_1aruwps62c4p",
+                            "link": "program-structure-and-compilation.html#fls_1aruwps62c4p",
+                            "number": "18.2:6"
+                        }
+                    ],
+                    "title": "Modules"
+                },
+                {
+                    "id": "fls_maw4u1o8q37u",
+                    "informational": false,
+                    "link": "program-structure-and-compilation.html#crates",
+                    "number": "18.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "c64331512493388d716b5e98082811475682dcffee41348b82483eb48cd91fc5",
+                            "id": "fls_qwghk79ok5h0",
+                            "link": "program-structure-and-compilation.html#fls_qwghk79ok5h0",
+                            "number": "18.3:1"
+                        },
+                        {
+                            "checksum": "076cdc6ed8a203ec16636f7d7a4f7bfc8fcf4ad833ca2a5eb22898fa6eeb576c",
+                            "id": "fls_unxalgMqIr3v",
+                            "link": "program-structure-and-compilation.html#fls_unxalgMqIr3v",
+                            "number": "18.3:2"
+                        },
+                        {
+                            "checksum": "cc519441f6acd2fc70f4251a27ea4b31fd340a96b04393a9725c4ee2ac8cb0f1",
+                            "id": "fls_e7jGvXvTsFpC",
+                            "link": "program-structure-and-compilation.html#fls_e7jGvXvTsFpC",
+                            "number": "18.3:3"
+                        },
+                        {
+                            "checksum": "900926091f2fede279a11afbb6e26774c0925d89e0c2a22e8d66e4454f946b6d",
+                            "id": "fls_kQiJPwb2Hjcc",
+                            "link": "program-structure-and-compilation.html#fls_kQiJPwb2Hjcc",
+                            "number": "18.3:4"
+                        },
+                        {
+                            "checksum": "3ac54406ea82315c87cf8183011163d2c68bb2596b63674f83fda32c046f21c9",
+                            "id": "fls_9ub6ks8qrang",
+                            "link": "program-structure-and-compilation.html#fls_9ub6ks8qrang",
+                            "number": "18.3:5"
+                        },
+                        {
+                            "checksum": "8db6a4b2f241361fa8613dd0e294548a09dde19ef5946330c8eca66ccd46bf09",
+                            "id": "fls_OyFwBtDGVimT",
+                            "link": "program-structure-and-compilation.html#fls_OyFwBtDGVimT",
+                            "number": "18.3:6"
+                        },
+                        {
+                            "checksum": "8b845c17714f7a58a93d5da09f978d3d87cfdbe7d4b7758b0f26740430c368de",
+                            "id": "fls_jQqXxPyND1ds",
+                            "link": "program-structure-and-compilation.html#fls_jQqXxPyND1ds",
+                            "number": "18.3:7"
+                        },
+                        {
+                            "checksum": "f15de757cf59ea80d471a93296df48599ad3b3402b7f85e22194e0e38f546b11",
+                            "id": "fls_d9nn4yuiw1ja",
+                            "link": "program-structure-and-compilation.html#fls_d9nn4yuiw1ja",
+                            "number": "18.3:8"
+                        },
+                        {
+                            "checksum": "bc735aaea18f5347b09a4b7ac21ae36e48f125b2cfa1ecbdb0566b0070303199",
+                            "id": "fls_Mf62VqAhoZ3c",
+                            "link": "program-structure-and-compilation.html#fls_Mf62VqAhoZ3c",
+                            "number": "18.3:9"
+                        },
+                        {
+                            "checksum": "ca2db7453a265830bd34e2a087ce0a6e08f97f20221a3ef1ab151f72892c5e8f",
+                            "id": "fls_RJJmN4tP7j4m",
+                            "link": "program-structure-and-compilation.html#fls_RJJmN4tP7j4m",
+                            "number": "18.3:10"
+                        },
+                        {
+                            "checksum": "7285d85fe56e6377849b918e1d006071c4bb14a18476290ddc8cce3adcc11a30",
+                            "id": "fls_h93C3wfbAoz1",
+                            "link": "program-structure-and-compilation.html#fls_h93C3wfbAoz1",
+                            "number": "18.3:11"
+                        }
+                    ],
+                    "title": "Crates"
+                },
+                {
+                    "id": "fls_gklst7joeo33",
+                    "informational": false,
+                    "link": "program-structure-and-compilation.html#crate-imports",
+                    "number": "18.4",
+                    "paragraphs": [
+                        {
+                            "checksum": "dbf3d3e47ad3d7220f2ffe8d071ff0607474ea6e8f4c3edd18a553ed36509d07",
+                            "id": "fls_d0pa807s5d5h",
+                            "link": "program-structure-and-compilation.html#fls_d0pa807s5d5h",
+                            "number": "18.4:1"
+                        },
+                        {
+                            "checksum": "fc37a08d96af01fa9eddc305c921ac70c13dabc6a3a41c58f09f74622cc29075",
+                            "id": "fls_vfam3wzeAiah",
+                            "link": "program-structure-and-compilation.html#fls_vfam3wzeAiah",
+                            "number": "18.4:2"
+                        },
+                        {
+                            "checksum": "c98120af9e1e4f6ac518733e42a91af54ae118579dc4ea7355c255e9b3e077e7",
+                            "id": "fls_ft860vkz0lkc",
+                            "link": "program-structure-and-compilation.html#fls_ft860vkz0lkc",
+                            "number": "18.4:3"
+                        },
+                        {
+                            "checksum": "662c29b5a73d3fc1aa97c39557c1a8401d2f480bba1ec488dba0c4bf1833fed3",
+                            "id": "fls_k90qtnf8kgu1",
+                            "link": "program-structure-and-compilation.html#fls_k90qtnf8kgu1",
+                            "number": "18.4:4"
+                        },
+                        {
+                            "checksum": "294202b2babc6658a990fded4bd4d3b7339acad054913a48ad0243ba8a907189",
+                            "id": "fls_siv8bl6s2ndu",
+                            "link": "program-structure-and-compilation.html#fls_siv8bl6s2ndu",
+                            "number": "18.4:5"
+                        },
+                        {
+                            "checksum": "0cecb1f1189c7f1a06d3c8d132b1e51f25548a0bf043f3ed3a93308b36f1506f",
+                            "id": "fls_7vz5n3x6jo1s",
+                            "link": "program-structure-and-compilation.html#fls_7vz5n3x6jo1s",
+                            "number": "18.4:6"
+                        },
+                        {
+                            "checksum": "06a0e85326100e5036cbd423c273ca615cb80431541ea5e8806f3714ffb46193",
+                            "id": "fls_3bgpc8m8yk4p",
+                            "link": "program-structure-and-compilation.html#fls_3bgpc8m8yk4p",
+                            "number": "18.4:7"
+                        }
+                    ],
+                    "title": "Crate Imports"
+                },
+                {
+                    "id": "fls_5w50kf83oo1u",
+                    "informational": false,
+                    "link": "program-structure-and-compilation.html#compilation-roots",
+                    "number": "18.5",
+                    "paragraphs": [
+                        {
+                            "checksum": "3a9ce035689a8fb35cebf8668b6c24df7ee70eff17799938db3029dea0b1edf4",
+                            "id": "fls_fhiqvgdamq5",
+                            "link": "program-structure-and-compilation.html#fls_fhiqvgdamq5",
+                            "number": "18.5:1"
+                        },
+                        {
+                            "checksum": "f870a40ce0c25e251e0e8856014efc6ad4611f1a28cdef8c9f460cfde2be372f",
+                            "id": "fls_tk8tl2e0a34",
+                            "link": "program-structure-and-compilation.html#fls_tk8tl2e0a34",
+                            "number": "18.5:2"
+                        },
+                        {
+                            "checksum": "232503cded53dd7221dcff57d6ac1d42bde0b44a3d83a1af322de4c453e185fa",
+                            "id": "fls_bsyfxdk3ap1t",
+                            "link": "program-structure-and-compilation.html#fls_bsyfxdk3ap1t",
+                            "number": "18.5:3"
+                        }
+                    ],
+                    "title": "Compilation Roots"
+                },
+                {
+                    "id": "fls_u1afezy1ye99",
+                    "informational": false,
+                    "link": "program-structure-and-compilation.html#conditional-compilation",
+                    "number": "18.6",
+                    "paragraphs": [
+                        {
+                            "checksum": "1a29f8f4ec010a8c63819db415dfd3ccd84eaad03d75e2973e3fe3313e327406",
+                            "id": "fls_9stc6nul6vq9",
+                            "link": "program-structure-and-compilation.html#fls_9stc6nul6vq9",
+                            "number": "18.6:1"
+                        },
+                        {
+                            "checksum": "b3978159779eed65918ef78768828461f8b34e7ba551de7a8c9048cac3b6edcc",
+                            "id": "fls_a0u9nnaf6drz",
+                            "link": "program-structure-and-compilation.html#fls_a0u9nnaf6drz",
+                            "number": "18.6:2"
+                        },
+                        {
+                            "checksum": "547cdabd4f386341f56db0ee6332a762b67d119af87f9944ebe2697637857ef7",
+                            "id": "fls_pf1v89h7pjhh",
+                            "link": "program-structure-and-compilation.html#fls_pf1v89h7pjhh",
+                            "number": "18.6:3"
+                        },
+                        {
+                            "checksum": "82d166eb360bad50b80bad46ce10a4d656966e94303a0fced35f59151561be1e",
+                            "id": "fls_y56RGw3cbFex",
+                            "link": "program-structure-and-compilation.html#fls_y56RGw3cbFex",
+                            "number": "18.6:4"
+                        },
+                        {
+                            "checksum": "483be06af44f42bd953cf6480fb4ba9de360289eef475b6671f2fc106a97e109",
+                            "id": "fls_h6b1fuw4nvi1",
+                            "link": "program-structure-and-compilation.html#fls_h6b1fuw4nvi1",
+                            "number": "18.6:5"
+                        }
+                    ],
+                    "title": "Conditional Compilation"
+                },
+                {
+                    "id": "fls_8jb3sjqamdpu",
+                    "informational": false,
+                    "link": "program-structure-and-compilation.html#program-entry-point",
+                    "number": "18.7",
+                    "paragraphs": [
+                        {
+                            "checksum": "2e5587a498db2567ffbf412e144bcbb85c9453ae0d1a9b9a2db81e2afa0338a5",
+                            "id": "fls_dp64b08em9BJ",
+                            "link": "program-structure-and-compilation.html#fls_dp64b08em9BJ",
+                            "number": "18.7:1"
+                        },
+                        {
+                            "checksum": "4211a854bc48f1108224e53ef3f2b18f213150fee9b6e0c6b0a8fdd3cde72ba6",
+                            "id": "fls_sbGnkm8Ephiu",
+                            "link": "program-structure-and-compilation.html#fls_sbGnkm8Ephiu",
+                            "number": "18.7:2"
+                        },
+                        {
+                            "checksum": "06806b5f2bb00b12d499429e29aa3f6916237f0c54e9136fd16474fae18c14fb",
+                            "id": "fls_o4fxok23134r",
+                            "link": "program-structure-and-compilation.html#fls_o4fxok23134r",
+                            "number": "18.7:3"
+                        },
+                        {
+                            "checksum": "c791afca579a283e2645e4a3bf9473606a55028fcaec0a1fca0c5d87bf7db370",
+                            "id": "fls_bk755pvc1l53",
+                            "link": "program-structure-and-compilation.html#fls_bk755pvc1l53",
+                            "number": "18.7:4"
+                        },
+                        {
+                            "checksum": "4eaf3f71fa346f0de97eaef7ae61b54e234608337d12733cee8930cd3a0a16be",
+                            "id": "fls_a3je4wc53bmo",
+                            "link": "program-structure-and-compilation.html#fls_a3je4wc53bmo",
+                            "number": "18.7:5"
+                        },
+                        {
+                            "checksum": "dc35e76e01d0f08b81b61a7c8861a422fa2dc8a5d44ce4557affba712d088d61",
+                            "id": "fls_w8q15zp7kyl0",
+                            "link": "program-structure-and-compilation.html#fls_w8q15zp7kyl0",
+                            "number": "18.7:6"
+                        },
+                        {
+                            "checksum": "0605829262c1b010a633c97250c2141e26eabf10f42a901e0ffae239bc84909e",
+                            "id": "fls_4psnfphsgdek",
+                            "link": "program-structure-and-compilation.html#fls_4psnfphsgdek",
+                            "number": "18.7:7"
+                        },
+                        {
+                            "checksum": "406115e1f2b804459a7155b5aa521a67fae4b9a11d3d9ee26b45671e0d705fad",
+                            "id": "fls_m7xfrhqif74",
+                            "link": "program-structure-and-compilation.html#fls_m7xfrhqif74",
+                            "number": "18.7:8"
+                        },
+                        {
+                            "checksum": "7527f425026d6c1455709270dbc862fa8c81edae9aa97bbf4c63b854ab77ea04",
+                            "id": "fls_qq9fzrw4aykd",
+                            "link": "program-structure-and-compilation.html#fls_qq9fzrw4aykd",
+                            "number": "18.7:9"
+                        }
+                    ],
+                    "title": "Program Entry Point"
+                }
+            ],
+            "title": "Program Structure and Compilation"
+        },
+        {
+            "informational": false,
             "link": "values.html",
             "sections": [
                 {
@@ -18474,1196 +16985,2132 @@
         },
         {
             "informational": false,
-            "link": "program-structure-and-compilation.html",
+            "link": "patterns.html",
             "sections": [
                 {
-                    "id": "fls_hdwwrsyunir",
+                    "id": "fls_xgqh0ju6bmbn",
                     "informational": false,
-                    "link": "program-structure-and-compilation.html",
-                    "number": "18",
-                    "paragraphs": [],
-                    "title": "Program Structure and Compilation"
-                },
-                {
-                    "id": "fls_s35hob3i7lr",
-                    "informational": false,
-                    "link": "program-structure-and-compilation.html#source-files",
-                    "number": "18.1",
+                    "link": "patterns.html",
+                    "number": "5",
                     "paragraphs": [
                         {
-                            "checksum": "55f6d3282e08235092b6157374cbc8fad302ec5965229b94dca69fbf5a239934",
-                            "id": "fls_4vicosdeaqmp",
-                            "link": "program-structure-and-compilation.html#fls_4vicosdeaqmp",
-                            "number": "18.1:1"
+                            "checksum": "fd701b3ef4e17c49416e15bb5e0685b07ec2165ebe338ee5ed86433fe2a1791c",
+                            "id": "fls_imegtsi224ts",
+                            "link": "patterns.html#fls_imegtsi224ts",
+                            "number": "5:1"
                         },
                         {
-                            "checksum": "7555cb7065456e8c9abbac7b69fc1d5e7a6e631762739806e629635a718a19ac",
-                            "id": "fls_ann3cha1xpek",
-                            "link": "program-structure-and-compilation.html#fls_ann3cha1xpek",
-                            "number": "18.1:2"
+                            "checksum": "f11f4d96ce76157d36700b1642b225614023417f88f39e02004f751fa0ceca1c",
+                            "id": "fls_mp6i4blzexnu",
+                            "link": "patterns.html#fls_mp6i4blzexnu",
+                            "number": "5:2"
+                        },
+                        {
+                            "checksum": "640a01339d6302f50e834a92db0b99f585848a4dc1dfb4801941267dfe6c1eff",
+                            "id": "fls_JJ1fJa1SsaWh",
+                            "link": "patterns.html#fls_JJ1fJa1SsaWh",
+                            "number": "5:3"
+                        },
+                        {
+                            "checksum": "28dec289d15cad76b56462aa121b43b5d1e42ef0f0d0636c38ac0eb7eca4b4f9",
+                            "id": "fls_6xx34zr069bj",
+                            "link": "patterns.html#fls_6xx34zr069bj",
+                            "number": "5:4"
+                        },
+                        {
+                            "checksum": "32457ed53a0bf4373c4cfb97677b5e208930233d39b87a5accc8c508af6f58ce",
+                            "id": "fls_8xzjb0yzftkd",
+                            "link": "patterns.html#fls_8xzjb0yzftkd",
+                            "number": "5:5"
+                        },
+                        {
+                            "checksum": "5ac967f09550667532acd0916172717779d286369a004f6e89c12e7852e25bc4",
+                            "id": "fls_cma5t8waon0x",
+                            "link": "patterns.html#fls_cma5t8waon0x",
+                            "number": "5:6"
+                        },
+                        {
+                            "checksum": "d92c5c133b1308dfee746f9722cc628be4cc1b150f3f387c0d2c08e961e687fb",
+                            "id": "fls_TUanRT7WU14E",
+                            "link": "patterns.html#fls_TUanRT7WU14E",
+                            "number": "5:7"
+                        },
+                        {
+                            "checksum": "ee361e573cbe4dbcbc9c1aec4bea99d7af68ce46d7a8f305323fea2d888a73ae",
+                            "id": "fls_8luyomzppck",
+                            "link": "patterns.html#fls_8luyomzppck",
+                            "number": "5:8"
+                        },
+                        {
+                            "checksum": "b70079f33aaa9cb4c2507706bdb13c9e8beed748288a7751770b7aa4309c17bf",
+                            "id": "fls_rpvdfmy3n05a",
+                            "link": "patterns.html#fls_rpvdfmy3n05a",
+                            "number": "5:9"
+                        },
+                        {
+                            "checksum": "66e6567b6902e8a974dcb281251e03d5341f1fbcd6c52bc6d9398d5b175905b1",
+                            "id": "fls_kv533rntni1x",
+                            "link": "patterns.html#fls_kv533rntni1x",
+                            "number": "5:10"
                         }
                     ],
-                    "title": "Source Files"
+                    "title": "Patterns"
                 },
                 {
-                    "id": "fls_e9hwvqsib5d5",
+                    "id": "fls_uh76pw6ykd57",
                     "informational": false,
-                    "link": "program-structure-and-compilation.html#modules",
-                    "number": "18.2",
+                    "link": "patterns.html#refutability",
+                    "number": "5.1",
                     "paragraphs": [
                         {
-                            "checksum": "ec4163446ba1d6053faea2c9be55ae44b49f9e489b2fb4266106708fe16bdda3",
-                            "id": "fls_odd1hj3y1mgu",
-                            "link": "program-structure-and-compilation.html#fls_odd1hj3y1mgu",
-                            "number": "18.2:1"
+                            "checksum": "74e294f01efeecaf5f7ea7508839e45750aee3872825525951cd7e1a5a369127",
+                            "id": "fls_9ntc4qmjmo90",
+                            "link": "patterns.html#fls_9ntc4qmjmo90",
+                            "number": "5.1:1"
                         },
                         {
-                            "checksum": "a552ab77145836cc109d96b376f5e785089d1f7d95d6d51c25ecfddb3708b512",
-                            "id": "fls_whgv72emrm47",
-                            "link": "program-structure-and-compilation.html#fls_whgv72emrm47",
-                            "number": "18.2:2"
+                            "checksum": "bedd24701ba15fd54193582bf452c8d028b7e7d24e62f7cf549bccc5f8d4e4b8",
+                            "id": "fls_9fjspnefoyvz",
+                            "link": "patterns.html#fls_9fjspnefoyvz",
+                            "number": "5.1:2"
                         },
                         {
-                            "checksum": "1233b4977ef4e5fd6c5969530904ff70690f361cc5fccddbf8952e1cc7d299f8",
-                            "id": "fls_qypjjpcf8uwq",
-                            "link": "program-structure-and-compilation.html#fls_qypjjpcf8uwq",
-                            "number": "18.2:3"
+                            "checksum": "30c83040e0dcb6e5472460546b82a2f1223224d1b6b315de2204a12c412741b0",
+                            "id": "fls_uq7ftuuq1sig",
+                            "link": "patterns.html#fls_uq7ftuuq1sig",
+                            "number": "5.1:3"
                         },
                         {
-                            "checksum": "f54b92d3867600666f831b9a1ca07de6acba61ac72937335bd0451a3de4cbb27",
-                            "id": "fls_cavwpr1ybk37",
-                            "link": "program-structure-and-compilation.html#fls_cavwpr1ybk37",
-                            "number": "18.2:4"
+                            "checksum": "788cc1b098646556626fa9669f0f2c05d8907e582b4bc899ecac453fcfc61dde",
+                            "id": "fls_mnbyt7jfYAZ9",
+                            "link": "patterns.html#fls_mnbyt7jfYAZ9",
+                            "number": "5.1:4"
                         },
                         {
-                            "checksum": "ddcd4deef3d419dcbf8b2c18aaa5d8bb453229bce34e4d7180d9e8f93d2bf303",
-                            "id": "fls_plepew2319g4",
-                            "link": "program-structure-and-compilation.html#fls_plepew2319g4",
-                            "number": "18.2:5"
+                            "checksum": "fb93c07735fd3880cae598758a01af1eb04fd98aa6fbdca79a2fd2e8a525c26d",
+                            "id": "fls_l76ycteulo8e",
+                            "link": "patterns.html#fls_l76ycteulo8e",
+                            "number": "5.1:5"
                         },
                         {
-                            "checksum": "fa07c91c0b0de63411270c072bdc923db3f1db860082d3eddad31ca6eed189c5",
-                            "id": "fls_1aruwps62c4p",
-                            "link": "program-structure-and-compilation.html#fls_1aruwps62c4p",
-                            "number": "18.2:6"
+                            "checksum": "8cbff3175ce2f1524fa0ece5a443ba2edd4a78433ff410a98a31ed00f38a2bde",
+                            "id": "fls_lh0d85tl4qvy",
+                            "link": "patterns.html#fls_lh0d85tl4qvy",
+                            "number": "5.1:6"
+                        },
+                        {
+                            "checksum": "abe5de2e97771298a372e5a404f34278ed54f0e8ada2a337d6f5d85fc5a7e7c0",
+                            "id": "fls_sgu9bnp7xajv",
+                            "link": "patterns.html#fls_sgu9bnp7xajv",
+                            "number": "5.1:7"
+                        },
+                        {
+                            "checksum": "d347b514f8d0662ae967270ae73f6f7be119b4ab60fdf44106ebe781e251e33d",
+                            "id": "fls_cl1g4fxfa020",
+                            "link": "patterns.html#fls_cl1g4fxfa020",
+                            "number": "5.1:8"
                         }
                     ],
-                    "title": "Modules"
+                    "title": "Refutability"
                 },
                 {
-                    "id": "fls_maw4u1o8q37u",
+                    "id": "fls_7bxv8lybxm18",
                     "informational": false,
-                    "link": "program-structure-and-compilation.html#crates",
-                    "number": "18.3",
+                    "link": "patterns.html#identifier-patterns",
+                    "number": "5.2",
                     "paragraphs": [
                         {
-                            "checksum": "c64331512493388d716b5e98082811475682dcffee41348b82483eb48cd91fc5",
-                            "id": "fls_qwghk79ok5h0",
-                            "link": "program-structure-and-compilation.html#fls_qwghk79ok5h0",
-                            "number": "18.3:1"
+                            "checksum": "12df3c9420d70b5492aee216c48d595bec10c1bfc7c95589c1aa150787788c68",
+                            "id": "fls_uljdw9rf7ies",
+                            "link": "patterns.html#fls_uljdw9rf7ies",
+                            "number": "5.2:1"
                         },
                         {
-                            "checksum": "076cdc6ed8a203ec16636f7d7a4f7bfc8fcf4ad833ca2a5eb22898fa6eeb576c",
-                            "id": "fls_unxalgMqIr3v",
-                            "link": "program-structure-and-compilation.html#fls_unxalgMqIr3v",
-                            "number": "18.3:2"
+                            "checksum": "241eeb37b7dae1635d202ba61372dfbf4a693e183ca1ece17e3818904f6c809d",
+                            "id": "fls_vy9uw586wy0d",
+                            "link": "patterns.html#fls_vy9uw586wy0d",
+                            "number": "5.2:2"
                         },
                         {
-                            "checksum": "cc519441f6acd2fc70f4251a27ea4b31fd340a96b04393a9725c4ee2ac8cb0f1",
-                            "id": "fls_e7jGvXvTsFpC",
-                            "link": "program-structure-and-compilation.html#fls_e7jGvXvTsFpC",
-                            "number": "18.3:3"
+                            "checksum": "d9b79bd4e33b5e5d59d8f9ed2df014f66c7fa0c487fc3b0b70e3700fdc7dc420",
+                            "id": "fls_hqwt3fvr063y",
+                            "link": "patterns.html#fls_hqwt3fvr063y",
+                            "number": "5.2:3"
                         },
                         {
-                            "checksum": "900926091f2fede279a11afbb6e26774c0925d89e0c2a22e8d66e4454f946b6d",
-                            "id": "fls_kQiJPwb2Hjcc",
-                            "link": "program-structure-and-compilation.html#fls_kQiJPwb2Hjcc",
-                            "number": "18.3:4"
+                            "checksum": "4f2142d8ccdb2e64efc1eaedfef6bdc5b02f5ab32bf7ed59698ff61681fd7384",
+                            "id": "fls_joIQdDn44oIT",
+                            "link": "patterns.html#fls_joIQdDn44oIT",
+                            "number": "5.2:4"
                         },
                         {
-                            "checksum": "3ac54406ea82315c87cf8183011163d2c68bb2596b63674f83fda32c046f21c9",
-                            "id": "fls_9ub6ks8qrang",
-                            "link": "program-structure-and-compilation.html#fls_9ub6ks8qrang",
-                            "number": "18.3:5"
+                            "checksum": "e7b226edcf6dc4bc129b1212d923d2b0052764e5f3087f635a8f5c48af37d436",
+                            "id": "fls_24c95c56tugl",
+                            "link": "patterns.html#fls_24c95c56tugl",
+                            "number": "5.2:5"
                         },
                         {
-                            "checksum": "8db6a4b2f241361fa8613dd0e294548a09dde19ef5946330c8eca66ccd46bf09",
-                            "id": "fls_OyFwBtDGVimT",
-                            "link": "program-structure-and-compilation.html#fls_OyFwBtDGVimT",
-                            "number": "18.3:6"
+                            "checksum": "3ee68e9c11cc6de58983cada3e69d6e25c9096bea32debb22614bb2a25d155f0",
+                            "id": "fls_twcavjk7iquy",
+                            "link": "patterns.html#fls_twcavjk7iquy",
+                            "number": "5.2:6"
                         },
                         {
-                            "checksum": "8b845c17714f7a58a93d5da09f978d3d87cfdbe7d4b7758b0f26740430c368de",
-                            "id": "fls_jQqXxPyND1ds",
-                            "link": "program-structure-and-compilation.html#fls_jQqXxPyND1ds",
-                            "number": "18.3:7"
+                            "checksum": "e762d3ac05f362349d87a2a26cc37f37eaa2148eadb4ab7a97745abed9a62df2",
+                            "id": "fls_k1yBTstX7jEE",
+                            "link": "patterns.html#fls_k1yBTstX7jEE",
+                            "number": "5.2:7"
                         },
                         {
-                            "checksum": "f15de757cf59ea80d471a93296df48599ad3b3402b7f85e22194e0e38f546b11",
-                            "id": "fls_d9nn4yuiw1ja",
-                            "link": "program-structure-and-compilation.html#fls_d9nn4yuiw1ja",
-                            "number": "18.3:8"
+                            "checksum": "a52f9ed5eaa2b34c018a779a37184c71defa111f92bc5a73d7642178df8e755f",
+                            "id": "fls_hw26hy33guk5",
+                            "link": "patterns.html#fls_hw26hy33guk5",
+                            "number": "5.2:8"
                         },
                         {
-                            "checksum": "bc735aaea18f5347b09a4b7ac21ae36e48f125b2cfa1ecbdb0566b0070303199",
-                            "id": "fls_Mf62VqAhoZ3c",
-                            "link": "program-structure-and-compilation.html#fls_Mf62VqAhoZ3c",
-                            "number": "18.3:9"
+                            "checksum": "b439ed8b20762b4889891571152f54745dc81b2f6b4abc45db0448e2cac4888d",
+                            "id": "fls_svfxwz4yy5i",
+                            "link": "patterns.html#fls_svfxwz4yy5i",
+                            "number": "5.2:9"
                         },
                         {
-                            "checksum": "ca2db7453a265830bd34e2a087ce0a6e08f97f20221a3ef1ab151f72892c5e8f",
-                            "id": "fls_RJJmN4tP7j4m",
-                            "link": "program-structure-and-compilation.html#fls_RJJmN4tP7j4m",
-                            "number": "18.3:10"
+                            "checksum": "db308f657bf02a10ddea3390b29681c6eccf4bb81b2069d5f1b2ecfbc7853dc1",
+                            "id": "fls_x6f6q22b5jpc",
+                            "link": "patterns.html#fls_x6f6q22b5jpc",
+                            "number": "5.2:10"
                         },
                         {
-                            "checksum": "7285d85fe56e6377849b918e1d006071c4bb14a18476290ddc8cce3adcc11a30",
-                            "id": "fls_h93C3wfbAoz1",
-                            "link": "program-structure-and-compilation.html#fls_h93C3wfbAoz1",
-                            "number": "18.3:11"
+                            "checksum": "dd8b86458df1b70addc97086f4ada7c7692ff5103622010059fbf0283f8ffbb3",
+                            "id": "fls_r2mb8v2lh3x0",
+                            "link": "patterns.html#fls_r2mb8v2lh3x0",
+                            "number": "5.2:11"
+                        },
+                        {
+                            "checksum": "0905da49ff8fceb1c24a37a019ba80b02f466cbede9db934f3506067251411de",
+                            "id": "fls_7oioaitb075g",
+                            "link": "patterns.html#fls_7oioaitb075g",
+                            "number": "5.2:12"
+                        },
+                        {
+                            "checksum": "11934cfbec627d51e8441eeef28fa1983d4ed59d73d9dcbff26e5d4cf4007fed",
+                            "id": "fls_40qin0ss5sqd",
+                            "link": "patterns.html#fls_40qin0ss5sqd",
+                            "number": "5.2:13"
+                        },
+                        {
+                            "checksum": "05ce4678c850feb8fbdc7b0bf9a65ccdd82414dec3163903b5ff487cf3cc1b8c",
+                            "id": "fls_pivz0v7ey6sw",
+                            "link": "patterns.html#fls_pivz0v7ey6sw",
+                            "number": "5.2:14"
+                        },
+                        {
+                            "checksum": "6827708c08fa8d7048aaf70d448f1ed456a018a5621ccbad9e38ba38eb4f001f",
+                            "id": "fls_2ahkrddxwj1n",
+                            "link": "patterns.html#fls_2ahkrddxwj1n",
+                            "number": "5.2:15"
+                        },
+                        {
+                            "checksum": "5938b3e5c53f5eb860f3c7aae1864e4e5b74c0a93b9460455798ee597639f3bd",
+                            "id": "fls_eucnafj3uedy",
+                            "link": "patterns.html#fls_eucnafj3uedy",
+                            "number": "5.2:16"
+                        },
+                        {
+                            "checksum": "25e0df417675d625d1a57e95afba6af3de12fa61abe805e4d2d81e90613250d0",
+                            "id": "fls_f8zo4scodhcr",
+                            "link": "patterns.html#fls_f8zo4scodhcr",
+                            "number": "5.2:17"
+                        },
+                        {
+                            "checksum": "7d886e7fba9c09e14a0789ddb951c710bb88a50cf8e06a6bcdd6629fb55562f6",
+                            "id": "fls_d3fs2h7oqjl0",
+                            "link": "patterns.html#fls_d3fs2h7oqjl0",
+                            "number": "5.2:18"
+                        },
+                        {
+                            "checksum": "655158cf590f06600319e8e2695db1b56219fadc4cc034888e17c53b07a84274",
+                            "id": "fls_exo8asevh5x1",
+                            "link": "patterns.html#fls_exo8asevh5x1",
+                            "number": "5.2:19"
+                        },
+                        {
+                            "checksum": "d3b46f205bcb595fe85d75191fcd80dd7933343080fd05b57200c0118ad6b609",
+                            "id": "fls_sfyfdxhvhk44",
+                            "link": "patterns.html#fls_sfyfdxhvhk44",
+                            "number": "5.2:20"
+                        },
+                        {
+                            "checksum": "b32516046ade3590c7036c2a5ecbf17d55a9f6f00da394c3d5281096f8cf26dc",
+                            "id": "fls_as0pqqmo1des",
+                            "link": "patterns.html#fls_as0pqqmo1des",
+                            "number": "5.2:21"
                         }
                     ],
-                    "title": "Crates"
+                    "title": "Identifier Patterns"
                 },
                 {
-                    "id": "fls_gklst7joeo33",
+                    "id": "fls_2krxnq8q9ef1",
                     "informational": false,
-                    "link": "program-structure-and-compilation.html#crate-imports",
-                    "number": "18.4",
+                    "link": "patterns.html#literal-patterns",
+                    "number": "5.3",
                     "paragraphs": [
                         {
-                            "checksum": "dbf3d3e47ad3d7220f2ffe8d071ff0607474ea6e8f4c3edd18a553ed36509d07",
-                            "id": "fls_d0pa807s5d5h",
-                            "link": "program-structure-and-compilation.html#fls_d0pa807s5d5h",
-                            "number": "18.4:1"
+                            "checksum": "7afee4377bf01eee53e398835c943ac86067eba24c1cf64551d7f801915e5ece",
+                            "id": "fls_pah15qa54irs",
+                            "link": "patterns.html#fls_pah15qa54irs",
+                            "number": "5.3:1"
                         },
                         {
-                            "checksum": "fc37a08d96af01fa9eddc305c921ac70c13dabc6a3a41c58f09f74622cc29075",
-                            "id": "fls_vfam3wzeAiah",
-                            "link": "program-structure-and-compilation.html#fls_vfam3wzeAiah",
-                            "number": "18.4:2"
+                            "checksum": "c8e3035b1a25edf2fccd9214fd3039e797d799bd22e801fdeda70976a39c68a2",
+                            "id": "fls_COQKJC0dvtNO",
+                            "link": "patterns.html#fls_COQKJC0dvtNO",
+                            "number": "5.3:2"
                         },
                         {
-                            "checksum": "c98120af9e1e4f6ac518733e42a91af54ae118579dc4ea7355c255e9b3e077e7",
-                            "id": "fls_ft860vkz0lkc",
-                            "link": "program-structure-and-compilation.html#fls_ft860vkz0lkc",
-                            "number": "18.4:3"
+                            "checksum": "279b07c6a35f3bcfed9d5bcccc78afdc28e8982a5be9e9b768dd95c2a3b0ae9c",
+                            "id": "fls_JP8YSbxSN0Ym",
+                            "link": "patterns.html#fls_JP8YSbxSN0Ym",
+                            "number": "5.3:3"
                         },
                         {
-                            "checksum": "662c29b5a73d3fc1aa97c39557c1a8401d2f480bba1ec488dba0c4bf1833fed3",
-                            "id": "fls_k90qtnf8kgu1",
-                            "link": "program-structure-and-compilation.html#fls_k90qtnf8kgu1",
-                            "number": "18.4:4"
+                            "checksum": "b5e4dea23898449138503e31ca3616865806df2f2af08e0460bf75c15cfda0d0",
+                            "id": "fls_co60bzvwashg",
+                            "link": "patterns.html#fls_co60bzvwashg",
+                            "number": "5.3:4"
                         },
                         {
-                            "checksum": "294202b2babc6658a990fded4bd4d3b7339acad054913a48ad0243ba8a907189",
-                            "id": "fls_siv8bl6s2ndu",
-                            "link": "program-structure-and-compilation.html#fls_siv8bl6s2ndu",
-                            "number": "18.4:5"
-                        },
-                        {
-                            "checksum": "0cecb1f1189c7f1a06d3c8d132b1e51f25548a0bf043f3ed3a93308b36f1506f",
-                            "id": "fls_7vz5n3x6jo1s",
-                            "link": "program-structure-and-compilation.html#fls_7vz5n3x6jo1s",
-                            "number": "18.4:6"
-                        },
-                        {
-                            "checksum": "06a0e85326100e5036cbd423c273ca615cb80431541ea5e8806f3714ffb46193",
-                            "id": "fls_3bgpc8m8yk4p",
-                            "link": "program-structure-and-compilation.html#fls_3bgpc8m8yk4p",
-                            "number": "18.4:7"
+                            "checksum": "617fb1beb5774f8f6685a4671e5bf2d72fd056bbe348e8236f22254e8462a51a",
+                            "id": "fls_fqclaznjgtb1",
+                            "link": "patterns.html#fls_fqclaznjgtb1",
+                            "number": "5.3:5"
                         }
                     ],
-                    "title": "Crate Imports"
+                    "title": "Literal Patterns"
                 },
                 {
-                    "id": "fls_5w50kf83oo1u",
+                    "id": "fls_1xit18et4ohh",
                     "informational": false,
-                    "link": "program-structure-and-compilation.html#compilation-roots",
-                    "number": "18.5",
+                    "link": "patterns.html#parenthesized-patterns",
+                    "number": "5.4",
                     "paragraphs": [
                         {
-                            "checksum": "3a9ce035689a8fb35cebf8668b6c24df7ee70eff17799938db3029dea0b1edf4",
-                            "id": "fls_fhiqvgdamq5",
-                            "link": "program-structure-and-compilation.html#fls_fhiqvgdamq5",
-                            "number": "18.5:1"
+                            "checksum": "24403c83d4acc034aaa73d968a14afbfe7d9f1bfdbee90b17ef960075453aaac",
+                            "id": "fls_kvqzmt7my5dh",
+                            "link": "patterns.html#fls_kvqzmt7my5dh",
+                            "number": "5.4:1"
                         },
                         {
-                            "checksum": "f870a40ce0c25e251e0e8856014efc6ad4611f1a28cdef8c9f460cfde2be372f",
-                            "id": "fls_tk8tl2e0a34",
-                            "link": "program-structure-and-compilation.html#fls_tk8tl2e0a34",
-                            "number": "18.5:2"
+                            "checksum": "5f42a52d41b664edb742dfd664f01990bf8432d041e601e283d750cb83a85f90",
+                            "id": "fls_mrjhpiq5refe",
+                            "link": "patterns.html#fls_mrjhpiq5refe",
+                            "number": "5.4:2"
                         },
                         {
-                            "checksum": "232503cded53dd7221dcff57d6ac1d42bde0b44a3d83a1af322de4c453e185fa",
-                            "id": "fls_bsyfxdk3ap1t",
-                            "link": "program-structure-and-compilation.html#fls_bsyfxdk3ap1t",
-                            "number": "18.5:3"
+                            "checksum": "41b7c39a45d4144509bc833e84ea455b7d86c0a67c5d58960e14e6337b2c44d4",
+                            "id": "fls_pe5kh8y8u664",
+                            "link": "patterns.html#fls_pe5kh8y8u664",
+                            "number": "5.4:3"
+                        },
+                        {
+                            "checksum": "edcbe640bd79fa7513605658a4cc16f8d648069f3cca0dd200ee8a2224d1612e",
+                            "id": "fls_2xq8852gihn9",
+                            "link": "patterns.html#fls_2xq8852gihn9",
+                            "number": "5.4:4"
+                        },
+                        {
+                            "checksum": "6b2bf289b930cfce356ecbd497063fe3f045ee08dc3919d303a7a90c52eae0fb",
+                            "id": "fls_2dmeukyjqz9y",
+                            "link": "patterns.html#fls_2dmeukyjqz9y",
+                            "number": "5.4:5"
                         }
                     ],
-                    "title": "Compilation Roots"
+                    "title": "Parenthesized Patterns"
                 },
                 {
-                    "id": "fls_u1afezy1ye99",
+                    "id": "fls_uloyjbaso8pz",
                     "informational": false,
-                    "link": "program-structure-and-compilation.html#conditional-compilation",
-                    "number": "18.6",
+                    "link": "patterns.html#path-patterns",
+                    "number": "5.5",
                     "paragraphs": [
                         {
-                            "checksum": "1a29f8f4ec010a8c63819db415dfd3ccd84eaad03d75e2973e3fe3313e327406",
-                            "id": "fls_9stc6nul6vq9",
-                            "link": "program-structure-and-compilation.html#fls_9stc6nul6vq9",
-                            "number": "18.6:1"
+                            "checksum": "6eab6a03669622290fe084028190344d03230efeca455f6bd9e2891ac8781c05",
+                            "id": "fls_1crq0mexo5r1",
+                            "link": "patterns.html#fls_1crq0mexo5r1",
+                            "number": "5.5:1"
                         },
                         {
-                            "checksum": "b3978159779eed65918ef78768828461f8b34e7ba551de7a8c9048cac3b6edcc",
-                            "id": "fls_a0u9nnaf6drz",
-                            "link": "program-structure-and-compilation.html#fls_a0u9nnaf6drz",
-                            "number": "18.6:2"
+                            "checksum": "6b5457b32a2fa8723c542bd4b63d6de477dfc4e8406457a6b0ec05a421fbb295",
+                            "id": "fls_xz5otkhogn31",
+                            "link": "patterns.html#fls_xz5otkhogn31",
+                            "number": "5.5:2"
                         },
                         {
-                            "checksum": "547cdabd4f386341f56db0ee6332a762b67d119af87f9944ebe2697637857ef7",
-                            "id": "fls_pf1v89h7pjhh",
-                            "link": "program-structure-and-compilation.html#fls_pf1v89h7pjhh",
-                            "number": "18.6:3"
+                            "checksum": "853158ce8e75116be9bf2d63bc0d49626010b9d0fa0c5ebe80a595ef4da37aa3",
+                            "id": "fls_t8sjzsif2ilf",
+                            "link": "patterns.html#fls_t8sjzsif2ilf",
+                            "number": "5.5:3"
                         },
                         {
-                            "checksum": "82d166eb360bad50b80bad46ce10a4d656966e94303a0fced35f59151561be1e",
-                            "id": "fls_y56RGw3cbFex",
-                            "link": "program-structure-and-compilation.html#fls_y56RGw3cbFex",
-                            "number": "18.6:4"
+                            "checksum": "32107632e6d0b56902397df91b587c925c1cf6ce0a1f364dd9a3708ce1e015f6",
+                            "id": "fls_zCswsyuitexI",
+                            "link": "patterns.html#fls_zCswsyuitexI",
+                            "number": "5.5:4"
                         },
                         {
-                            "checksum": "483be06af44f42bd953cf6480fb4ba9de360289eef475b6671f2fc106a97e109",
-                            "id": "fls_h6b1fuw4nvi1",
-                            "link": "program-structure-and-compilation.html#fls_h6b1fuw4nvi1",
-                            "number": "18.6:5"
+                            "checksum": "a7a4f59c59d6e146496c10f6e1dd0db5adf148faf1242b54a905805871e1fefb",
+                            "id": "fls_wJ9f906BlBvg",
+                            "link": "patterns.html#fls_wJ9f906BlBvg",
+                            "number": "5.5:5"
+                        },
+                        {
+                            "checksum": "c1c27a19deb008cded1ee11e11c906c699c4a1a086d847190fd58dcc97f4785c",
+                            "id": "fls_hF19K8sWU8FF",
+                            "link": "patterns.html#fls_hF19K8sWU8FF",
+                            "number": "5.5:6"
+                        },
+                        {
+                            "checksum": "e3791cb88451803cd0eccbbf5f370fc3c972abe87f321825dc692aacb617742b",
+                            "id": "fls_bv9psmitxfuw",
+                            "link": "patterns.html#fls_bv9psmitxfuw",
+                            "number": "5.5:7"
+                        },
+                        {
+                            "checksum": "7f7d5841b9bc8e1f3eca2f3f52fb1c78bb016e93d8212e3225a673fd4bc4b053",
+                            "id": "fls_sl47k9oj5p7t",
+                            "link": "patterns.html#fls_sl47k9oj5p7t",
+                            "number": "5.5:8"
+                        },
+                        {
+                            "checksum": "e7dd58da27f566ab9464de185e98749b36b5c3340a8c22fed6be8e199d11dd91",
+                            "id": "fls_cfoy86mkmqa4",
+                            "link": "patterns.html#fls_cfoy86mkmqa4",
+                            "number": "5.5:9"
+                        },
+                        {
+                            "checksum": "2a1df52ca100bd83979fa4b150b96d836a748c8114e32462390076966acbb005",
+                            "id": "fls_rnppz6y5z8pi",
+                            "link": "patterns.html#fls_rnppz6y5z8pi",
+                            "number": "5.5:10"
+                        },
+                        {
+                            "checksum": "686e4dfe42f5f913ee2465c883ade027d7e59e9e065e490993681639adbc6114",
+                            "id": "fls_ag6m4mvpturw",
+                            "link": "patterns.html#fls_ag6m4mvpturw",
+                            "number": "5.5:11"
+                        },
+                        {
+                            "checksum": "0156b2335414d9b4db2b75d75ed55fbca446bd1b5b81604e0171ea7872fd44a2",
+                            "id": "fls_pedy2pqrvnx7",
+                            "link": "patterns.html#fls_pedy2pqrvnx7",
+                            "number": "5.5:12"
+                        },
+                        {
+                            "checksum": "546530c46d84a01d6017493ea2f9e61645c557cd4ca99d9d518a6145f9ec0367",
+                            "id": "fls_u59rilepu8z9",
+                            "link": "patterns.html#fls_u59rilepu8z9",
+                            "number": "5.5:13"
                         }
                     ],
-                    "title": "Conditional Compilation"
+                    "title": "Path Patterns"
                 },
                 {
-                    "id": "fls_8jb3sjqamdpu",
+                    "id": "fls_6tl1fx99yn6c",
                     "informational": false,
-                    "link": "program-structure-and-compilation.html#program-entry-point",
-                    "number": "18.7",
+                    "link": "patterns.html#range-patterns",
+                    "number": "5.6",
                     "paragraphs": [
                         {
-                            "checksum": "2e5587a498db2567ffbf412e144bcbb85c9453ae0d1a9b9a2db81e2afa0338a5",
-                            "id": "fls_dp64b08em9BJ",
-                            "link": "program-structure-and-compilation.html#fls_dp64b08em9BJ",
-                            "number": "18.7:1"
+                            "checksum": "959fe2ad28f3934a1ce306646ec29b82f95de36f84a5c69840957aeac1b88eb9",
+                            "id": "fls_okupyoav13rm",
+                            "link": "patterns.html#fls_okupyoav13rm",
+                            "number": "5.6:1"
                         },
                         {
-                            "checksum": "4211a854bc48f1108224e53ef3f2b18f213150fee9b6e0c6b0a8fdd3cde72ba6",
-                            "id": "fls_sbGnkm8Ephiu",
-                            "link": "program-structure-and-compilation.html#fls_sbGnkm8Ephiu",
-                            "number": "18.7:2"
+                            "checksum": "0b382770b9780b9239f762eb87f95835b03588805b1a4b3def28336d666ff7a1",
+                            "id": "fls_jhchm7dy927k",
+                            "link": "patterns.html#fls_jhchm7dy927k",
+                            "number": "5.6:2"
                         },
                         {
-                            "checksum": "06806b5f2bb00b12d499429e29aa3f6916237f0c54e9136fd16474fae18c14fb",
-                            "id": "fls_o4fxok23134r",
-                            "link": "program-structure-and-compilation.html#fls_o4fxok23134r",
-                            "number": "18.7:3"
+                            "checksum": "1cfc9d659ff30640a5179ad40746d5c08c3c187b5271f28b88305b4de6ba138a",
+                            "id": "fls_q86j23iiqv8w",
+                            "link": "patterns.html#fls_q86j23iiqv8w",
+                            "number": "5.6:3"
                         },
                         {
-                            "checksum": "c791afca579a283e2645e4a3bf9473606a55028fcaec0a1fca0c5d87bf7db370",
-                            "id": "fls_bk755pvc1l53",
-                            "link": "program-structure-and-compilation.html#fls_bk755pvc1l53",
-                            "number": "18.7:4"
+                            "checksum": "b49f2f20e78bc39e912613682452652bf00d8a9b7ad85fcbbeef325cc638e298",
+                            "id": "fls_3PyquOKjA7SI",
+                            "link": "patterns.html#fls_3PyquOKjA7SI",
+                            "number": "5.6:4"
                         },
                         {
-                            "checksum": "4eaf3f71fa346f0de97eaef7ae61b54e234608337d12733cee8930cd3a0a16be",
-                            "id": "fls_a3je4wc53bmo",
-                            "link": "program-structure-and-compilation.html#fls_a3je4wc53bmo",
-                            "number": "18.7:5"
+                            "checksum": "2730f4be7e58310acdcc2e8df0d5792b76b2437850f3bea63f0e94ad25e46eee",
+                            "id": "fls_akf9x5r6e0ta",
+                            "link": "patterns.html#fls_akf9x5r6e0ta",
+                            "number": "5.6:5"
                         },
                         {
-                            "checksum": "dc35e76e01d0f08b81b61a7c8861a422fa2dc8a5d44ce4557affba712d088d61",
-                            "id": "fls_w8q15zp7kyl0",
-                            "link": "program-structure-and-compilation.html#fls_w8q15zp7kyl0",
-                            "number": "18.7:6"
+                            "checksum": "0ba8c1ec907ade4c15c689e735f0a5a8b187b5496f656c893968eca7e5468b54",
+                            "id": "fls_vrpr6ttpfpal",
+                            "link": "patterns.html#fls_vrpr6ttpfpal",
+                            "number": "5.6:6"
                         },
                         {
-                            "checksum": "0605829262c1b010a633c97250c2141e26eabf10f42a901e0ffae239bc84909e",
-                            "id": "fls_4psnfphsgdek",
-                            "link": "program-structure-and-compilation.html#fls_4psnfphsgdek",
-                            "number": "18.7:7"
+                            "checksum": "656232ce77042076d43593f3f21939aac2c7066d0c750836345ff9ec0a42124b",
+                            "id": "fls_nk48gregn3me",
+                            "link": "patterns.html#fls_nk48gregn3me",
+                            "number": "5.6:7"
                         },
                         {
-                            "checksum": "406115e1f2b804459a7155b5aa521a67fae4b9a11d3d9ee26b45671e0d705fad",
-                            "id": "fls_m7xfrhqif74",
-                            "link": "program-structure-and-compilation.html#fls_m7xfrhqif74",
-                            "number": "18.7:8"
+                            "checksum": "6316acea87cf2eeeb7b2e0acb3d99f9f56716dc64ba70e167716659033b9bde4",
+                            "id": "fls_83v1xqbebs58",
+                            "link": "patterns.html#fls_83v1xqbebs58",
+                            "number": "5.6:8"
                         },
                         {
-                            "checksum": "7527f425026d6c1455709270dbc862fa8c81edae9aa97bbf4c63b854ab77ea04",
-                            "id": "fls_qq9fzrw4aykd",
-                            "link": "program-structure-and-compilation.html#fls_qq9fzrw4aykd",
-                            "number": "18.7:9"
+                            "checksum": "785db35c5291babacd0f8648588325297f8f45c2eebe7fb665e52b8ac76eca68",
+                            "id": "fls_2hpuccwh2xml",
+                            "link": "patterns.html#fls_2hpuccwh2xml",
+                            "number": "5.6:9"
+                        },
+                        {
+                            "checksum": "0c9d1f2587c2e5d8ed9ee166a68762909b9b7936245dc9d2341c1f7df6670e6e",
+                            "id": "fls_9kk81isk0mlp",
+                            "link": "patterns.html#fls_9kk81isk0mlp",
+                            "number": "5.6:10"
+                        },
+                        {
+                            "checksum": "7254a7b52add01e9d7d977900c9322544a9970def2f7c73fdb9a63b417574f5c",
+                            "id": "fls_8bdOqkO1NuJW",
+                            "link": "patterns.html#fls_8bdOqkO1NuJW",
+                            "number": "5.6:11"
+                        },
+                        {
+                            "checksum": "88a5cfae2ddc1c38d1df4a2dc1b86e99bcced79bc5b40afef543633e7c48bce9",
+                            "id": "fls_s2b5n4snc4d7",
+                            "link": "patterns.html#fls_s2b5n4snc4d7",
+                            "number": "5.6:12"
+                        },
+                        {
+                            "checksum": "b55a395def7ce875a26f0fe8a3f186342864481fa72edba9c13c5d5f3f93c9e6",
+                            "id": "fls_4o4ge6x9a8rs",
+                            "link": "patterns.html#fls_4o4ge6x9a8rs",
+                            "number": "5.6:13"
+                        },
+                        {
+                            "checksum": "fe437f18136d4053707f9c2e3b8a79e527d78c77863abc6bfd04f4a73204d3b5",
+                            "id": "fls_6o995ak4hywq",
+                            "link": "patterns.html#fls_6o995ak4hywq",
+                            "number": "5.6:14"
+                        },
+                        {
+                            "checksum": "5d22fc340f1c7e324df48a970cf5ae8a4811f8a5ad3880704eda257dd3d2add8",
+                            "id": "fls_3js1645tgh31",
+                            "link": "patterns.html#fls_3js1645tgh31",
+                            "number": "5.6:15"
+                        },
+                        {
+                            "checksum": "d004b00ad56daa028bd112c7ad04042c90cfb4ab5ad4df095a5a9d01f32c4bba",
+                            "id": "fls_8Q6NfRx4j5V7",
+                            "link": "patterns.html#fls_8Q6NfRx4j5V7",
+                            "number": "5.6:16"
+                        },
+                        {
+                            "checksum": "4993d699bb304cc5b32245e03cfd7425d322876b5dc54fef12048c5874c667c0",
+                            "id": "fls_rgr7t33s0m7m",
+                            "link": "patterns.html#fls_rgr7t33s0m7m",
+                            "number": "5.6:17"
+                        },
+                        {
+                            "checksum": "0315d5b53fda43c91943de2a08eda96b79f469004237b8d0f02f52f4c1f35567",
+                            "id": "fls_5ey5mj8t8knd",
+                            "link": "patterns.html#fls_5ey5mj8t8knd",
+                            "number": "5.6:18"
+                        },
+                        {
+                            "checksum": "9f6d9020a6778f7a34629150159b8a67764f0aea6638d4f0d47a20fc22fbe70e",
+                            "id": "fls_z4js96mchcsv",
+                            "link": "patterns.html#fls_z4js96mchcsv",
+                            "number": "5.6:19"
+                        },
+                        {
+                            "checksum": "5dc529cd76b4f3bba978dfd0fcaf3a618fcaf8f381f22c9f5d63d39585ed34fa",
+                            "id": "fls_3wwpq8i6mo2a",
+                            "link": "patterns.html#fls_3wwpq8i6mo2a",
+                            "number": "5.6:20"
                         }
                     ],
-                    "title": "Program Entry Point"
+                    "title": "Range Patterns"
+                },
+                {
+                    "id": "fls_d2sc9hl3v0mk",
+                    "informational": false,
+                    "link": "patterns.html#reference-patterns",
+                    "number": "5.7",
+                    "paragraphs": [
+                        {
+                            "checksum": "0ac86e5a12c490f5eb80008b0e18cc9da39af2074dfbdc99545777192814afa3",
+                            "id": "fls_fhahcc1mz2qh",
+                            "link": "patterns.html#fls_fhahcc1mz2qh",
+                            "number": "5.7:1"
+                        },
+                        {
+                            "checksum": "028c5b3284521a34ff97d008866bec2c4654a464089a7da864aad3e4a4f04686",
+                            "id": "fls_x0bmzl1315gq",
+                            "link": "patterns.html#fls_x0bmzl1315gq",
+                            "number": "5.7:2"
+                        },
+                        {
+                            "checksum": "cdf387e98a664c3724ff90541e30f67670be603da49923fcb4e3a4ee54ba432e",
+                            "id": "fls_fedo8zhgpla5",
+                            "link": "patterns.html#fls_fedo8zhgpla5",
+                            "number": "5.7:3"
+                        },
+                        {
+                            "checksum": "b78639be70162116c61abcb66a81cfa0e2adb505b2a71ffb60f9639cf7a038d5",
+                            "id": "fls_30u9ij164ww3",
+                            "link": "patterns.html#fls_30u9ij164ww3",
+                            "number": "5.7:4"
+                        },
+                        {
+                            "checksum": "cc0ee91216508f36e23696e7ee09cd4fa77b065e4c323a2cf3610c891336fe3f",
+                            "id": "fls_d1kc73hpncpo",
+                            "link": "patterns.html#fls_d1kc73hpncpo",
+                            "number": "5.7:5"
+                        },
+                        {
+                            "checksum": "f829652e4b19ceb3e612e92c40aa060fe77b46424b5fc3858eccbcfcea45016c",
+                            "id": "fls_mpeuhov0umfa",
+                            "link": "patterns.html#fls_mpeuhov0umfa",
+                            "number": "5.7:6"
+                        }
+                    ],
+                    "title": "Reference Patterns"
+                },
+                {
+                    "id": "fls_7wpgnp4kjq82",
+                    "informational": false,
+                    "link": "patterns.html#rest-patterns",
+                    "number": "5.8",
+                    "paragraphs": [
+                        {
+                            "checksum": "071b1b905e799a04118d9b0fe22e82b9944ef00a527e80a327c0c4f6511fd52b",
+                            "id": "fls_eso51epfofxb",
+                            "link": "patterns.html#fls_eso51epfofxb",
+                            "number": "5.8:1"
+                        },
+                        {
+                            "checksum": "d787720d08f2fd60c09276b2b5be62b0bd3a0ad5aef799a71bacba9691897fda",
+                            "id": "fls_5a75a2y43uev",
+                            "link": "patterns.html#fls_5a75a2y43uev",
+                            "number": "5.8:2"
+                        },
+                        {
+                            "checksum": "3bf650bd8078af8405ff969b3616899e1bc80ef2ef591d2b291cf99f03008f32",
+                            "id": "fls_rsqyza99vl3x",
+                            "link": "patterns.html#fls_rsqyza99vl3x",
+                            "number": "5.8:3"
+                        },
+                        {
+                            "checksum": "11486a40e40c1eaa6529d06f4f52771cd804d9d0cea29d215e5e9e6748877b01",
+                            "id": "fls_w1pw40phsv2o",
+                            "link": "patterns.html#fls_w1pw40phsv2o",
+                            "number": "5.8:4"
+                        },
+                        {
+                            "checksum": "318a513cb1fdf4e37047eccc4975636818c7cd86126e00b5b3e132411c629003",
+                            "id": "fls_x8ylgxrf9ca",
+                            "link": "patterns.html#fls_x8ylgxrf9ca",
+                            "number": "5.8:5"
+                        },
+                        {
+                            "checksum": "de50b523931b5b23b262977da389190179884668be06d4b514d2908f9ad2aeab",
+                            "id": "fls_zgoke73xrhk3",
+                            "link": "patterns.html#fls_zgoke73xrhk3",
+                            "number": "5.8:6"
+                        },
+                        {
+                            "checksum": "3e6c88357b38cf981ef309c03b2df1cb25d9f796365ca21fbbd67f2d4571cd42",
+                            "id": "fls_bdcv6rwx0fsv",
+                            "link": "patterns.html#fls_bdcv6rwx0fsv",
+                            "number": "5.8:7"
+                        },
+                        {
+                            "checksum": "c6203fbb28f63565945031f16bc7f7096f16bee4c02f2c16161cb0c3cf80c7a5",
+                            "id": "fls_qz9guhlg19j3",
+                            "link": "patterns.html#fls_qz9guhlg19j3",
+                            "number": "5.8:8"
+                        }
+                    ],
+                    "title": "Rest Patterns"
+                },
+                {
+                    "id": "fls_qte70mgzpras",
+                    "informational": false,
+                    "link": "patterns.html#slice-patterns",
+                    "number": "5.9",
+                    "paragraphs": [
+                        {
+                            "checksum": "f9dbdad2eec41e1e1c60cd8c0cacf14973b904c94631089f41ca0e1bbda98a17",
+                            "id": "fls_qqiu594hki8g",
+                            "link": "patterns.html#fls_qqiu594hki8g",
+                            "number": "5.9:1"
+                        },
+                        {
+                            "checksum": "948b35cfd7619032dc69a5d84fa17b28a615e792a6f0e0d49e140816b136e7e9",
+                            "id": "fls_h6x9xlxi7y5n",
+                            "link": "patterns.html#fls_h6x9xlxi7y5n",
+                            "number": "5.9:2"
+                        },
+                        {
+                            "checksum": "b21f2e9bea39902d97b0a75bd48f584b5bcb685635cecfeab096b27a096de184",
+                            "id": "fls_jbmxu7y5fnm6",
+                            "link": "patterns.html#fls_jbmxu7y5fnm6",
+                            "number": "5.9:3"
+                        },
+                        {
+                            "checksum": "9ea93d82c4cebaa6550a0787f2925118cf5370ed8a0c02104b3a623c197ae9c1",
+                            "id": "fls_r78zzw7yyg34",
+                            "link": "patterns.html#fls_r78zzw7yyg34",
+                            "number": "5.9:4"
+                        },
+                        {
+                            "checksum": "93891609dbf9042a20ed470adda1893453d146707a716c6a05793ff9c64e10f0",
+                            "id": "fls_ndor56nou676",
+                            "link": "patterns.html#fls_ndor56nou676",
+                            "number": "5.9:5"
+                        },
+                        {
+                            "checksum": "b7fb9cf107baa52a1c3140dbb24ee079813601a2c74f83321a61e14127737833",
+                            "id": "fls_9yuobz1jsehf",
+                            "link": "patterns.html#fls_9yuobz1jsehf",
+                            "number": "5.9:6"
+                        }
+                    ],
+                    "title": "Slice Patterns"
+                },
+                {
+                    "id": "fls_7dbd5t2750ce",
+                    "informational": false,
+                    "link": "patterns.html#struct-patterns",
+                    "number": "5.10",
+                    "paragraphs": [
+                        {
+                            "checksum": "d667b4f41510c041296f0f8c9950b33a0e697269e268024bd87aac1d04c4b450",
+                            "id": "fls_vjdkpr3zml51",
+                            "link": "patterns.html#fls_vjdkpr3zml51",
+                            "number": "5.10:1"
+                        },
+                        {
+                            "checksum": "1226159f94faa8a70839d078914f48a7ec073bb47550a83a77554fab5106550c",
+                            "id": "fls_6o3x101wo478",
+                            "link": "patterns.html#fls_6o3x101wo478",
+                            "number": "5.10:2"
+                        },
+                        {
+                            "checksum": "4951a056adbfabc5da1900d164468c7f4be7716b2094657ab9e28e53f3b985a9",
+                            "id": "fls_k9zih9s0oe5h",
+                            "link": "patterns.html#fls_k9zih9s0oe5h",
+                            "number": "5.10:3"
+                        },
+                        {
+                            "checksum": "b68597321297c9f745d6b9be53beda335702f6e28a1bb97a08c277dac931130d",
+                            "id": "fls_r8rat3qmc4hy",
+                            "link": "patterns.html#fls_r8rat3qmc4hy",
+                            "number": "5.10:4"
+                        },
+                        {
+                            "checksum": "c8b65f1ad8bbb7a147b1cfa9636cd2ebe6b61c1727898f08637df63d004a8391",
+                            "id": "fls_hUX723DmLg2a",
+                            "link": "patterns.html#fls_hUX723DmLg2a",
+                            "number": "5.10:5"
+                        },
+                        {
+                            "checksum": "83183cd23b19214bc0cd0c9da72221ac67d6ec71f26a49c5445307f86a2d7d8c",
+                            "id": "fls_p4OplpUvS04l",
+                            "link": "patterns.html#fls_p4OplpUvS04l",
+                            "number": "5.10:6"
+                        },
+                        {
+                            "checksum": "0bdc00a13a57ef1c0b6611c62de6e170f3d281e81b68d9cf86a7b8f227180905",
+                            "id": "fls_pre3YwAv01FE",
+                            "link": "patterns.html#fls_pre3YwAv01FE",
+                            "number": "5.10:7"
+                        },
+                        {
+                            "checksum": "81f1732cfd416b1abb73fa22440e8d2cd8f4406e031d6f14d72610567aac5bca",
+                            "id": "fls_MK83WE0iDqNf",
+                            "link": "patterns.html#fls_MK83WE0iDqNf",
+                            "number": "5.10:8"
+                        }
+                    ],
+                    "title": "Struct Patterns"
+                },
+                {
+                    "id": "fls_nruvg0es3kx7",
+                    "informational": false,
+                    "link": "patterns.html#record-struct-patterns",
+                    "number": "5.10.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "939f66a2cc6a712f7ec20d7536b02ec2600f18a1799b2144aea19eec95022846",
+                            "id": "fls_g6dytd6aq62d",
+                            "link": "patterns.html#fls_g6dytd6aq62d",
+                            "number": "5.10.1:1"
+                        },
+                        {
+                            "checksum": "62c9ac85366cbfb730c4705821715b95ce875f485a87b252fa3dd810128a62b6",
+                            "id": "fls_3px4oiweg9dm",
+                            "link": "patterns.html#fls_3px4oiweg9dm",
+                            "number": "5.10.1:2"
+                        },
+                        {
+                            "checksum": "e1814d800e0feb6269bf895ed95022e6deb5cc33cc635c2bb63b14baec538159",
+                            "id": "fls_mnh35ehva8tx",
+                            "link": "patterns.html#fls_mnh35ehva8tx",
+                            "number": "5.10.1:3"
+                        },
+                        {
+                            "checksum": "3e48a4f72d15cce2c39a5d3dc6ee479532f77da0b1bf93691b99fc840384f6fe",
+                            "id": "fls_p2rjnlbvifaa",
+                            "link": "patterns.html#fls_p2rjnlbvifaa",
+                            "number": "5.10.1:4"
+                        },
+                        {
+                            "checksum": "6645895b56834ed4cc394b448f835a215f06b82857dcc694fa41f1413c2e8780",
+                            "id": "fls_23be2x50at14",
+                            "link": "patterns.html#fls_23be2x50at14",
+                            "number": "5.10.1:5"
+                        },
+                        {
+                            "checksum": "a4aa45e4d07c9304ffcc9d862e913507d5000a1730b669278ac285dc603a771c",
+                            "id": "fls_46u4ddj0yf93",
+                            "link": "patterns.html#fls_46u4ddj0yf93",
+                            "number": "5.10.1:6"
+                        },
+                        {
+                            "checksum": "7df489a39e2a1942c161d32a9ce2ef5ce0e4848eab53b9ff7321c1d546572c74",
+                            "id": "fls_qu3dvfdq6oy7",
+                            "link": "patterns.html#fls_qu3dvfdq6oy7",
+                            "number": "5.10.1:7"
+                        },
+                        {
+                            "checksum": "b07b1a9330e57dc967b57e196fbc8f1a408952860995a438d3d757900c0a9bb5",
+                            "id": "fls_4b2hchdzv30u",
+                            "link": "patterns.html#fls_4b2hchdzv30u",
+                            "number": "5.10.1:8"
+                        },
+                        {
+                            "checksum": "a8132d829bf34f884995af4cb9ae77e246d14ffc39f464dfd0579841244ed1a7",
+                            "id": "fls_9wfizujx0szd",
+                            "link": "patterns.html#fls_9wfizujx0szd",
+                            "number": "5.10.1:9"
+                        },
+                        {
+                            "checksum": "6e903cc0782eee63efea8b0c7d9bd83aaeca3c3659c72b4f1b64b24dbae63273",
+                            "id": "fls_jTh9Hur0qsIb",
+                            "link": "patterns.html#fls_jTh9Hur0qsIb",
+                            "number": "5.10.1:10"
+                        },
+                        {
+                            "checksum": "c8519c37bf9a85c68075db3cb98c5ff8ab8db77174740ac05497368044b20534",
+                            "id": "fls_as54u97xis8z",
+                            "link": "patterns.html#fls_as54u97xis8z",
+                            "number": "5.10.1:11"
+                        },
+                        {
+                            "checksum": "3515e0658c65c83d72e0dd7ad0e82d86216d338c31040d3e27832951a2aa83b5",
+                            "id": "fls_8364ueejn5y3",
+                            "link": "patterns.html#fls_8364ueejn5y3",
+                            "number": "5.10.1:12"
+                        },
+                        {
+                            "checksum": "f951f3c203a03b558cf318fb35a3313fa155405830ed6d804fcdea0b828eb716",
+                            "id": "fls_7t0be1w2hq3c",
+                            "link": "patterns.html#fls_7t0be1w2hq3c",
+                            "number": "5.10.1:13"
+                        },
+                        {
+                            "checksum": "6103ce2aaa63552db1ddd1712d330355e209efd8b3f05e2ee118128d79c0f57a",
+                            "id": "fls_3vgmkm2mzwwy",
+                            "link": "patterns.html#fls_3vgmkm2mzwwy",
+                            "number": "5.10.1:14"
+                        },
+                        {
+                            "checksum": "b94ca5c69e41ecdd7da89cf82764d0e4561528548bd0a3491afd0dcc1dc27452",
+                            "id": "fls_m91ith3rjy79",
+                            "link": "patterns.html#fls_m91ith3rjy79",
+                            "number": "5.10.1:15"
+                        },
+                        {
+                            "checksum": "b71b81a6c560dbce28bfa29908e6476ea8fd75a9b27df354ac6d310149124194",
+                            "id": "fls_c09jf2vpcr58",
+                            "link": "patterns.html#fls_c09jf2vpcr58",
+                            "number": "5.10.1:16"
+                        },
+                        {
+                            "checksum": "cb358844aa1dd3a9c5395b092c62c4e62c28a58e0b909d2c9d99344e409fafac",
+                            "id": "fls_4h00oqypa8qg",
+                            "link": "patterns.html#fls_4h00oqypa8qg",
+                            "number": "5.10.1:17"
+                        },
+                        {
+                            "checksum": "2406df736b1c1b7e052beb8d6a704041b3804de21cf83ac7e64bb84ea5c0180f",
+                            "id": "fls_195mqijyrnam",
+                            "link": "patterns.html#fls_195mqijyrnam",
+                            "number": "5.10.1:18"
+                        },
+                        {
+                            "checksum": "685de37c2ee81a66dccabb7f81942c82479d896f00e1e1334d4a60a9ea3b6bdc",
+                            "id": "fls_ta0vdoqmt2k1",
+                            "link": "patterns.html#fls_ta0vdoqmt2k1",
+                            "number": "5.10.1:19"
+                        },
+                        {
+                            "checksum": "c02d71a02dfad46132450d2be620a7cabbd2eabf47c6bd9b01945121cd5d3aa0",
+                            "id": "fls_f0u0j4q90lpl",
+                            "link": "patterns.html#fls_f0u0j4q90lpl",
+                            "number": "5.10.1:20"
+                        },
+                        {
+                            "checksum": "b0f4dad87afccd06af733d465607f36dcde450f57438e710856d594b3dfb6e8d",
+                            "id": "fls_8bi8q3usubby",
+                            "link": "patterns.html#fls_8bi8q3usubby",
+                            "number": "5.10.1:21"
+                        },
+                        {
+                            "checksum": "da482f0aac1389101e1acc7d29df971ea52cbb5a914a549589717f367179ec59",
+                            "id": "fls_1x0o71kxj3yq",
+                            "link": "patterns.html#fls_1x0o71kxj3yq",
+                            "number": "5.10.1:22"
+                        },
+                        {
+                            "checksum": "d75c1d570151a0c0add5bd9dbd8879ab364860d21ddd5a1981f20b5a358d8ac6",
+                            "id": "fls_1thgpx95lfg5",
+                            "link": "patterns.html#fls_1thgpx95lfg5",
+                            "number": "5.10.1:23"
+                        },
+                        {
+                            "checksum": "014416678ebb189d6688fb5242e5205e11770c286ca59a48f79dda7f6ae4a8b1",
+                            "id": "fls_rpo1wimbmzhc",
+                            "link": "patterns.html#fls_rpo1wimbmzhc",
+                            "number": "5.10.1:24"
+                        },
+                        {
+                            "checksum": "5dfa02c07c1e043d1fbc3b8eab7d4555147d7e61752f59b311c2486f4a53c2ef",
+                            "id": "fls_brhtaaxt1s3s",
+                            "link": "patterns.html#fls_brhtaaxt1s3s",
+                            "number": "5.10.1:25"
+                        },
+                        {
+                            "checksum": "bc8d158c05838e267c985dd76e4808b795b9c9b82d65690a8d2744bf8753e87e",
+                            "id": "fls_jwz3arnfkxwn",
+                            "link": "patterns.html#fls_jwz3arnfkxwn",
+                            "number": "5.10.1:26"
+                        },
+                        {
+                            "checksum": "cd32c48d96ca8821d8b097e61f7031858e9955ae4cb198bb1001a71624f77a7f",
+                            "id": "fls_pfz8xlwezbw1",
+                            "link": "patterns.html#fls_pfz8xlwezbw1",
+                            "number": "5.10.1:27"
+                        },
+                        {
+                            "checksum": "892be146ad066dad2bd25128cc3091054cbd49abdf7268f54e6f21339362e750",
+                            "id": "fls_XFKBJZe6k1o2",
+                            "link": "patterns.html#fls_XFKBJZe6k1o2",
+                            "number": "5.10.1:28"
+                        },
+                        {
+                            "checksum": "3dda2685fefad7736c09572d77850f39aea37aff6a75b4775df949965c478004",
+                            "id": "fls_mu166csowj71",
+                            "link": "patterns.html#fls_mu166csowj71",
+                            "number": "5.10.1:29"
+                        },
+                        {
+                            "checksum": "ae7dbf4db5d0804bb1b4f47f1a3d6ac4f752d00aacb5fd25e7d8f748f4760adc",
+                            "id": "fls_y09fygnglu3n",
+                            "link": "patterns.html#fls_y09fygnglu3n",
+                            "number": "5.10.1:30"
+                        },
+                        {
+                            "checksum": "b61a46d5ed3d3618df19128c327bc64de735101d00f7fc3b645d60b73ded72dd",
+                            "id": "fls_2tadaatmauzk",
+                            "link": "patterns.html#fls_2tadaatmauzk",
+                            "number": "5.10.1:31"
+                        },
+                        {
+                            "checksum": "d75819f44a8d7f85c50196f3a44487fcbfdaa07c19627675b6bb09b4f2fc97c4",
+                            "id": "fls_oq30xkmvyz72",
+                            "link": "patterns.html#fls_oq30xkmvyz72",
+                            "number": "5.10.1:32"
+                        },
+                        {
+                            "checksum": "5f55bfd0214be05b8229314e347c9671c485811ab7606a2c8c5a06c39aa89aae",
+                            "id": "fls_9y1gbv47z23o",
+                            "link": "patterns.html#fls_9y1gbv47z23o",
+                            "number": "5.10.1:33"
+                        },
+                        {
+                            "checksum": "013fca3143fcb9507c780ebe41cc1f74a40222e55f6c4b695758e3b78c605d12",
+                            "id": "fls_dHtV2BPRFVBB",
+                            "link": "patterns.html#fls_dHtV2BPRFVBB",
+                            "number": "5.10.1:34"
+                        },
+                        {
+                            "checksum": "af8c99976d128dfd24b2788359de45493a9f94be7c7f89b9a4f4f5864bdbf1b0",
+                            "id": "fls_zRCiKnhQebyp",
+                            "link": "patterns.html#fls_zRCiKnhQebyp",
+                            "number": "5.10.1:35"
+                        },
+                        {
+                            "checksum": "c268e10c795ada4873656e9f0fab449fea0c4a36994b5b024693b3b6bb4ee3a7",
+                            "id": "fls_D5tAGzrjXFTu",
+                            "link": "patterns.html#fls_D5tAGzrjXFTu",
+                            "number": "5.10.1:36"
+                        },
+                        {
+                            "checksum": "16873908fc7b0e081b3a93d248479b79ce08a2c8d800fe5b80a55f81b3507300",
+                            "id": "fls_FhvMzLPRlY7p",
+                            "link": "patterns.html#fls_FhvMzLPRlY7p",
+                            "number": "5.10.1:37"
+                        }
+                    ],
+                    "title": "Record Struct Patterns"
+                },
+                {
+                    "id": "fls_vlrto778v49m",
+                    "informational": false,
+                    "link": "patterns.html#tuple-struct-patterns",
+                    "number": "5.10.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "398db4748805660067dff91c2d8c07f0ce9a02f750eedab4d786b7097ea8a772",
+                            "id": "fls_ks6y1syab2bp",
+                            "link": "patterns.html#fls_ks6y1syab2bp",
+                            "number": "5.10.2:1"
+                        },
+                        {
+                            "checksum": "c49ac22e3f94f28c61a3b041503608d3e3f6a337ad9fdd9162106b3e8a729ddd",
+                            "id": "fls_t1mrijw16k9a",
+                            "link": "patterns.html#fls_t1mrijw16k9a",
+                            "number": "5.10.2:2"
+                        },
+                        {
+                            "checksum": "caed82759506953820cc05207e2ff166b8c73479f82882f1d52cec340b5ea5f2",
+                            "id": "fls_ryfcrqrkp28y",
+                            "link": "patterns.html#fls_ryfcrqrkp28y",
+                            "number": "5.10.2:3"
+                        },
+                        {
+                            "checksum": "52efa16e2d2072309e596e1e678e1ed4c435a2a10a044d200823d457ae75c86b",
+                            "id": "fls_ehf9r6halgh1",
+                            "link": "patterns.html#fls_ehf9r6halgh1",
+                            "number": "5.10.2:4"
+                        },
+                        {
+                            "checksum": "88a50cbe98942f52e03b0825ff7e25f2b0c89e3c3a66979381da5376a170cee7",
+                            "id": "fls_5lo1hs8wzz0t",
+                            "link": "patterns.html#fls_5lo1hs8wzz0t",
+                            "number": "5.10.2:5"
+                        },
+                        {
+                            "checksum": "3dc2817ca063542426c88f985729203dbe054c09d6efe49d7eb52097ec52bca6",
+                            "id": "fls_gwuc2xffosu",
+                            "link": "patterns.html#fls_gwuc2xffosu",
+                            "number": "5.10.2:6"
+                        },
+                        {
+                            "checksum": "541bd9b4e34b9b13bac861950cbc1ff7a06f887ca4d3a08d65ca538b08a21639",
+                            "id": "fls_w369n8lmwr7g",
+                            "link": "patterns.html#fls_w369n8lmwr7g",
+                            "number": "5.10.2:7"
+                        },
+                        {
+                            "checksum": "ca44a0d983f6a2c58de0d0da866f70042fb1589545be9d179d6b19542bf94f4f",
+                            "id": "fls_4is6h95jj3gd",
+                            "link": "patterns.html#fls_4is6h95jj3gd",
+                            "number": "5.10.2:8"
+                        },
+                        {
+                            "checksum": "d8b0cbea39dac23dc53d3b24c98a4832ca33e84bd17e7a35598838c1ec69d58b",
+                            "id": "fls_budf0rpsa4lx",
+                            "link": "patterns.html#fls_budf0rpsa4lx",
+                            "number": "5.10.2:9"
+                        },
+                        {
+                            "checksum": "f47bc7199534d69e8491c54e3507a6dab7fa624a91bc061b87c451e8ed8af807",
+                            "id": "fls_vo6mtauh4qhb",
+                            "link": "patterns.html#fls_vo6mtauh4qhb",
+                            "number": "5.10.2:10"
+                        },
+                        {
+                            "checksum": "9e91b8f7ea80554c6c9d801b284fd737f8072273ca2869a7a1a7c23f6cba1e10",
+                            "id": "fls_rco3fwlx2a76",
+                            "link": "patterns.html#fls_rco3fwlx2a76",
+                            "number": "5.10.2:11"
+                        },
+                        {
+                            "checksum": "435aadfae6890acd5b2f7c089d2bf6c6bde46b865278bc446f816f2900ad444d",
+                            "id": "fls_4vrnxslad09e",
+                            "link": "patterns.html#fls_4vrnxslad09e",
+                            "number": "5.10.2:12"
+                        },
+                        {
+                            "checksum": "c18b1eaabbf21d6d906c4d4255fe8e1efcf58af3fbebbfffa7348ac6b6edf3c5",
+                            "id": "fls_qgilaqy5zx7q",
+                            "link": "patterns.html#fls_qgilaqy5zx7q",
+                            "number": "5.10.2:13"
+                        },
+                        {
+                            "checksum": "2d585002f71b603779602116d0639fd90c72f6c4832288b134b5a2c57dc36717",
+                            "id": "fls_2u99arsbnlnk",
+                            "link": "patterns.html#fls_2u99arsbnlnk",
+                            "number": "5.10.2:14"
+                        }
+                    ],
+                    "title": "Tuple Struct Patterns"
+                },
+                {
+                    "id": "fls_urbr5rg9206v",
+                    "informational": false,
+                    "link": "patterns.html#tuple-patterns",
+                    "number": "5.10.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "86e5cf86cc1727a1ec3d2c9b3c7770ba2d5a0a0be11e05f181cf89208cef7e8f",
+                            "id": "fls_e2manugp4e0b",
+                            "link": "patterns.html#fls_e2manugp4e0b",
+                            "number": "5.10.3:1"
+                        },
+                        {
+                            "checksum": "968065a0acde4dc1fc6772c9a80d889371d997d4d812bece3bb143b855b791f3",
+                            "id": "fls_xk8udu4k61kj",
+                            "link": "patterns.html#fls_xk8udu4k61kj",
+                            "number": "5.10.3:2"
+                        },
+                        {
+                            "checksum": "c046f561eb355602680f839ad87e202a633dd889397bbc12f7027ffc7b5a284a",
+                            "id": "fls_yhcaz6v49ub2",
+                            "link": "patterns.html#fls_yhcaz6v49ub2",
+                            "number": "5.10.3:3"
+                        },
+                        {
+                            "checksum": "208f90ce72da5d32c30755d34df67702194f5fe887e9c7a1bd0554c4718eeede",
+                            "id": "fls_6WCm0Ra8NQl4",
+                            "link": "patterns.html#fls_6WCm0Ra8NQl4",
+                            "number": "5.10.3:4"
+                        },
+                        {
+                            "checksum": "d4a0b43d9d6a5e0b17d67fcdf081a940f340d1b85d971f31c684778d9986fb2b",
+                            "id": "fls_a3qvQjyilORx",
+                            "link": "patterns.html#fls_a3qvQjyilORx",
+                            "number": "5.10.3:5"
+                        },
+                        {
+                            "checksum": "289e79602b945e44a6b259d8d0c1e225e914afa943874c7698ef97f89f8f3def",
+                            "id": "fls_KmIHFxlBYelZ",
+                            "link": "patterns.html#fls_KmIHFxlBYelZ",
+                            "number": "5.10.3:6"
+                        },
+                        {
+                            "checksum": "bd944455b4e5b2992d60a0276dd284685483fbdb2ce0a6e8b861676e3d2069b7",
+                            "id": "fls_5bXqIaKiFcLg",
+                            "link": "patterns.html#fls_5bXqIaKiFcLg",
+                            "number": "5.10.3:7"
+                        },
+                        {
+                            "checksum": "47877ba9b3984b4661b6db0b34526c8edb770ea1f800c33d64c5523a6d44b8f2",
+                            "id": "fls_soHCAVfGlv5f",
+                            "link": "patterns.html#fls_soHCAVfGlv5f",
+                            "number": "5.10.3:8"
+                        },
+                        {
+                            "checksum": "325628fddc5edcfee5dde126d580262949d54d516c4f6d9243baff7c4f607da9",
+                            "id": "fls_iiKvYs61959S",
+                            "link": "patterns.html#fls_iiKvYs61959S",
+                            "number": "5.10.3:9"
+                        },
+                        {
+                            "checksum": "80b589c7aaacf22228397ab8de7f859870551fa23bbc58316341c4fe297455b0",
+                            "id": "fls_F4k6ljuP8Amf",
+                            "link": "patterns.html#fls_F4k6ljuP8Amf",
+                            "number": "5.10.3:10"
+                        },
+                        {
+                            "checksum": "d0a0133555000675455b2bf5ab37681e6e7bb93783c7e8ebd5178f80704e6ce1",
+                            "id": "fls_GjjCDkVJPQS8",
+                            "link": "patterns.html#fls_GjjCDkVJPQS8",
+                            "number": "5.10.3:11"
+                        },
+                        {
+                            "checksum": "46bd974ba3f88ec8c528de9c9907e74139719b19f51d32a06f37cede033afd44",
+                            "id": "fls_9Qw9N87swwNe",
+                            "link": "patterns.html#fls_9Qw9N87swwNe",
+                            "number": "5.10.3:12"
+                        },
+                        {
+                            "checksum": "f1887b73be484d54fe02b6a04ea8aee012209872ae40fb9179a705c3f4856242",
+                            "id": "fls_CQ84wkLyrAJv",
+                            "link": "patterns.html#fls_CQ84wkLyrAJv",
+                            "number": "5.10.3:13"
+                        },
+                        {
+                            "checksum": "176644151cc57b936a43b35578e7182a3c89ac881b62ba4e3aa5bfede1008ecf",
+                            "id": "fls_cC6ohNuiltfL",
+                            "link": "patterns.html#fls_cC6ohNuiltfL",
+                            "number": "5.10.3:14"
+                        },
+                        {
+                            "checksum": "c479906bca39314417e1caa942e7ef8efbb0987857a2c5ea2e3dc30d69cc4a20",
+                            "id": "fls_8r81vtv5hnrd",
+                            "link": "patterns.html#fls_8r81vtv5hnrd",
+                            "number": "5.10.3:15"
+                        }
+                    ],
+                    "title": "Tuple Patterns"
+                },
+                {
+                    "id": "fls_qfsfnql1t7m",
+                    "informational": false,
+                    "link": "patterns.html#underscore-patterns",
+                    "number": "5.11",
+                    "paragraphs": [
+                        {
+                            "checksum": "ffe05e2b6f44aab3204db8f037bcbabda722b0b2a4c36233bd344165b0915664",
+                            "id": "fls_dreny9e0ei6r",
+                            "link": "patterns.html#fls_dreny9e0ei6r",
+                            "number": "5.11:1"
+                        },
+                        {
+                            "checksum": "512af904f1afbc0ae83e21197bac2017c65eb4d2820eb33ef0e964251753ac99",
+                            "id": "fls_42fye1v0th8l",
+                            "link": "patterns.html#fls_42fye1v0th8l",
+                            "number": "5.11:2"
+                        },
+                        {
+                            "checksum": "4df12d4b4abe0cd1029651c34033e70582bd69ad83cfc6a3a733e4bf20d8da0a",
+                            "id": "fls_b87mvrcc13f2",
+                            "link": "patterns.html#fls_b87mvrcc13f2",
+                            "number": "5.11:3"
+                        },
+                        {
+                            "checksum": "7dd5b2d964186c34d5eb0d46902b5bcc8cef29ddc8f75425c634837f9354dbcd",
+                            "id": "fls_j3u6x1ensrbe",
+                            "link": "patterns.html#fls_j3u6x1ensrbe",
+                            "number": "5.11:4"
+                        }
+                    ],
+                    "title": "Underscore Patterns"
+                },
+                {
+                    "id": "fls_qssijtofa9i8",
+                    "informational": false,
+                    "link": "patterns.html#binding-modes",
+                    "number": "5.12",
+                    "paragraphs": [
+                        {
+                            "checksum": "ce737fd6a8e0011aa5361836e179e7da00b62d001685d8a3099eda2e5f94ff52",
+                            "id": "fls_7xby6d1903kw",
+                            "link": "patterns.html#fls_7xby6d1903kw",
+                            "number": "5.12:1"
+                        },
+                        {
+                            "checksum": "ee24110781d1935c43cf0567d764e1aadf2cc3db7f17740efe4e767ac0ee9632",
+                            "id": "fls_vnh9wfrvumdz",
+                            "link": "patterns.html#fls_vnh9wfrvumdz",
+                            "number": "5.12:2"
+                        },
+                        {
+                            "checksum": "3689001f3e5a3fadb5bce3f16c76e8babf3aa8a1b12b24dc1d08cc2709b6336c",
+                            "id": "fls_RViC5UEZPQUV",
+                            "link": "patterns.html#fls_RViC5UEZPQUV",
+                            "number": "5.12:3"
+                        },
+                        {
+                            "checksum": "1a8541da9715b497aff0fb8fd6116cd249a0350898d3dd89d00b2c30c7e82671",
+                            "id": "fls_6lXtoxebD5It",
+                            "link": "patterns.html#fls_6lXtoxebD5It",
+                            "number": "5.12:4"
+                        },
+                        {
+                            "checksum": "0b306a42847f796ecf6339eefc0af21e5781a2cde421ae3141018b146e11ffb0",
+                            "id": "fls_xNxQN8sgpZ3O",
+                            "link": "patterns.html#fls_xNxQN8sgpZ3O",
+                            "number": "5.12:5"
+                        },
+                        {
+                            "checksum": "0871ae0bb0826a8d223e8c2cee52f184b7c0e39f86c5063fcd676f7fbc614365",
+                            "id": "fls_dqe75i8h2fie",
+                            "link": "patterns.html#fls_dqe75i8h2fie",
+                            "number": "5.12:6"
+                        },
+                        {
+                            "checksum": "959846317dd64ecd23fd6c93f96608048d818682c7cd48599dfffcd231a8557a",
+                            "id": "fls_y3wuvj1y5j20",
+                            "link": "patterns.html#fls_y3wuvj1y5j20",
+                            "number": "5.12:7"
+                        },
+                        {
+                            "checksum": "edc7cf534c55c29625cd191432a05763797465d54cbd387fee8127a17ad0f1ed",
+                            "id": "fls_55jtzh6a292x",
+                            "link": "patterns.html#fls_55jtzh6a292x",
+                            "number": "5.12:8"
+                        },
+                        {
+                            "checksum": "174692122d916648a54e197fff15a1e7bf17984b9523fd06224c71a7484e0445",
+                            "id": "fls_qcaf2kup7zn0",
+                            "link": "patterns.html#fls_qcaf2kup7zn0",
+                            "number": "5.12:9"
+                        },
+                        {
+                            "checksum": "c9dfbc0519fed7bb3f112777102c928f15a4d5c3cfc13d4d3017e9c15259ce08",
+                            "id": "fls_6acdqz8rwnn",
+                            "link": "patterns.html#fls_6acdqz8rwnn",
+                            "number": "5.12:10"
+                        },
+                        {
+                            "checksum": "61b076c4aa153ed7b1ed996845d08b881a2327bfe131501f20b3ae9b3a2c042d",
+                            "id": "fls_tv0avib387bv",
+                            "link": "patterns.html#fls_tv0avib387bv",
+                            "number": "5.12:11"
+                        },
+                        {
+                            "checksum": "a30925ea032d35a24204cb5c81fc5ad636e77d19ce00fb38615985b1bec396d6",
+                            "id": "fls_dbgmwldye42e",
+                            "link": "patterns.html#fls_dbgmwldye42e",
+                            "number": "5.12:12"
+                        },
+                        {
+                            "checksum": "e9940ece8b67430f6507527efb4e0837eea8ecd615884b2d4a3773018ca5df88",
+                            "id": "fls_t34oqarwcusu",
+                            "link": "patterns.html#fls_t34oqarwcusu",
+                            "number": "5.12:13"
+                        },
+                        {
+                            "checksum": "94de4c12fad70f9cac54c2a50a2c65b9a5d0f42b1847bddbbb2e5c23d1e9917c",
+                            "id": "fls_7gxb74u1np36",
+                            "link": "patterns.html#fls_7gxb74u1np36",
+                            "number": "5.12:14"
+                        },
+                        {
+                            "checksum": "7b6cefba0ed64069e11e48d9eddf7bdab4f5ec7b32d73b3a9c0c92d7fd078d3a",
+                            "id": "fls_7y56d0ulxomf",
+                            "link": "patterns.html#fls_7y56d0ulxomf",
+                            "number": "5.12:15"
+                        },
+                        {
+                            "checksum": "7a06ffc02f7927cd15e2513d53f8a618b2100301b066a92e111ba6ce488b6941",
+                            "id": "fls_pxvtqxke1enp",
+                            "link": "patterns.html#fls_pxvtqxke1enp",
+                            "number": "5.12:16"
+                        }
+                    ],
+                    "title": "Binding Modes"
+                },
+                {
+                    "id": "fls_jm6l7b90h6wa",
+                    "informational": false,
+                    "link": "patterns.html#pattern-matching",
+                    "number": "5.13",
+                    "paragraphs": [
+                        {
+                            "checksum": "6b0c9b448ffa1317860d5ce72327a183542c035ca71f57b637fe069226784ff8",
+                            "id": "fls_tlwr4u7bjhh5",
+                            "link": "patterns.html#fls_tlwr4u7bjhh5",
+                            "number": "5.13:1"
+                        },
+                        {
+                            "checksum": "b6d21ac4978904629594c63e865c13ff0e8188557a1ee1fc16bf38d292273905",
+                            "id": "fls_67ajub7d2b4c",
+                            "link": "patterns.html#fls_67ajub7d2b4c",
+                            "number": "5.13:2"
+                        },
+                        {
+                            "checksum": "d6e77f76c3b70cd441241b2ddcb2ece4258490b36edc54866617c3d56b1d1db9",
+                            "id": "fls_62626ws222op",
+                            "link": "patterns.html#fls_62626ws222op",
+                            "number": "5.13:3"
+                        },
+                        {
+                            "checksum": "6867ae30832eda7ee1fee559e718d1cc657447cfdb727917e47a405431cbb8fc",
+                            "id": "fls_q0z46h1gnzez",
+                            "link": "patterns.html#fls_q0z46h1gnzez",
+                            "number": "5.13:4"
+                        },
+                        {
+                            "checksum": "b919a4d8d9ed226bbf402a3d3d51992d55a4159a5723b7534992db054a299aa0",
+                            "id": "fls_1r0vm6rg13o9",
+                            "link": "patterns.html#fls_1r0vm6rg13o9",
+                            "number": "5.13:5"
+                        },
+                        {
+                            "checksum": "7a5e47b54e578d0454d02d99d9d1735d8480757b894acfedb724f6f4945d4557",
+                            "id": "fls_am5h8r887bz5",
+                            "link": "patterns.html#fls_am5h8r887bz5",
+                            "number": "5.13:6"
+                        },
+                        {
+                            "checksum": "0261db6dc821115e2d72a8963d41e3816c27ff5dec58ab612b4b0043bab2628c",
+                            "id": "fls_eppmiloh7bgg",
+                            "link": "patterns.html#fls_eppmiloh7bgg",
+                            "number": "5.13:7"
+                        },
+                        {
+                            "checksum": "d8bde8dafa190be72dc04dbd04f9dcc381ba9e56fc7c59ef14e0adf12d08da99",
+                            "id": "fls_gwc08xayno7q",
+                            "link": "patterns.html#fls_gwc08xayno7q",
+                            "number": "5.13:8"
+                        },
+                        {
+                            "checksum": "5b38e89f8e8e644db16464772877616b08bec8b5dc081183f140b1944cd02d7d",
+                            "id": "fls_19iygu12s315",
+                            "link": "patterns.html#fls_19iygu12s315",
+                            "number": "5.13:9"
+                        },
+                        {
+                            "checksum": "e7cdc075b361ca70248b735173fd1ae43a881787197759e135ebe311f34f316a",
+                            "id": "fls_r307spfk6cs9",
+                            "link": "patterns.html#fls_r307spfk6cs9",
+                            "number": "5.13:10"
+                        },
+                        {
+                            "checksum": "7e28619896a113dc0b4fcbbfbc7c0e60f3fbe58465cdd9e0c57ae6883ca75849",
+                            "id": "fls_qhdofvbso3gl",
+                            "link": "patterns.html#fls_qhdofvbso3gl",
+                            "number": "5.13:11"
+                        },
+                        {
+                            "checksum": "0f085b2b200d131b0f3ad93e901232589ae5185e8b937688595401a2281802f1",
+                            "id": "fls_drb114dtvlpt",
+                            "link": "patterns.html#fls_drb114dtvlpt",
+                            "number": "5.13:12"
+                        },
+                        {
+                            "checksum": "1b7c6f4e677eefe1fb3db44988440585f0a06c492b2c55de71cbc12e1ee26149",
+                            "id": "fls_uxysntb3u03j",
+                            "link": "patterns.html#fls_uxysntb3u03j",
+                            "number": "5.13:13"
+                        },
+                        {
+                            "checksum": "8bd4950f12c3fc2761c334a84cb412e80a671197a21ca640ebe447e01836d826",
+                            "id": "fls_wh201rmh6u6d",
+                            "link": "patterns.html#fls_wh201rmh6u6d",
+                            "number": "5.13:14"
+                        },
+                        {
+                            "checksum": "fd13d0bd953b8f054714e974f43ba2b7fa374ed3ffd288303907a4242b346c4e",
+                            "id": "fls_vstdqifqipbh",
+                            "link": "patterns.html#fls_vstdqifqipbh",
+                            "number": "5.13:15"
+                        }
+                    ],
+                    "title": "Pattern Matching"
+                },
+                {
+                    "id": "fls_vnai6ag4qrdb",
+                    "informational": false,
+                    "link": "patterns.html#identifier-pattern-matching",
+                    "number": "5.13.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "dd60a44dea7a972ddea069491ecd9f406558f404e901527ddd0d2149eeb48ebd",
+                            "id": "fls_4f3lzw64myhk",
+                            "link": "patterns.html#fls_4f3lzw64myhk",
+                            "number": "5.13.1:1"
+                        },
+                        {
+                            "checksum": "aa285e853a6324a841c40d2b74e066fb6002f1fb6707b20a81ff680616eae3fc",
+                            "id": "fls_wauqwmdbcpna",
+                            "link": "patterns.html#fls_wauqwmdbcpna",
+                            "number": "5.13.1:2"
+                        },
+                        {
+                            "checksum": "4aef617035a62c693b0db6e84d556a1afe10c28af4f9b0ca18065503767f6015",
+                            "id": "fls_3jyog8n6x2aa",
+                            "link": "patterns.html#fls_3jyog8n6x2aa",
+                            "number": "5.13.1:3"
+                        },
+                        {
+                            "checksum": "0db8e23416d53e90ad73fa4df5b10d7e3ef8d53418d42a8860380a85d5d1163a",
+                            "id": "fls_w637uvlbzsyo",
+                            "link": "patterns.html#fls_w637uvlbzsyo",
+                            "number": "5.13.1:4"
+                        },
+                        {
+                            "checksum": "1cf4f4074ffc3e6745944b1dcd726ac4b7d65f44568c669f04ddfcbe8068d57e",
+                            "id": "fls_arz8ik3gf6u4",
+                            "link": "patterns.html#fls_arz8ik3gf6u4",
+                            "number": "5.13.1:5"
+                        },
+                        {
+                            "checksum": "5003a32c5e8a49a9e7d778d70ff05edcf2411bd284272a8bf7bd04d2df3a40fe",
+                            "id": "fls_u6o5ndnezwbe",
+                            "link": "patterns.html#fls_u6o5ndnezwbe",
+                            "number": "5.13.1:6"
+                        },
+                        {
+                            "checksum": "de66751e709611b36e4517f705acf75d052724e2501a8c5ee5ab8c40757115e5",
+                            "id": "fls_h1er04t0yta7",
+                            "link": "patterns.html#fls_h1er04t0yta7",
+                            "number": "5.13.1:7"
+                        }
+                    ],
+                    "title": "Identifier Pattern Matching"
+                },
+                {
+                    "id": "fls_azzf1llv3wf",
+                    "informational": false,
+                    "link": "patterns.html#literal-pattern-matching",
+                    "number": "5.13.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "ffb06275d46d70835ab2e118cff4b0071d02544ee94a260f428fd2b5533bed1c",
+                            "id": "fls_fqkhhgushje9",
+                            "link": "patterns.html#fls_fqkhhgushje9",
+                            "number": "5.13.2:1"
+                        },
+                        {
+                            "checksum": "d04dcff15efbb13e790e1f78948bf446426570ec9618c3b921293adfc2012199",
+                            "id": "fls_m01eo9sa55s",
+                            "link": "patterns.html#fls_m01eo9sa55s",
+                            "number": "5.13.2:2"
+                        },
+                        {
+                            "checksum": "fe6504c691ded75e993e4d66b216f7260d30ac52c0a60e35151af31c01905992",
+                            "id": "fls_294jtwbfq3p9",
+                            "link": "patterns.html#fls_294jtwbfq3p9",
+                            "number": "5.13.2:3"
+                        }
+                    ],
+                    "title": "Literal Pattern Matching"
+                },
+                {
+                    "id": "fls_5loglxds6zik",
+                    "informational": false,
+                    "link": "patterns.html#parenthesized-pattern-matching",
+                    "number": "5.13.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "7f3d87f0e2bf7a6dc15e6e0bcda2506008be955f016459a792ea2b99d16bacbf",
+                            "id": "fls_jajvvwoy3399",
+                            "link": "patterns.html#fls_jajvvwoy3399",
+                            "number": "5.13.3:1"
+                        }
+                    ],
+                    "title": "Parenthesized Pattern Matching"
+                },
+                {
+                    "id": "fls_d44aflefat88",
+                    "informational": false,
+                    "link": "patterns.html#path-pattern-matching",
+                    "number": "5.13.4",
+                    "paragraphs": [
+                        {
+                            "checksum": "b62c95bf3039a32f793c95cd983bcc5cd80b8faeb5d469cc963c3a487f437fae",
+                            "id": "fls_4faltss0xbn4",
+                            "link": "patterns.html#fls_4faltss0xbn4",
+                            "number": "5.13.4:1"
+                        },
+                        {
+                            "checksum": "ee205e802f76cf743647cd0b8c7be7f9d118ea51ef62a9f8ccd237ee2a7c874c",
+                            "id": "fls_fqt5w3qsykca",
+                            "link": "patterns.html#fls_fqt5w3qsykca",
+                            "number": "5.13.4:2"
+                        },
+                        {
+                            "checksum": "10a9ff549fbafbc317a299a46f8f61ed3ec121a3f1c97d94c1a3ae2aeee961f7",
+                            "id": "fls_h3y8r4298s53",
+                            "link": "patterns.html#fls_h3y8r4298s53",
+                            "number": "5.13.4:3"
+                        }
+                    ],
+                    "title": "Path Pattern Matching"
+                },
+                {
+                    "id": "fls_fyskeih6twyb",
+                    "informational": false,
+                    "link": "patterns.html#range-pattern-matching",
+                    "number": "5.13.5",
+                    "paragraphs": [
+                        {
+                            "checksum": "74c808f389212d771098798db71f913b01fad773d198d3babf0a21ae6f4ce792",
+                            "id": "fls_mrh9vfdek5fi",
+                            "link": "patterns.html#fls_mrh9vfdek5fi",
+                            "number": "5.13.5:1"
+                        },
+                        {
+                            "checksum": "4e77c3805f9c1fde39877a54a3b99be7582ff7dde64d6f8b033465fcfb625c8c",
+                            "id": "fls_7nxkgls0a5os",
+                            "link": "patterns.html#fls_7nxkgls0a5os",
+                            "number": "5.13.5:2"
+                        },
+                        {
+                            "checksum": "fd8fba85c57e8cde11619040e0cf63b8bee10a4ad77a5a663655cf44f7527d00",
+                            "id": "fls_6kgj2fjccoig",
+                            "link": "patterns.html#fls_6kgj2fjccoig",
+                            "number": "5.13.5:3"
+                        },
+                        {
+                            "checksum": "6ceef4a4fb5e7197f8e4fbeea43c666aa1ee532e0e198a0242be6ab5dca9d26c",
+                            "id": "fls_EDL1Pi56KQ2H",
+                            "link": "patterns.html#fls_EDL1Pi56KQ2H",
+                            "number": "5.13.5:4"
+                        },
+                        {
+                            "checksum": "7ee404fd4fb97fe0f1daafdb86a76994a1056bc3cbc4571522f37b405f651572",
+                            "id": "fls_n4t3xah1pk7i",
+                            "link": "patterns.html#fls_n4t3xah1pk7i",
+                            "number": "5.13.5:5"
+                        }
+                    ],
+                    "title": "Range Pattern Matching"
+                },
+                {
+                    "id": "fls_org6hqv397fp",
+                    "informational": false,
+                    "link": "patterns.html#reference-pattern-matching",
+                    "number": "5.13.6",
+                    "paragraphs": [
+                        {
+                            "checksum": "b6dad8a8eb45a793423595800323ed5f357d864241174e7198f4101b4d5c9c9b",
+                            "id": "fls_ysfgdzaiww8z",
+                            "link": "patterns.html#fls_ysfgdzaiww8z",
+                            "number": "5.13.6:1"
+                        },
+                        {
+                            "checksum": "9932447e7ad4cb062a332bea07f5eb902fa9f0482de8917d2a3bee05f86c2fdf",
+                            "id": "fls_7rxnxd4ybxbt",
+                            "link": "patterns.html#fls_7rxnxd4ybxbt",
+                            "number": "5.13.6:2"
+                        },
+                        {
+                            "checksum": "b76bff46c3fb725fb95fd036da6eec2951e358e24662e16fe7a2b277948422eb",
+                            "id": "fls_l2nwz166curc",
+                            "link": "patterns.html#fls_l2nwz166curc",
+                            "number": "5.13.6:3"
+                        }
+                    ],
+                    "title": "Reference Pattern Matching"
+                },
+                {
+                    "id": "fls_57ic33pwdvp3",
+                    "informational": false,
+                    "link": "patterns.html#slice-pattern-matching",
+                    "number": "5.13.7",
+                    "paragraphs": [
+                        {
+                            "checksum": "545a7b4ddaf1e7bfb2237db616a2cf9a24e53676e02591cec035c44ace0b0fd1",
+                            "id": "fls_hzyv4ofu0ny",
+                            "link": "patterns.html#fls_hzyv4ofu0ny",
+                            "number": "5.13.7:1"
+                        },
+                        {
+                            "checksum": "a08c2a45fe77ae5f047f5e6cf64b8f743c4433b940e5f5fb0245051c079e7e8a",
+                            "id": "fls_x10AKxoXXbs8",
+                            "link": "patterns.html#fls_x10AKxoXXbs8",
+                            "number": "5.13.7:2"
+                        },
+                        {
+                            "checksum": "00b9a97b9280c3716ddfa172c721a2bf0e2081a9fa912cffde3cda55d1197952",
+                            "id": "fls_69bnxrtj0nar",
+                            "link": "patterns.html#fls_69bnxrtj0nar",
+                            "number": "5.13.7:3"
+                        },
+                        {
+                            "checksum": "c48b717f055594a928a658edaf02b1fabf8a096bdefdb3fbc8f24437462635da",
+                            "id": "fls_twhwiy213ibf",
+                            "link": "patterns.html#fls_twhwiy213ibf",
+                            "number": "5.13.7:4"
+                        },
+                        {
+                            "checksum": "3f7ea24067807e7941333db26d088679f21fbd2c64a2407cf545ff6861841872",
+                            "id": "fls_ei7y4ul6n6hu",
+                            "link": "patterns.html#fls_ei7y4ul6n6hu",
+                            "number": "5.13.7:5"
+                        },
+                        {
+                            "checksum": "4925bc389627a9c0258c8b5aa732c62f27ea3c62e2b3c0bbfd6e8f9c1350920e",
+                            "id": "fls_ad2jud5h1rfp",
+                            "link": "patterns.html#fls_ad2jud5h1rfp",
+                            "number": "5.13.7:6"
+                        },
+                        {
+                            "checksum": "0a3498e1551afa3c7f492391c8187746fccf5ebb43ae48f55741d4dd39aaceab",
+                            "id": "fls_pc97m47p34wq",
+                            "link": "patterns.html#fls_pc97m47p34wq",
+                            "number": "5.13.7:7"
+                        },
+                        {
+                            "checksum": "ff3c524edac17baef16b63f1da2eead531f9c065f671838de8c437b87e87f859",
+                            "id": "fls_kwQyiSoyAwZ8",
+                            "link": "patterns.html#fls_kwQyiSoyAwZ8",
+                            "number": "5.13.7:8"
+                        },
+                        {
+                            "checksum": "624d69de485ef8707d6d98a26dcdfd92081861894d0c06dba07882fe19de3ee2",
+                            "id": "fls_zAdtysiuUwBX",
+                            "link": "patterns.html#fls_zAdtysiuUwBX",
+                            "number": "5.13.7:9"
+                        },
+                        {
+                            "checksum": "8f94a20f9d18e18084cc5e7931d668de6254cce6b14813fce2f2a16d4a699598",
+                            "id": "fls_SezcYXcSlEq7",
+                            "link": "patterns.html#fls_SezcYXcSlEq7",
+                            "number": "5.13.7:10"
+                        },
+                        {
+                            "checksum": "f14008365b9b2173763090e4ac8e371acae7932276efa64dd5c4bef234a9b625",
+                            "id": "fls_6xRXEt2pGnZi",
+                            "link": "patterns.html#fls_6xRXEt2pGnZi",
+                            "number": "5.13.7:11"
+                        }
+                    ],
+                    "title": "Slice Pattern Matching"
+                },
+                {
+                    "id": "fls_asj8rgccvkoe",
+                    "informational": false,
+                    "link": "patterns.html#record-struct-pattern-matching",
+                    "number": "5.13.8",
+                    "paragraphs": [
+                        {
+                            "checksum": "a64d7a8315d7d5f47ec10463a26465d1b20225bc5c426030b5af68285a662722",
+                            "id": "fls_evuhau2rwm8i",
+                            "link": "patterns.html#fls_evuhau2rwm8i",
+                            "number": "5.13.8:1"
+                        },
+                        {
+                            "checksum": "202123ed4c141cd00114f671cc7b4a9caaafd86ff150c865e93c8e9dad4257fc",
+                            "id": "fls_bde1hpvrosui",
+                            "link": "patterns.html#fls_bde1hpvrosui",
+                            "number": "5.13.8:2"
+                        },
+                        {
+                            "checksum": "d0da6696f0030559710cd9ee013efb4dbfb95b1df235fe5f469bfcd2d24034c4",
+                            "id": "fls_447s4hc07ozn",
+                            "link": "patterns.html#fls_447s4hc07ozn",
+                            "number": "5.13.8:3"
+                        },
+                        {
+                            "checksum": "b11dc2c5dfcaf758c45e4029e582f72a53c74e7c2c98575fb2b7461ae1e7d805",
+                            "id": "fls_vfdb1i5l41yk",
+                            "link": "patterns.html#fls_vfdb1i5l41yk",
+                            "number": "5.13.8:4"
+                        },
+                        {
+                            "checksum": "36081581a365a6503d56139e07b8e1749757cf878634d805e84663d3172cb005",
+                            "id": "fls_yfk52fr7trw3",
+                            "link": "patterns.html#fls_yfk52fr7trw3",
+                            "number": "5.13.8:5"
+                        },
+                        {
+                            "checksum": "8b8f1725d0cf2ef6489bd548eec9d59fab537eca1f33a509f8141751325cba76",
+                            "id": "fls_6sdcykdrpe5d",
+                            "link": "patterns.html#fls_6sdcykdrpe5d",
+                            "number": "5.13.8:6"
+                        }
+                    ],
+                    "title": "Record Struct Pattern Matching"
+                },
+                {
+                    "id": "fls_eexupzdsu7f",
+                    "informational": false,
+                    "link": "patterns.html#tuple-struct-pattern-matching",
+                    "number": "5.13.9",
+                    "paragraphs": [
+                        {
+                            "checksum": "ed45c176d905341bee988af8640b3011dd6a97d9c8fe53b45410925a79d5e056",
+                            "id": "fls_dexg9g9cct30",
+                            "link": "patterns.html#fls_dexg9g9cct30",
+                            "number": "5.13.9:1"
+                        },
+                        {
+                            "checksum": "03c31f4e25eebbe78169c4bc173609effc1e8269dfe4f263b29363409e316dab",
+                            "id": "fls_boc7juqj69hw",
+                            "link": "patterns.html#fls_boc7juqj69hw",
+                            "number": "5.13.9:2"
+                        },
+                        {
+                            "checksum": "6b75afdc8b9b09fcd7df94b0c730c87e30d4bb2de200714adf3a08575e90a90a",
+                            "id": "fls_4dr1stiw82v9",
+                            "link": "patterns.html#fls_4dr1stiw82v9",
+                            "number": "5.13.9:3"
+                        },
+                        {
+                            "checksum": "13343ca1b2a108f58c91e7fcdb4c9e4c975f5fa11d841db4951a8883a4bcc7d5",
+                            "id": "fls_h14emtt6iyk3",
+                            "link": "patterns.html#fls_h14emtt6iyk3",
+                            "number": "5.13.9:4"
+                        }
+                    ],
+                    "title": "Tuple Struct Pattern Matching"
+                },
+                {
+                    "id": "fls_rce8bb7nz2jy",
+                    "informational": false,
+                    "link": "patterns.html#tuple-pattern-matching",
+                    "number": "5.13.10",
+                    "paragraphs": [
+                        {
+                            "checksum": "746ffe5085ba7cfbb59d3c44688b6f8584fa574128327bb37f2f051173efb07d",
+                            "id": "fls_w4xypnrnhycb",
+                            "link": "patterns.html#fls_w4xypnrnhycb",
+                            "number": "5.13.10:1"
+                        },
+                        {
+                            "checksum": "5f1c0e7fad583c2e4331c5805f1dbf89717118d493a01549a42dfeaa3f0279ca",
+                            "id": "fls_vnx1bpval595",
+                            "link": "patterns.html#fls_vnx1bpval595",
+                            "number": "5.13.10:2"
+                        },
+                        {
+                            "checksum": "e86a7e2ae632d8ce6ffaeb404902846bb48e160aab297c2c2652d9b985f7982e",
+                            "id": "fls_dzf32f40y7fr",
+                            "link": "patterns.html#fls_dzf32f40y7fr",
+                            "number": "5.13.10:3"
+                        },
+                        {
+                            "checksum": "37eed365431808077ba3f82d504515f343520002fd244c7649305e39f6c96d7e",
+                            "id": "fls_krl32txvxxkz",
+                            "link": "patterns.html#fls_krl32txvxxkz",
+                            "number": "5.13.10:4"
+                        }
+                    ],
+                    "title": "Tuple Pattern Matching"
+                },
+                {
+                    "id": "fls_yc4xm4hrfyw7",
+                    "informational": false,
+                    "link": "patterns.html#underscore-pattern-matching",
+                    "number": "5.13.11",
+                    "paragraphs": [
+                        {
+                            "checksum": "b9ccebce07421997dfd958ff40f0aef3a1b9e546fb3bcf0c2cefe7fbfdd64d01",
+                            "id": "fls_dvk7r1gf7pwp",
+                            "link": "patterns.html#fls_dvk7r1gf7pwp",
+                            "number": "5.13.11:1"
+                        },
+                        {
+                            "checksum": "33c34bf81e9f7a3651a3718b8ab5b88c0ba416ea85e283b4fbd4a7e30e78b48a",
+                            "id": "fls_e0uprihqn1y6",
+                            "link": "patterns.html#fls_e0uprihqn1y6",
+                            "number": "5.13.11:2"
+                        },
+                        {
+                            "checksum": "8e3a3ff978133c3bfffe09986eace47f5b4afb21f6c71af39fd93f4f27ad2860",
+                            "id": "fls_ljcq2vyo052q",
+                            "link": "patterns.html#fls_ljcq2vyo052q",
+                            "number": "5.13.11:3"
+                        }
+                    ],
+                    "title": "Underscore Pattern Matching"
                 }
             ],
-            "title": "Program Structure and Compilation"
+            "title": "Patterns"
         },
         {
             "informational": false,
-            "link": "implementations.html",
+            "link": "functions.html",
             "sections": [
                 {
-                    "id": "fls_fk2m2irwpeof",
+                    "id": "fls_qcb1n9c0e5hz",
                     "informational": false,
-                    "link": "implementations.html",
-                    "number": "11",
+                    "link": "functions.html",
+                    "number": "9",
                     "paragraphs": [
                         {
-                            "checksum": "68d68054bfe8ffe57002321f94f09f2c21faac92f10052af0b8ebb6bb2e4bdd4",
-                            "id": "fls_ivxpoxggy7s6",
-                            "link": "implementations.html#fls_ivxpoxggy7s6",
-                            "number": "11:1"
+                            "checksum": "d85148abd62f72e649abbb14ec33bcf5dd833660e6d429978a1233e8aa19e739",
+                            "id": "fls_gn1ngtx2tp2s",
+                            "link": "functions.html#fls_gn1ngtx2tp2s",
+                            "number": "9:1"
                         },
                         {
-                            "checksum": "a88885418df7946e8facb892e33e099cc8789c354fbf7bd977f460e40ec2089d",
-                            "id": "fls_yopmjbnw8tbl",
-                            "link": "implementations.html#fls_yopmjbnw8tbl",
-                            "number": "11:2"
+                            "checksum": "0b7f0bc4680d19a82f2a03e22ab8228330095ac38f768e6138b1fa061209b0cd",
+                            "id": "fls_bdx9gnnjxru3",
+                            "link": "functions.html#fls_bdx9gnnjxru3",
+                            "number": "9:2"
                         },
                         {
-                            "checksum": "28523ce67d9161886a6bbdc6415a2a18a12cac0bd7cf96d2e560d4acaa243c96",
-                            "id": "fls_eIHc8Y9fBtr0",
-                            "link": "implementations.html#fls_eIHc8Y9fBtr0",
-                            "number": "11:3"
+                            "checksum": "4ef42a17784ccf912f1917cdc894f87abaa5c3ae6bbc330e5d97884670ee69a3",
+                            "id": "fls_87jnkimc15gi",
+                            "link": "functions.html#fls_87jnkimc15gi",
+                            "number": "9:3"
                         },
                         {
-                            "checksum": "073aeb6b836eee108b5b6d5a5ded4f1b8df8ab96ec075686dca1d2b7fc6c1b34",
-                            "id": "fls_Mcpdzzcw43M7",
-                            "link": "implementations.html#fls_Mcpdzzcw43M7",
-                            "number": "11:4"
+                            "checksum": "1be13228840af974c47c9d4a16fb932edc3efcbbb1b5a5d8261d4eb3d4db1df5",
+                            "id": "fls_nwywh1vjt6rr",
+                            "link": "functions.html#fls_nwywh1vjt6rr",
+                            "number": "9:4"
                         },
                         {
-                            "checksum": "6d7038fd93f535f1a95c93f6917f3cebd5b30ad181afde8d89173856ec36d502",
-                            "id": "fls_v0n0bna40dqr",
-                            "link": "implementations.html#fls_v0n0bna40dqr",
-                            "number": "11:5"
+                            "checksum": "e7bbdbb6cf00db43de1e27fe5b39e71062d7737351b11ee44c1f02ab45beabfb",
+                            "id": "fls_uwuthzfgslif",
+                            "link": "functions.html#fls_uwuthzfgslif",
+                            "number": "9:5"
                         },
                         {
-                            "checksum": "e18c1caa38c5924e033a0026fc017b1c792df55f87c598c5783efe25cb62819f",
-                            "id": "fls_797etpdk5dyb",
-                            "link": "implementations.html#fls_797etpdk5dyb",
-                            "number": "11:6"
+                            "checksum": "d6307364051e9afc70d6e0e3e277a7a096ecb2eb1db51e356303d7ee87537a12",
+                            "id": "fls_ymeo93t4mz4",
+                            "link": "functions.html#fls_ymeo93t4mz4",
+                            "number": "9:6"
                         },
                         {
-                            "checksum": "74cac3914710c2f1a1f624a3c5a1c9aaf33da46b9946695f9bee4eaeb22c5e42",
-                            "id": "fls_ry3an0mwb63g",
-                            "link": "implementations.html#fls_ry3an0mwb63g",
-                            "number": "11:7"
+                            "checksum": "2119a7ea0e7b937c1318f8b7cb342aea3ec7249cab773a35ff4b8a0701d43f4b",
+                            "id": "fls_ijbt4tgnl95n",
+                            "link": "functions.html#fls_ijbt4tgnl95n",
+                            "number": "9:7"
                         },
                         {
-                            "checksum": "dd34aa75e7947124723372145385a391a6527acf3d57821cf6bfb3530926d0df",
-                            "id": "fls_8pwr7ibvhmhu",
-                            "link": "implementations.html#fls_8pwr7ibvhmhu",
-                            "number": "11:8"
+                            "checksum": "b7ee5ce366f421f0fae995e21d17b77d938b59f2f8a07975cb3aa3486b963304",
+                            "id": "fls_AAYJDCNMJgTq",
+                            "link": "functions.html#fls_AAYJDCNMJgTq",
+                            "number": "9:8"
                         },
                         {
-                            "checksum": "ba2818ea733c9b43c0160165759dc06495876220780d457240575201aebbf397",
-                            "id": "fls_47x0ep8of8wr",
-                            "link": "implementations.html#fls_47x0ep8of8wr",
-                            "number": "11:9"
+                            "checksum": "29b6ace4daea786064b460a8bf0c7ddbe2b6800631188e26b46177257bf8fa33",
+                            "id": "fls_PGtp39f6gJwU",
+                            "link": "functions.html#fls_PGtp39f6gJwU",
+                            "number": "9:9"
                         },
                         {
-                            "checksum": "8223ac177e0dcc171dbac1fb21b191141842026a92038b9694be40797d2bdad8",
-                            "id": "fls_agitlryvyc16",
-                            "link": "implementations.html#fls_agitlryvyc16",
-                            "number": "11:10"
+                            "checksum": "2205b3649789767c105c262228a48536d8d9af2734351fcab5e8650eed044f19",
+                            "id": "fls_yZ2yIXxmy2ri",
+                            "link": "functions.html#fls_yZ2yIXxmy2ri",
+                            "number": "9:10"
                         },
                         {
-                            "checksum": "0ecbb270fa78be720b325ddc3197182ea1ca39be3069bd7d37f201389c9b3991",
-                            "id": "fls_mx5xjcejwa6u",
-                            "link": "implementations.html#fls_mx5xjcejwa6u",
-                            "number": "11:11"
+                            "checksum": "00ff6766b53e2501ce67b57b21ac801f24b86208afab3a509a0cd92439b2f346",
+                            "id": "fls_35aSvBxBnIzm",
+                            "link": "functions.html#fls_35aSvBxBnIzm",
+                            "number": "9:11"
                         },
                         {
-                            "checksum": "7ec52a2c02f0e55bea6e0a3c728c22e5720e34bdeabc0740d52707774946acbe",
-                            "id": "fls_z78dg261oob6",
-                            "link": "implementations.html#fls_z78dg261oob6",
-                            "number": "11:12"
+                            "checksum": "d44af44daa180c96d7c066dd036be5c2217e9ef54e5440a28226f4155da1fbd9",
+                            "id": "fls_Ogziu8S01qPQ",
+                            "link": "functions.html#fls_Ogziu8S01qPQ",
+                            "number": "9:12"
                         },
                         {
-                            "checksum": "1f973a701dba719c9b5c7879e8f7e39c271e60ebd4708b781a5ec557ca35bb6b",
-                            "id": "fls_89yNjGNB7KI3",
-                            "link": "implementations.html#fls_89yNjGNB7KI3",
-                            "number": "11:13"
+                            "checksum": "e007c5d5fe350258fe85248f1a507b573c634bb18cf907d6b83babb1a8a98f5d",
+                            "id": "fls_xCSsxYUZUFed",
+                            "link": "functions.html#fls_xCSsxYUZUFed",
+                            "number": "9:13"
                         },
                         {
-                            "checksum": "94597e560f592f649b38ef27778a62819bc7e5c2e01faa0ef53fa29225d8083c",
-                            "id": "fls_yuyesijndu9n",
-                            "link": "implementations.html#fls_yuyesijndu9n",
-                            "number": "11:14"
+                            "checksum": "afcad007b988dd4e9a7ae77d05318b5818905bf05921cd7d14070abe83ebb9b2",
+                            "id": "fls_lxzinvqveuqh",
+                            "link": "functions.html#fls_lxzinvqveuqh",
+                            "number": "9:14"
                         },
                         {
-                            "checksum": "7093aa443b2d63b8c3ad1d99dc26a6f1df03d367428b954e62e372eab3d4f569",
-                            "id": "fls_o62i75sjzp9y",
-                            "link": "implementations.html#fls_o62i75sjzp9y",
-                            "number": "11:15"
+                            "checksum": "af44866222e3ba28adab818deff3cff0fe079c936325cb39ed958ac977eaf988",
+                            "id": "fls_kcAbTPZXQ5Y8",
+                            "link": "functions.html#fls_kcAbTPZXQ5Y8",
+                            "number": "9:15"
                         },
                         {
-                            "checksum": "8ad70788c23781cfbb4cc77f8e9b280870f2088b7f3522cf5adf7a4030b29b48",
-                            "id": "fls_a2utf0tmuhy4",
-                            "link": "implementations.html#fls_a2utf0tmuhy4",
-                            "number": "11:16"
+                            "checksum": "a6f8a428953b804ae4d9a530c1659087e99139633acc2e99d4315bf792bf123a",
+                            "id": "fls_PGDKWK7nPvgw",
+                            "link": "functions.html#fls_PGDKWK7nPvgw",
+                            "number": "9:16"
+                        },
+                        {
+                            "checksum": "681f0328a6e3f3599494c7ab05e29ca62e56c28c57ecde0bbe7cd5b96d6db84d",
+                            "id": "fls_o4uSLPo00KUg",
+                            "link": "functions.html#fls_o4uSLPo00KUg",
+                            "number": "9:17"
+                        },
+                        {
+                            "checksum": "2a3652b695660398bf0fcad1529e0346fed7c9fa6809502c46ecdb89c2bf93d6",
+                            "id": "fls_icdzs1mjh0n4",
+                            "link": "functions.html#fls_icdzs1mjh0n4",
+                            "number": "9:18"
+                        },
+                        {
+                            "checksum": "408643016febf0219e0809cd2e92e018cab38026b8e8612741262fc29b5daa00",
+                            "id": "fls_OR85NVifPwjr",
+                            "link": "functions.html#fls_OR85NVifPwjr",
+                            "number": "9:19"
+                        },
+                        {
+                            "checksum": "4bc2a2eb8ccee2c72bf5174dc901116ca5cf7ed223c6d8860b2bfbca11943925",
+                            "id": "fls_4s2IdfYDzPrX",
+                            "link": "functions.html#fls_4s2IdfYDzPrX",
+                            "number": "9:20"
+                        },
+                        {
+                            "checksum": "fca8a97c468b1b73283de8c4f98ad8e13873aba97f8c10a0392dab4826a7fe00",
+                            "id": "fls_ZJJppPfiJRou",
+                            "link": "functions.html#fls_ZJJppPfiJRou",
+                            "number": "9:21"
+                        },
+                        {
+                            "checksum": "7dd1d3308749e298f5b2a22e71ac500637ce35b2d9cf6ccf24634f53e2885f12",
+                            "id": "fls_jOyZh9ujWWHQ",
+                            "link": "functions.html#fls_jOyZh9ujWWHQ",
+                            "number": "9:22"
+                        },
+                        {
+                            "checksum": "99c1950124ddc4f31f88a1064b15e1cb78f9e374abb2eece4a801f0648c89300",
+                            "id": "fls_Xdr0bFwxhWiB",
+                            "link": "functions.html#fls_Xdr0bFwxhWiB",
+                            "number": "9:23"
+                        },
+                        {
+                            "checksum": "898ff3d8792a073b155387b8ee5e51b48f03b4ad15845d393f6162730578c4a3",
+                            "id": "fls_DpTFEHZAABdD",
+                            "link": "functions.html#fls_DpTFEHZAABdD",
+                            "number": "9:24"
+                        },
+                        {
+                            "checksum": "421ab0ac3cb998e26b832f6f921db20f8d80617dce79045d9906b460e2dbbadb",
+                            "id": "fls_b7FTlWfnX2OI",
+                            "link": "functions.html#fls_b7FTlWfnX2OI",
+                            "number": "9:25"
+                        },
+                        {
+                            "checksum": "eda198b5564690046f7225520acae5222abaccf175ac28f4c3b8b13d0d0bbf14",
+                            "id": "fls_6urL6fZ5cpaA",
+                            "link": "functions.html#fls_6urL6fZ5cpaA",
+                            "number": "9:26"
+                        },
+                        {
+                            "checksum": "513827ea79b2bb852e3a03fc1d52ad23aaa08dccee280c50059a7e31df7d6139",
+                            "id": "fls_TMOzb6cYIOlH",
+                            "link": "functions.html#fls_TMOzb6cYIOlH",
+                            "number": "9:27"
+                        },
+                        {
+                            "checksum": "15571a856ea4d62c8fe363b440ddf0f1a63e654322bf5c97a6fbc7973c16420e",
+                            "id": "fls_eHPWHrvs7ETl",
+                            "link": "functions.html#fls_eHPWHrvs7ETl",
+                            "number": "9:28"
+                        },
+                        {
+                            "checksum": "42a5a6b2aef837c0262688bbc4f2dae48d988fd49bcbcbcd7a84175224069dd8",
+                            "id": "fls_mjCrvmikm58M",
+                            "link": "functions.html#fls_mjCrvmikm58M",
+                            "number": "9:29"
+                        },
+                        {
+                            "checksum": "1b8b316d3d56bf10df2d8521160902a8137f08c3a5c8d39d5bf8f22900dac035",
+                            "id": "fls_4EUb9zFatZ97",
+                            "link": "functions.html#fls_4EUb9zFatZ97",
+                            "number": "9:30"
+                        },
+                        {
+                            "checksum": "a2e6957d275225e3cb26e75af5b4e0d3d31afa9b43a77eaef4117c78d920ac52",
+                            "id": "fls_4B4B5FIqAes9",
+                            "link": "functions.html#fls_4B4B5FIqAes9",
+                            "number": "9:31"
+                        },
+                        {
+                            "checksum": "b82bf4578023aa2218ec01202b93d193cbb48fd8b53d740a5c9d3bb482caaf10",
+                            "id": "fls_vljy4mm0zca2",
+                            "link": "functions.html#fls_vljy4mm0zca2",
+                            "number": "9:32"
+                        },
+                        {
+                            "checksum": "b89caf540730b919c47a1f20bdd5dc9302aca3ec99300e25098600be2e706acf",
+                            "id": "fls_EqJb3Jl3vK8K",
+                            "link": "functions.html#fls_EqJb3Jl3vK8K",
+                            "number": "9:33"
+                        },
+                        {
+                            "checksum": "e2ca22f3a68ea69c89d5499ab8bfaff4ea879242e37d601e8b78939484e3fbd9",
+                            "id": "fls_C7dvzcXcpQCy",
+                            "link": "functions.html#fls_C7dvzcXcpQCy",
+                            "number": "9:34"
+                        },
+                        {
+                            "checksum": "2f2202efc417e1cd3118f5b446cf8c8a375b6e5f8ebaed72a0201aa9d161578a",
+                            "id": "fls_J8X8ahnJLrMo",
+                            "link": "functions.html#fls_J8X8ahnJLrMo",
+                            "number": "9:35"
+                        },
+                        {
+                            "checksum": "f01d77c3faa9dafff3f5a3ca3928a29d60e2867a2438140aaaa4cbceb25da31b",
+                            "id": "fls_927nfm5mkbsp",
+                            "link": "functions.html#fls_927nfm5mkbsp",
+                            "number": "9:36"
+                        },
+                        {
+                            "checksum": "a8e601de98599b419876278ab5521c5cc49ae6bfdacfe061350c283e236e211f",
+                            "id": "fls_yfm0jh62oaxr",
+                            "link": "functions.html#fls_yfm0jh62oaxr",
+                            "number": "9:37"
+                        },
+                        {
+                            "checksum": "45189d0422353cd31d5e3d1460ac0bf25731cc9f464574e6acf3ba0a8661dffb",
+                            "id": "fls_bHwy8FLzEUi3",
+                            "link": "functions.html#fls_bHwy8FLzEUi3",
+                            "number": "9:38"
+                        },
+                        {
+                            "checksum": "1952dd7798e9fd4d8fb5f525eedc05613f2ef1a660b93bfa8f24167e67f839bb",
+                            "id": "fls_5Q861wb08DU3",
+                            "link": "functions.html#fls_5Q861wb08DU3",
+                            "number": "9:39"
+                        },
+                        {
+                            "checksum": "a336a489c323ad22b7aa3059350a2400bb8e41f5eef6ce02b17682c438a9fd09",
+                            "id": "fls_owdlsaaygtho",
+                            "link": "functions.html#fls_owdlsaaygtho",
+                            "number": "9:40"
+                        },
+                        {
+                            "checksum": "4355b34dd22393af15f6fad33ae3c69fc7091736b751b78d2b18cb15ceb7b3cc",
+                            "id": "fls_2049qu3ji5x7",
+                            "link": "functions.html#fls_2049qu3ji5x7",
+                            "number": "9:41"
+                        },
+                        {
+                            "checksum": "515666a67e5b60858568348fd8b4c6021e49484b778d6ccd6c357f9b792643d1",
+                            "id": "fls_7mlanuh5mvpn",
+                            "link": "functions.html#fls_7mlanuh5mvpn",
+                            "number": "9:42"
+                        },
+                        {
+                            "checksum": "4ccbc87469f1565c32bef31f5909da4c2b2f1febaf71e3b0216053540e2732c4",
+                            "id": "fls_otr3hgp8lj1q",
+                            "link": "functions.html#fls_otr3hgp8lj1q",
+                            "number": "9:43"
+                        },
+                        {
+                            "checksum": "45a75ca66fc48e3abbe4a9b46d1599f9ecbcfae9fbc5df35e1b5d8939f41f8c4",
+                            "id": "fls_m3jiunibqj81",
+                            "link": "functions.html#fls_m3jiunibqj81",
+                            "number": "9:44"
+                        },
+                        {
+                            "checksum": "388876fffc5a50a274a155691b5fe0142ca2651fe1ce20d17301a9682d3638f6",
+                            "id": "fls_7vogmqyd87ey",
+                            "link": "functions.html#fls_7vogmqyd87ey",
+                            "number": "9:45"
+                        },
+                        {
+                            "checksum": "a0ec3be9336e08cd1fca0ed1ac63762201261a4c25b465370a9c89d2c35e0647",
+                            "id": "fls_7ucwmzqtittv",
+                            "link": "functions.html#fls_7ucwmzqtittv",
+                            "number": "9:46"
+                        },
+                        {
+                            "checksum": "77e3105531c29da1bb23103569cc04ef5d3377e723b9f8adcf7603d91463ceae",
+                            "id": "fls_nUADhgcfvvGC",
+                            "link": "functions.html#fls_nUADhgcfvvGC",
+                            "number": "9:47"
+                        },
+                        {
+                            "checksum": "fbf5fb05e9efc647400ab22d0002c1bc09b999d239850236501817c8374a143c",
+                            "id": "fls_5hn8fkf7rcvz",
+                            "link": "functions.html#fls_5hn8fkf7rcvz",
+                            "number": "9:48"
                         }
                     ],
-                    "title": "Implementations"
-                },
-                {
-                    "id": "fls_46ork6fz5o2e",
-                    "informational": false,
-                    "link": "implementations.html#implementation-coherence",
-                    "number": "11.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "f593f63f6406327889e137ab55ec05d98a6d439176ec14afafae261241a14f1c",
-                            "id": "fls_fv1l4yjuut7p",
-                            "link": "implementations.html#fls_fv1l4yjuut7p",
-                            "number": "11.1:1"
-                        },
-                        {
-                            "checksum": "1452e1e4d864f7a4178e6f1be77e9694766805cd6a0556f67f5314caf0a5d8de",
-                            "id": "fls_swdusjwzgksx",
-                            "link": "implementations.html#fls_swdusjwzgksx",
-                            "number": "11.1:2"
-                        },
-                        {
-                            "checksum": "9763aff40d5e4ca431a133884a391a71d1e3434b2dd8e6ab1c928ba846346526",
-                            "id": "fls_ir7hp941ky8t",
-                            "link": "implementations.html#fls_ir7hp941ky8t",
-                            "number": "11.1:3"
-                        },
-                        {
-                            "checksum": "3a7e9191eb41e4bba88408faba2f7f149137b7df440996588e945fad99c82867",
-                            "id": "fls_3tbm20k2ixol",
-                            "link": "implementations.html#fls_3tbm20k2ixol",
-                            "number": "11.1:4"
-                        },
-                        {
-                            "checksum": "46b1fe27e9a10a5a463205624c88ba78b4851fbf47c3d1e31d45026df49b1774",
-                            "id": "fls_lscc9ileg3gm",
-                            "link": "implementations.html#fls_lscc9ileg3gm",
-                            "number": "11.1:5"
-                        },
-                        {
-                            "checksum": "90514614f2da8202c20d849b7c71d72ae95423a582d7fcb612d03343c5ce1b8a",
-                            "id": "fls_9klwbsh3vlxu",
-                            "link": "implementations.html#fls_9klwbsh3vlxu",
-                            "number": "11.1:6"
-                        },
-                        {
-                            "checksum": "79f486e433c0cc3589e42f1efbdc6df12866131778c2b136b5be7d27ff1b67ec",
-                            "id": "fls_9gmc1tcscq9v",
-                            "link": "implementations.html#fls_9gmc1tcscq9v",
-                            "number": "11.1:7"
-                        },
-                        {
-                            "checksum": "6b6dac78cb7d28fe378157a5827ca98ef8996833871c9acbbad28e04b8781132",
-                            "id": "fls_UkQhjEWSJpDq",
-                            "link": "implementations.html#fls_UkQhjEWSJpDq",
-                            "number": "11.1:8"
-                        },
-                        {
-                            "checksum": "cbf8117eb6e59dd31ff3217f236513679c4236d8d108c4451693dfdeb766d3d2",
-                            "id": "fls_fSybUG40hA5r",
-                            "link": "implementations.html#fls_fSybUG40hA5r",
-                            "number": "11.1:9"
-                        },
-                        {
-                            "checksum": "35936abe2e47a3f84e6b97c5b8773f0e57035b2a2311e2ec92b001e91f057096",
-                            "id": "fls_z8APl0CEF7a0",
-                            "link": "implementations.html#fls_z8APl0CEF7a0",
-                            "number": "11.1:10"
-                        },
-                        {
-                            "checksum": "16c8bf3ad79c585e2a19ab5043608ba5cdfbe59b334ba09913fe7cb101ef98a0",
-                            "id": "fls_RJJafhpVsi6M",
-                            "link": "implementations.html#fls_RJJafhpVsi6M",
-                            "number": "11.1:11"
-                        },
-                        {
-                            "checksum": "bd35a79daaebf148b48f637a939718b4e78fe6d95ec05e092dabf33c372e5045",
-                            "id": "fls_dtUJxhNkl8Ty",
-                            "link": "implementations.html#fls_dtUJxhNkl8Ty",
-                            "number": "11.1:12"
-                        },
-                        {
-                            "checksum": "8e6a64bbe4e6692fa29ab6cab825bed32aa92944541ab8b3cab95f46ec47ae1a",
-                            "id": "fls_zJKovQrXQWdU",
-                            "link": "implementations.html#fls_zJKovQrXQWdU",
-                            "number": "11.1:13"
-                        },
-                        {
-                            "checksum": "881eb7081d32bca6dd31a402732083c1a10cfbb0703d65d4903481c9df0fa6cc",
-                            "id": "fls_V6R8yQtsqNyv",
-                            "link": "implementations.html#fls_V6R8yQtsqNyv",
-                            "number": "11.1:14"
-                        },
-                        {
-                            "checksum": "0bff693cd5c7bd24006d97966faf22d8ad51776dd27b155aa3c4c53705f1e230",
-                            "id": "fls_CpC6XQN1iWqU",
-                            "link": "implementations.html#fls_CpC6XQN1iWqU",
-                            "number": "11.1:15"
-                        },
-                        {
-                            "checksum": "3a1f51af690831f150b9917ff7ed785fc0ad8572bfdb024cbbe419e2b1536063",
-                            "id": "fls_dj7YGw4e4i4H",
-                            "link": "implementations.html#fls_dj7YGw4e4i4H",
-                            "number": "11.1:16"
-                        },
-                        {
-                            "checksum": "a69a7eba188277ac25d75030529f9289094778fd2d87d38a1ed7ab9c1871938e",
-                            "id": "fls_koy70k770ayu",
-                            "link": "implementations.html#fls_koy70k770ayu",
-                            "number": "11.1:17"
-                        }
-                    ],
-                    "title": "Implementation Coherence"
-                },
-                {
-                    "id": "fls_e1pgdlv81vul",
-                    "informational": false,
-                    "link": "implementations.html#implementation-conformance",
-                    "number": "11.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "235dcfef5a150c402f42c33dd6eabd7189375ddb2bb8e3cd3cc162fe22a53e9a",
-                            "id": "fls_YyUSuAYG4lX6",
-                            "link": "implementations.html#fls_YyUSuAYG4lX6",
-                            "number": "11.2:1"
-                        },
-                        {
-                            "checksum": "5f1a4f88e1dd9fd77d93c773080c7b2e8fa3179f7d8e4de72e39d0ff16a2a387",
-                            "id": "fls_v31idwjau90d",
-                            "link": "implementations.html#fls_v31idwjau90d",
-                            "number": "11.2:2"
-                        },
-                        {
-                            "checksum": "f18161b732608a6732ea2886b4c609dc56b7dde6df16c57cf321542c887aa1d8",
-                            "id": "fls_k3wfh5japmyw",
-                            "link": "implementations.html#fls_k3wfh5japmyw",
-                            "number": "11.2:3"
-                        },
-                        {
-                            "checksum": "428b016d82301c34cac20a058d8e9f87628abcd977fc4d1ff1557bc1bf2d24f8",
-                            "id": "fls_11qrqfuc3rmh",
-                            "link": "implementations.html#fls_11qrqfuc3rmh",
-                            "number": "11.2:4"
-                        },
-                        {
-                            "checksum": "7e921c53c7799271e80ccbadf2d47a340d1ef1bd9326fe4e2bdf54e5dcf2d127",
-                            "id": "fls_qmhduwunxww0",
-                            "link": "implementations.html#fls_qmhduwunxww0",
-                            "number": "11.2:5"
-                        },
-                        {
-                            "checksum": "aa4594177b713ab6ee2d502e2c0f20256ac5a5e546fab64bcc52db72ee407c5d",
-                            "id": "fls_2500ivh0cc3y",
-                            "link": "implementations.html#fls_2500ivh0cc3y",
-                            "number": "11.2:6"
-                        },
-                        {
-                            "checksum": "f3fb2ce2caeb76b89e224e1c88594d2dc95ddc66e180f8cb6d50b428f01eedcf",
-                            "id": "fls_18gimgfy0kw9",
-                            "link": "implementations.html#fls_18gimgfy0kw9",
-                            "number": "11.2:7"
-                        },
-                        {
-                            "checksum": "0b6f276c677931c78d760ff5def7e67a7e4cbd817e1f21f0343edb674c80e0b4",
-                            "id": "fls_fi4qmauirlsm",
-                            "link": "implementations.html#fls_fi4qmauirlsm",
-                            "number": "11.2:8"
-                        },
-                        {
-                            "checksum": "31bad81c5be19c117a8675a891a00247edb13fe1ab49a36e1f439da9b3123b6f",
-                            "id": "fls_2s8lh3k4rw6u",
-                            "link": "implementations.html#fls_2s8lh3k4rw6u",
-                            "number": "11.2:9"
-                        },
-                        {
-                            "checksum": "fe5486ca02f9ffadaed847c11ea13af8afba0eb18ea38527ec5b8cc5d45cbf83",
-                            "id": "fls_bb874uu2alt3",
-                            "link": "implementations.html#fls_bb874uu2alt3",
-                            "number": "11.2:10"
-                        },
-                        {
-                            "checksum": "43150bf6a5f61f75ca365a77174d7d659f67e1c8cd00dcd74b3f72cdc7282045",
-                            "id": "fls_so8em6rphkhv",
-                            "link": "implementations.html#fls_so8em6rphkhv",
-                            "number": "11.2:11"
-                        },
-                        {
-                            "checksum": "2928f339f8abfbe9b10de44c5ab57f730fdc2e7881dc3cce685844a2ada75373",
-                            "id": "fls_ldu9bmb9cy10",
-                            "link": "implementations.html#fls_ldu9bmb9cy10",
-                            "number": "11.2:12"
-                        },
-                        {
-                            "checksum": "1a07917d9eeb24596f2800e26f4930f6ecc94fc0027f33f7cce840c026ee28a5",
-                            "id": "fls_5cr6un2gzdft",
-                            "link": "implementations.html#fls_5cr6un2gzdft",
-                            "number": "11.2:13"
-                        },
-                        {
-                            "checksum": "dc51b8a6f90c2e32e2ec099057c7d4745f9082e4521e0f0cb64ba03ac87c95ed",
-                            "id": "fls_pshfe3ioh0mg",
-                            "link": "implementations.html#fls_pshfe3ioh0mg",
-                            "number": "11.2:14"
-                        },
-                        {
-                            "checksum": "bc54fae0d59dee07617ca65931de1869df56a18c8afe575dcc287c8d2d9305ed",
-                            "id": "fls_8yq1g7nzv9px",
-                            "link": "implementations.html#fls_8yq1g7nzv9px",
-                            "number": "11.2:15"
-                        }
-                    ],
-                    "title": "Implementation Conformance"
+                    "title": "Functions"
                 }
             ],
-            "title": "Implementations"
-        },
-        {
-            "informational": true,
-            "link": "general.html",
-            "sections": [
-                {
-                    "id": "fls_48qldfwwh493",
-                    "informational": false,
-                    "link": "general.html",
-                    "number": "1",
-                    "paragraphs": [
-                        {
-                            "checksum": "b56c8be8103d8226bbdec210a97ca8f2c38405d36f65f17b15936a1a8284b26c",
-                            "id": "fls_c4ry0kgmvk9z",
-                            "link": "general.html#fls_c4ry0kgmvk9z",
-                            "number": "1:1"
-                        },
-                        {
-                            "checksum": "4a8fd448c0e40fd0675f5d82c36b6f963f99259021c6022cc9bd5104c20fbdeb",
-                            "id": "fls_gxqbj0qoiaio",
-                            "link": "general.html#fls_gxqbj0qoiaio",
-                            "number": "1:2"
-                        },
-                        {
-                            "checksum": "02be35a62aff5e48d56d3fb05c75ade724aff55d6ad8278715bd7fac8adbe03f",
-                            "id": "fls_u8k9zr8da30",
-                            "link": "general.html#fls_u8k9zr8da30",
-                            "number": "1:3"
-                        },
-                        {
-                            "checksum": "11a39a0b407d0ca45db7639f588e85fe27910624c6c508283f983229a6aad5db",
-                            "id": "fls_8mt9iigoboba",
-                            "link": "general.html#fls_8mt9iigoboba",
-                            "number": "1:4"
-                        },
-                        {
-                            "checksum": "cd1b728c4e56af1dd90836a76afce9239d07ea2aa3095cbeedf8693a22f14caf",
-                            "id": "fls_suhf2g3fatfa",
-                            "link": "general.html#fls_suhf2g3fatfa",
-                            "number": "1:5"
-                        },
-                        {
-                            "checksum": "8b4dce11b14d66a6a1177ef131384957fe6a887c388d56a1902e09ee60f80af0",
-                            "id": "fls_jjr5kbn0wuco",
-                            "link": "general.html#fls_jjr5kbn0wuco",
-                            "number": "1:6"
-                        },
-                        {
-                            "checksum": "3a278c9aaaabec045a6eede8eb5a0beab745d8b84b098a39b6cdf2e167bc5178",
-                            "id": "fls_4dfcjyprkzbx",
-                            "link": "general.html#fls_4dfcjyprkzbx",
-                            "number": "1:7"
-                        },
-                        {
-                            "checksum": "1e02dbccc64818a6cebcc7d6331d8281a24621e813178d0f5be9d0b3356c7a22",
-                            "id": "fls_tq9jcv5ddvwn",
-                            "link": "general.html#fls_tq9jcv5ddvwn",
-                            "number": "1:8"
-                        }
-                    ],
-                    "title": "General"
-                },
-                {
-                    "id": "fls_fo1c7pg2mw1",
-                    "informational": false,
-                    "link": "general.html#scope",
-                    "number": "1.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "cd56fca25aa434be193f4140fb7a1cd61650876d6446d93d81093eaad448d442",
-                            "id": "fls_srdq4mota5pr",
-                            "link": "general.html#fls_srdq4mota5pr",
-                            "number": "1.1:1"
-                        },
-                        {
-                            "checksum": "b3cdec704c28577193c03cd2eb90cec360e5651ed07b259d112673a67dc0200d",
-                            "id": "fls_dv1qish8svc",
-                            "link": "general.html#fls_dv1qish8svc",
-                            "number": "1.1:2"
-                        }
-                    ],
-                    "title": "Scope"
-                },
-                {
-                    "id": "fls_10yukmkhl0ng",
-                    "informational": false,
-                    "link": "general.html#extent",
-                    "number": "1.1.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "07358ef439d78086f970b0606b6da177cb6cc2e64318f27af92832c21a67be43",
-                            "id": "fls_x78yd1sszydv",
-                            "link": "general.html#fls_x78yd1sszydv",
-                            "number": "1.1.1:1"
-                        },
-                        {
-                            "checksum": "818ed40aac2e52250ea0014e5de7fbcbcf1e8f325b74a015ac0085699523a43d",
-                            "id": "fls_9e032738udnb",
-                            "link": "general.html#fls_9e032738udnb",
-                            "number": "1.1.1:2"
-                        },
-                        {
-                            "checksum": "85861dc839d41712fe2a39712eb1dcfd1dc88ba30f3782f92bd1986fe355c196",
-                            "id": "fls_jk7scu5xs17z",
-                            "link": "general.html#fls_jk7scu5xs17z",
-                            "number": "1.1.1:3"
-                        },
-                        {
-                            "checksum": "dc11c0150f1c1ea89b5e2e31e3d90c45c62fa5d26005eb9ed3a16e3f7a3fb68c",
-                            "id": "fls_jiryupa5fxgf",
-                            "link": "general.html#fls_jiryupa5fxgf",
-                            "number": "1.1.1:4"
-                        },
-                        {
-                            "checksum": "4ce6c16caad38e7ccb47adc109089c53cc047073ebba0a06457cbeded05f68e0",
-                            "id": "fls_sph1a3sapinh",
-                            "link": "general.html#fls_sph1a3sapinh",
-                            "number": "1.1.1:5"
-                        },
-                        {
-                            "checksum": "7c348ba84b24afee5a0a39c44f15af8c05a07208877750c9a766d44ab767da7b",
-                            "id": "fls_7tm19jxtffc8",
-                            "link": "general.html#fls_7tm19jxtffc8",
-                            "number": "1.1.1:6"
-                        },
-                        {
-                            "checksum": "585a289861cd9b12366dc2314022378903323fea3cdbd6863a2e5bd96ed69446",
-                            "id": "fls_5pbrl8lhuth1",
-                            "link": "general.html#fls_5pbrl8lhuth1",
-                            "number": "1.1.1:7"
-                        },
-                        {
-                            "checksum": "fc97ac93c58134f54e07f9f6ff5334dbf3afdc8b1e707525ddd8eb232a915c74",
-                            "id": "fls_o8fc3e53vp7g",
-                            "link": "general.html#fls_o8fc3e53vp7g",
-                            "number": "1.1.1:8"
-                        },
-                        {
-                            "checksum": "8adc0c63aa968e623b7251ecc0776057325470f81d39879bb6dfb23d1985a407",
-                            "id": "fls_rw0y5t13y6gs",
-                            "link": "general.html#fls_rw0y5t13y6gs",
-                            "number": "1.1.1:9"
-                        },
-                        {
-                            "checksum": "2f2276e84ea3e0251d343a2c859bafeefc4eb09d8d7222774ce538650c01980b",
-                            "id": "fls_x7c3o621qj9z",
-                            "link": "general.html#fls_x7c3o621qj9z",
-                            "number": "1.1.1:10"
-                        },
-                        {
-                            "checksum": "cd7a1f68c81b43b8536b355596a13da9ddc2e33d7b37a18af00eee2456c3fd06",
-                            "id": "fls_5y2b6yjcl1vz",
-                            "link": "general.html#fls_5y2b6yjcl1vz",
-                            "number": "1.1.1:11"
-                        },
-                        {
-                            "checksum": "a695d7fe1b36b6516b8530ec034376b8c43e7aa53cd0795f48e39482be5a38cf",
-                            "id": "fls_8dennhk2dha",
-                            "link": "general.html#fls_8dennhk2dha",
-                            "number": "1.1.1:12"
-                        },
-                        {
-                            "checksum": "65c2d0a375d2b29b8836f90cfdf174fc8fe72f5198073097bb9401add5d0880b",
-                            "id": "fls_j2gs3hrbxtyx",
-                            "link": "general.html#fls_j2gs3hrbxtyx",
-                            "number": "1.1.1:13"
-                        },
-                        {
-                            "checksum": "94c8f2e37b34e95fffa62df717bbcd7d87653a8506a65f52d91e1706e0dfe9d8",
-                            "id": "fls_gy2c7vfwkd8j",
-                            "link": "general.html#fls_gy2c7vfwkd8j",
-                            "number": "1.1.1:14"
-                        }
-                    ],
-                    "title": "Extent"
-                },
-                {
-                    "id": "fls_xscgklvg1wd2",
-                    "informational": false,
-                    "link": "general.html#structure",
-                    "number": "1.1.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "9d1641a50a597e4ce0553ceca94bbf6c254d57933639a13b9b13f852c10f4640",
-                            "id": "fls_6lrqailxjb02",
-                            "link": "general.html#fls_6lrqailxjb02",
-                            "number": "1.1.2:1"
-                        },
-                        {
-                            "checksum": "13aa072e39fbda618587953663ec86d1a188fe0eb4db97252b906ca8e9c2fe51",
-                            "id": "fls_tys7ciqnp8bn",
-                            "link": "general.html#fls_tys7ciqnp8bn",
-                            "number": "1.1.2:2"
-                        },
-                        {
-                            "checksum": "934ba26ee073ed0a5cbaf9b98cf9005d3786c907b9de25f60f31c18a1d5ddb1c",
-                            "id": "fls_3ubhkaheu8i1",
-                            "link": "general.html#fls_3ubhkaheu8i1",
-                            "number": "1.1.2:3"
-                        },
-                        {
-                            "checksum": "b9623aca56a3fe17319f63a0b550b6405ad21f99012d17ae6f6ce41d1f1605d4",
-                            "id": "fls_xw3grr2g5zgi",
-                            "link": "general.html#fls_xw3grr2g5zgi",
-                            "number": "1.1.2:4"
-                        },
-                        {
-                            "checksum": "11c90805ef23752a416f5a6a8b69230febfdf97b68edaf26f6517bd359492443",
-                            "id": "fls_6srbinvnyd54",
-                            "link": "general.html#fls_6srbinvnyd54",
-                            "number": "1.1.2:5"
-                        },
-                        {
-                            "checksum": "fdcfcebd0c9395a151b773b35ef5d5e2720a08080c54f279652f7668a0182897",
-                            "id": "fls_ciixfg9jhv42",
-                            "link": "general.html#fls_ciixfg9jhv42",
-                            "number": "1.1.2:6"
-                        },
-                        {
-                            "checksum": "25a56f970c722a9217989c3250b9b75798453ac229d32dc74b97c2a6c84a2109",
-                            "id": "fls_ej94lm2682kg",
-                            "link": "general.html#fls_ej94lm2682kg",
-                            "number": "1.1.2:7"
-                        },
-                        {
-                            "checksum": "1531d2cfb29ab712e3adf7fc798c2342b8977bae5175dda990efd578592d2454",
-                            "id": "fls_xgk91jrbpyoc",
-                            "link": "general.html#fls_xgk91jrbpyoc",
-                            "number": "1.1.2:8"
-                        },
-                        {
-                            "checksum": "db3c5f8206004bb2cca82ca219a417ec2a4fe259773ae667ab3d10114d5740ee",
-                            "id": "fls_jc4upf6685bw",
-                            "link": "general.html#fls_jc4upf6685bw",
-                            "number": "1.1.2:9"
-                        },
-                        {
-                            "checksum": "1594b619675d7802bccfee40ca10262be9916e29f70d8f7fecbf5dddd00246f4",
-                            "id": "fls_oxzjqxgejx9t",
-                            "link": "general.html#fls_oxzjqxgejx9t",
-                            "number": "1.1.2:10"
-                        },
-                        {
-                            "checksum": "acf02a4a250adb8e29284b356a6f4a386a936d32f0e85d3b304e708863f10929",
-                            "id": "fls_gmx688d6ek1o",
-                            "link": "general.html#fls_gmx688d6ek1o",
-                            "number": "1.1.2:11"
-                        },
-                        {
-                            "checksum": "7f053104dd4947498f1bb5121b9fe28a23d78ead65d37dd580df0111d558d8dd",
-                            "id": "fls_5zdjikp1jhc",
-                            "link": "general.html#fls_5zdjikp1jhc",
-                            "number": "1.1.2:12"
-                        },
-                        {
-                            "checksum": "44025e9b54bdddecd35c847f5628ffddbfc9e4721cd733f41c9186c904ef15b1",
-                            "id": "fls_as5bhc5t285g",
-                            "link": "general.html#fls_as5bhc5t285g",
-                            "number": "1.1.2:13"
-                        },
-                        {
-                            "checksum": "6efef41c7a703e3b3562b12e95047110a954b19026060d22099de222c142ed8b",
-                            "id": "fls_70qjvaqoz007",
-                            "link": "general.html#fls_70qjvaqoz007",
-                            "number": "1.1.2:14"
-                        },
-                        {
-                            "checksum": "525edc88be77e71d6777eef00907902bcd024abb3c401a92d67f1ca997971c5a",
-                            "id": "fls_o4rdsbc7u98",
-                            "link": "general.html#fls_o4rdsbc7u98",
-                            "number": "1.1.2:15"
-                        },
-                        {
-                            "checksum": "3ab99fa52627e6796ca7e01a7242052885523e5e0f93b9dd98ec22d483688e60",
-                            "id": "fls_w8j575w2hmc8",
-                            "link": "general.html#fls_w8j575w2hmc8",
-                            "number": "1.1.2:16"
-                        }
-                    ],
-                    "title": "Structure"
-                },
-                {
-                    "id": "fls_99b7xi1bkgih",
-                    "informational": false,
-                    "link": "general.html#conformity",
-                    "number": "1.1.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "42aa78f31bd39d9d54d95d846fc09f42910052efc6f2cb7eb50a7b34706f7c97",
-                            "id": "fls_kdyqtnc6loam",
-                            "link": "general.html#fls_kdyqtnc6loam",
-                            "number": "1.1.3:1"
-                        },
-                        {
-                            "checksum": "1b1e377b795c593c09c9e640deb4d270fad22997bd2c697ee3bb4b3c4109ecca",
-                            "id": "fls_dBKu9jgx3OyH",
-                            "link": "general.html#fls_dBKu9jgx3OyH",
-                            "number": "1.1.3:2"
-                        },
-                        {
-                            "checksum": "8ade643b2872a946f749a6125849c9d9af29cb64ca9c611b05332fae6c4ceacb",
-                            "id": "fls_faRvWyJJpno8",
-                            "link": "general.html#fls_faRvWyJJpno8",
-                            "number": "1.1.3:3"
-                        },
-                        {
-                            "checksum": "581e966a0c27c9ea6c0cbfb6d1bf739d24fb579f2495fc002947b3e93977c231",
-                            "id": "fls_GZmxrO61eiJ1",
-                            "link": "general.html#fls_GZmxrO61eiJ1",
-                            "number": "1.1.3:4"
-                        },
-                        {
-                            "checksum": "1f8c2956cb9f8b946f0f56053a038a9ab8efaf6dd7881bb5d1d65e1c87b05900",
-                            "id": "fls_nnmx2qsu14ft",
-                            "link": "general.html#fls_nnmx2qsu14ft",
-                            "number": "1.1.3:5"
-                        },
-                        {
-                            "checksum": "adb8b69470c26508c51b735aa65a30d464dae4eecafb85f3cad7b62450557213",
-                            "id": "fls_gu3331rmv2ho",
-                            "link": "general.html#fls_gu3331rmv2ho",
-                            "number": "1.1.3:6"
-                        },
-                        {
-                            "checksum": "030c86e984b66288b589337553d3375d3fdecc0dfab304381123495642596b20",
-                            "id": "fls_AR8ZIYlDRSNs",
-                            "link": "general.html#fls_AR8ZIYlDRSNs",
-                            "number": "1.1.3:7"
-                        },
-                        {
-                            "checksum": "09785f4e7f3719f15b9790de8e8388bce97f35323591af71ed34b453c9b2ef30",
-                            "id": "fls_xAYhvEh7WWel",
-                            "link": "general.html#fls_xAYhvEh7WWel",
-                            "number": "1.1.3:8"
-                        },
-                        {
-                            "checksum": "01a005ca17491af3519bb4e745fbef2a83ce55109d5787034a94659c1dd03f36",
-                            "id": "fls_QvFpU8v5p8Hb",
-                            "link": "general.html#fls_QvFpU8v5p8Hb",
-                            "number": "1.1.3:9"
-                        },
-                        {
-                            "checksum": "849ea928df375ac126378ee4fd16534119a4f03f42721cd25145edc4d7850294",
-                            "id": "fls_pl0fyjcwslqm",
-                            "link": "general.html#fls_pl0fyjcwslqm",
-                            "number": "1.1.3:10"
-                        },
-                        {
-                            "checksum": "534de23af559805d2b96e284fdd9afc9838e9e3f65b120c5401aa7cf130d439b",
-                            "id": "fls_lkdm0mdghppv",
-                            "link": "general.html#fls_lkdm0mdghppv",
-                            "number": "1.1.3:11"
-                        },
-                        {
-                            "checksum": "f87533ba7b47cb56f59c27e8d99d031d3c5c35b16c4d3ae271ddb9b3ee18c33b",
-                            "id": "fls_d07x1mbhgpsd",
-                            "link": "general.html#fls_d07x1mbhgpsd",
-                            "number": "1.1.3:12"
-                        }
-                    ],
-                    "title": "Conformity"
-                },
-                {
-                    "id": "fls_79rl6ylmct07",
-                    "informational": false,
-                    "link": "general.html#method-of-description-and-syntax-notation",
-                    "number": "1.1.4",
-                    "paragraphs": [
-                        {
-                            "checksum": "8811c1ef8e9707861f67d171dc813cc290188343fde68d68304072ab9d422c41",
-                            "id": "fls_mc4a28do6kcp",
-                            "link": "general.html#fls_mc4a28do6kcp",
-                            "number": "1.1.4:1"
-                        },
-                        {
-                            "checksum": "e62cf2d485b81b81793c685b6fef64ad6d407da40349a45129bfd298fb8d0258",
-                            "id": "fls_ioyp4wux6skt",
-                            "link": "general.html#fls_ioyp4wux6skt",
-                            "number": "1.1.4:2"
-                        },
-                        {
-                            "checksum": "5be24f2bcda1727c3b6e1ad27d2d7c8ffe6e487d292f2b48bd528e411c2ae1be",
-                            "id": "fls_jsflt7691ye4",
-                            "link": "general.html#fls_jsflt7691ye4",
-                            "number": "1.1.4:3"
-                        },
-                        {
-                            "checksum": "15f27fa3164d4f34e687dff0589a9406f64fd304a5cbac1d917e215a3420b24d",
-                            "id": "fls_98fm7z04lq9",
-                            "link": "general.html#fls_98fm7z04lq9",
-                            "number": "1.1.4:4"
-                        },
-                        {
-                            "checksum": "bf197e4e3db74f8f9189b2d39392b793c47f8e26908e5ff493a91d3567e2e58d",
-                            "id": "fls_ceb5a8t6cakr",
-                            "link": "general.html#fls_ceb5a8t6cakr",
-                            "number": "1.1.4:5"
-                        },
-                        {
-                            "checksum": "e53521056d56c3f85475811368708e304047e64d39a20604584fa7f38d9c7f86",
-                            "id": "fls_pts29mb5ld68",
-                            "link": "general.html#fls_pts29mb5ld68",
-                            "number": "1.1.4:6"
-                        },
-                        {
-                            "checksum": "48013ee45666937c8ad55fb39de161c383ead549216e3bdc9e2882e83bcf0a90",
-                            "id": "fls_gqjo5oh7vn3b",
-                            "link": "general.html#fls_gqjo5oh7vn3b",
-                            "number": "1.1.4:7"
-                        },
-                        {
-                            "checksum": "f6d36c515bd4436ca87447bc369bb7b1c69b50ca9215b1d6981dabce39f33593",
-                            "id": "fls_1dz634xp8xp5",
-                            "link": "general.html#fls_1dz634xp8xp5",
-                            "number": "1.1.4:8"
-                        },
-                        {
-                            "checksum": "949f3857c5bbb056b780f44c08df02afc05d59db42be92d94a86c97a20ae4943",
-                            "id": "fls_pp9vtjlyblrl",
-                            "link": "general.html#fls_pp9vtjlyblrl",
-                            "number": "1.1.4:9"
-                        },
-                        {
-                            "checksum": "d7b7b2e401f1bc24ffd16c1f417d18c3d12336cc2d2325ecc1c07d77ea0e513e",
-                            "id": "fls_6e2vd9fvhsmk",
-                            "link": "general.html#fls_6e2vd9fvhsmk",
-                            "number": "1.1.4:10"
-                        },
-                        {
-                            "checksum": "0eda08ae37976f0d7d15570d790c9bc3107ea4533794e554872ea0d77af06d9c",
-                            "id": "fls_4onq0kkrt6qv",
-                            "link": "general.html#fls_4onq0kkrt6qv",
-                            "number": "1.1.4:11"
-                        },
-                        {
-                            "checksum": "bf1b757e4fec099109dc75529b8709e0177c379698e8c762c5c27fe8fe0ac2d3",
-                            "id": "fls_qu4rsmnq659w",
-                            "link": "general.html#fls_qu4rsmnq659w",
-                            "number": "1.1.4:12"
-                        },
-                        {
-                            "checksum": "ca3586f81ab3962899f5a1a79386ef8637003025a729a5b76bebdb5d1e43cb28",
-                            "id": "fls_rllu7aksf17e",
-                            "link": "general.html#fls_rllu7aksf17e",
-                            "number": "1.1.4:13"
-                        },
-                        {
-                            "checksum": "87380f5c66b721c614a404b1852a6c1f93b93d02b04517c8be6e401f85832f82",
-                            "id": "fls_blvsfqeevosr",
-                            "link": "general.html#fls_blvsfqeevosr",
-                            "number": "1.1.4:14"
-                        },
-                        {
-                            "checksum": "d05cec36bfece44c3203af30f098975bd0f3d0cccd9687f0956cd9eca66c810f",
-                            "id": "fls_lwcjq3wzjyvb",
-                            "link": "general.html#fls_lwcjq3wzjyvb",
-                            "number": "1.1.4:15"
-                        },
-                        {
-                            "checksum": "9a579e74f8de12da445c5197e2555aab86fc739d0defc1f685c0aa5dfb44cebc",
-                            "id": "fls_v7wd5yk00im6",
-                            "link": "general.html#fls_v7wd5yk00im6",
-                            "number": "1.1.4:16"
-                        },
-                        {
-                            "checksum": "afb0e775413f09199a584413d501b6ec88d107c1be87cac6e07bc33ecce6ad74",
-                            "id": "fls_nf8alga8uz6c",
-                            "link": "general.html#fls_nf8alga8uz6c",
-                            "number": "1.1.4:17"
-                        }
-                    ],
-                    "title": "Method of Description and Syntax Notation"
-                },
-                {
-                    "id": "fls_9cd746qe40ag",
-                    "informational": false,
-                    "link": "general.html#versioning",
-                    "number": "1.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "ac30f10574356a3a3472c8858b8b13e8b8ef034312c5823a3674a594b4e4e468",
-                            "id": "fls_l80e3kdwnldc",
-                            "link": "general.html#fls_l80e3kdwnldc",
-                            "number": "1.2:1"
-                        }
-                    ],
-                    "title": "Versioning"
-                },
-                {
-                    "id": "fls_ijzgf4h0mp3c",
-                    "informational": false,
-                    "link": "general.html#definitions",
-                    "number": "1.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "34f82930e1b6b4af471b30519f81d43725341882ad0a3e8e36d85ab7b3f5713b",
-                            "id": "fls_sm2kexes5pr7",
-                            "link": "general.html#fls_sm2kexes5pr7",
-                            "number": "1.3:1"
-                        },
-                        {
-                            "checksum": "397ee14d96917a0a9033a587347a2246e4118f1270d64cce0f7eefeeaf565980",
-                            "id": "fls_2o98zw29xc46",
-                            "link": "general.html#fls_2o98zw29xc46",
-                            "number": "1.3:2"
-                        },
-                        {
-                            "checksum": "969a1f3b691a3118abcd815618a71feba07fdd5be4c2a12ce37d0b49595d013a",
-                            "id": "fls_lon5qffd65fi",
-                            "link": "general.html#fls_lon5qffd65fi",
-                            "number": "1.3:3"
-                        },
-                        {
-                            "checksum": "0d6e2d5075e9ccebe0f79ee2d1d393c07fae6b8d4b6cbf7fbf59b1348185fc5d",
-                            "id": "fls_qeolgxvcy75",
-                            "link": "general.html#fls_qeolgxvcy75",
-                            "number": "1.3:4"
-                        },
-                        {
-                            "checksum": "70b86c11c1708aa3d4d6b52af002352aebaef77835c4b45ebc4233a789844230",
-                            "id": "fls_h2m244agxaxs",
-                            "link": "general.html#fls_h2m244agxaxs",
-                            "number": "1.3:5"
-                        },
-                        {
-                            "checksum": "c669dced28f1bb44dbac7e17e855e184b1f14baecfa15e22b21d2379a5998be6",
-                            "id": "fls_47svine904xk",
-                            "link": "general.html#fls_47svine904xk",
-                            "number": "1.3:6"
-                        }
-                    ],
-                    "title": "Definitions"
-                }
-            ],
-            "title": "General"
+            "title": "Functions"
         },
         {
             "informational": false,
@@ -20893,100 +20340,175 @@
                     "title": "Borrow Expression"
                 },
                 {
+                    "id": "fls_vxguvrwolbee",
+                    "informational": false,
+                    "link": "expressions.html#raw-borrow-expression",
+                    "number": "6.5.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "b814a9dc3d1a1ae28c4f466bc7f6fd0f2cc398c5143dd1dcee45e6d0b560437a",
+                            "id": "fls_TS6DvMon5h27",
+                            "link": "expressions.html#fls_TS6DvMon5h27",
+                            "number": "6.5.2:1"
+                        },
+                        {
+                            "checksum": "d334a2ea162c08a078c9efc96c54353ef243a320da1fd9b5bc5e34daf57fa170",
+                            "id": "fls_UtjWrE2qeplQ",
+                            "link": "expressions.html#fls_UtjWrE2qeplQ",
+                            "number": "6.5.2:2"
+                        },
+                        {
+                            "checksum": "6beab888d8d4e129466aace5f4c4d4f0a64c369b021794667ee23cced979415a",
+                            "id": "fls_4e7EE4a8Yvmy",
+                            "link": "expressions.html#fls_4e7EE4a8Yvmy",
+                            "number": "6.5.2:3"
+                        },
+                        {
+                            "checksum": "53bac137d0858ec7798957d5b5f811dafdc5533e54987f7f4ae62fc781c20de6",
+                            "id": "fls_gOXUWePymgGV",
+                            "link": "expressions.html#fls_gOXUWePymgGV",
+                            "number": "6.5.2:4"
+                        },
+                        {
+                            "checksum": "65c60bbe30206c4ae6a03c51cde6e5c3ec57379e3447a75bc2039f6b3e9377de",
+                            "id": "fls_YBC8GrIBzZbi",
+                            "link": "expressions.html#fls_YBC8GrIBzZbi",
+                            "number": "6.5.2:5"
+                        },
+                        {
+                            "checksum": "6794a4fddaa7211478879f5cdd3ae1c71df8de74d488900101a10651053b94d4",
+                            "id": "fls_Twkre8IzUa8S",
+                            "link": "expressions.html#fls_Twkre8IzUa8S",
+                            "number": "6.5.2:6"
+                        },
+                        {
+                            "checksum": "c25b5c85bea772da45b8bbde270d8e9d0c815f2033ee2999da28bf4d44abd7b8",
+                            "id": "fls_Ki4FOzJMqtvJ",
+                            "link": "expressions.html#fls_Ki4FOzJMqtvJ",
+                            "number": "6.5.2:7"
+                        },
+                        {
+                            "checksum": "03f1f3f42dac7107312066bd913be7d440b55121130a80d435439cce504429ae",
+                            "id": "fls_DJxQDBsO9hc7",
+                            "link": "expressions.html#fls_DJxQDBsO9hc7",
+                            "number": "6.5.2:8"
+                        },
+                        {
+                            "checksum": "0e8388d16705508711d3aa9c46c8130b8545d7596fb8b731db0a05119c249858",
+                            "id": "fls_WlXB0AHifCdd",
+                            "link": "expressions.html#fls_WlXB0AHifCdd",
+                            "number": "6.5.2:9"
+                        },
+                        {
+                            "checksum": "a3e29c3e339b22b3ed3f65266a969681e92a742e338b7866361d8519390d386c",
+                            "id": "fls_qQrV8QuGGcVO",
+                            "link": "expressions.html#fls_qQrV8QuGGcVO",
+                            "number": "6.5.2:10"
+                        },
+                        {
+                            "checksum": "7752805d169b4ea002c92d0b378112418e8556fd751db36982e0a87c1575999c",
+                            "id": "fls_dTABiwAPGhdZ",
+                            "link": "expressions.html#fls_dTABiwAPGhdZ",
+                            "number": "6.5.2:11"
+                        }
+                    ],
+                    "title": "Raw Borrow Expression"
+                },
+                {
                     "id": "fls_5cm4gkt55hjh",
                     "informational": false,
                     "link": "expressions.html#dereference-expression",
-                    "number": "6.5.2",
+                    "number": "6.5.3",
                     "paragraphs": [
                         {
                             "checksum": "2ca9af25277c175fa9ab6b0b74a4ba46f5038fd562befbd363a40be6ba27d2dc",
                             "id": "fls_f6wktzofzdn1",
                             "link": "expressions.html#fls_f6wktzofzdn1",
-                            "number": "6.5.2:1"
+                            "number": "6.5.3:1"
                         },
                         {
                             "checksum": "9a5b1f7e7d7d38a721fe16a98b61e35a54dcc7c07d9828ea2e2248bef356dd07",
                             "id": "fls_aeh5pzpcjveq",
                             "link": "expressions.html#fls_aeh5pzpcjveq",
-                            "number": "6.5.2:2"
+                            "number": "6.5.3:2"
                         },
                         {
                             "checksum": "b7a8de951a21c65d72d8a668a0e505a25388b7e5a5e2e183d7b9f9e04269c213",
                             "id": "fls_9cc0ml2sru6x",
                             "link": "expressions.html#fls_9cc0ml2sru6x",
-                            "number": "6.5.2:3"
+                            "number": "6.5.3:3"
                         },
                         {
                             "checksum": "279107e1bd6cf6fbda8a96631d179989aea331a986c05395e205d44a9386d427",
                             "id": "fls_8i4jzksxlrw0",
                             "link": "expressions.html#fls_8i4jzksxlrw0",
-                            "number": "6.5.2:4"
+                            "number": "6.5.3:4"
                         },
                         {
                             "checksum": "46cd3d16ac76ee2960c5568740cf587ad2c6ceed1218114e80c3a9bb47df7a63",
                             "id": "fls_d68ddlse4zp",
                             "link": "expressions.html#fls_d68ddlse4zp",
-                            "number": "6.5.2:5"
+                            "number": "6.5.3:5"
                         },
                         {
                             "checksum": "82ab49fac0f518382455ae1ff105c18fc25eac3f8ac00ffc53deff57a0b75dcc",
                             "id": "fls_g73vguanbs1x",
                             "link": "expressions.html#fls_g73vguanbs1x",
-                            "number": "6.5.2:6"
+                            "number": "6.5.3:6"
                         },
                         {
                             "checksum": "bdc85222a07f89578d68b14e06ee8d7f4e4cd516e7c70ceef67645f2d88b625b",
                             "id": "fls_8ibfqxtnahzx",
                             "link": "expressions.html#fls_8ibfqxtnahzx",
-                            "number": "6.5.2:7"
+                            "number": "6.5.3:7"
                         },
                         {
                             "checksum": "4b76624fefafbe89f67f9634f8671e9768189ba2be891749d2cae7f88061857f",
                             "id": "fls_7e7tka4f2f1a",
                             "link": "expressions.html#fls_7e7tka4f2f1a",
-                            "number": "6.5.2:8"
+                            "number": "6.5.3:8"
                         },
                         {
                             "checksum": "1f706d90689273d6cd3ac4319f378aef1bf50f62e07e0596cca8a78f8ef5e23f",
                             "id": "fls_y9bc691kkh6v",
                             "link": "expressions.html#fls_y9bc691kkh6v",
-                            "number": "6.5.2:9"
+                            "number": "6.5.3:9"
                         },
                         {
                             "checksum": "a7e8224d319471b493644e345b6551b79a0646cd520f3e10b8edf2bfec6a1f84",
                             "id": "fls_gw49nukfveib",
                             "link": "expressions.html#fls_gw49nukfveib",
-                            "number": "6.5.2:10"
+                            "number": "6.5.3:10"
                         },
                         {
                             "checksum": "5bd3c5f7bd491a7f42f8c2da78d2064ae8679d448dc019897996d49374b0e175",
                             "id": "fls_jjf3sz9ddfhy",
                             "link": "expressions.html#fls_jjf3sz9ddfhy",
-                            "number": "6.5.2:11"
+                            "number": "6.5.3:11"
                         },
                         {
                             "checksum": "a1370288ab9df6143029b28cc57c082c16176e3bc260e846bb35545f9fe1d8d5",
                             "id": "fls_fyend8kkpqq4",
                             "link": "expressions.html#fls_fyend8kkpqq4",
-                            "number": "6.5.2:12"
+                            "number": "6.5.3:12"
                         },
                         {
                             "checksum": "b22770ba76b69e3248df639840e98bc59ca865e515da69cc327b84d83d318b43",
                             "id": "fls_72bpdsxxbgeq",
                             "link": "expressions.html#fls_72bpdsxxbgeq",
-                            "number": "6.5.2:13"
+                            "number": "6.5.3:13"
                         },
                         {
                             "checksum": "1082cd3a0c4e2cab05c42e2cf9fcd73902c976d592285073adbf4663ec94947a",
                             "id": "fls_9wgldua1u8yt",
                             "link": "expressions.html#fls_9wgldua1u8yt",
-                            "number": "6.5.2:14"
+                            "number": "6.5.3:14"
                         },
                         {
                             "checksum": "5e5ef6637f5645209cfecb5cdf406f57bb31eac2cd9fe496b170e087f86c8c53",
                             "id": "fls_9ifaterm8nop",
                             "link": "expressions.html#fls_9ifaterm8nop",
-                            "number": "6.5.2:15"
+                            "number": "6.5.3:15"
                         }
                     ],
                     "title": "Dereference Expression"
@@ -20995,55 +20517,55 @@
                     "id": "fls_pocsh1neugpc",
                     "informational": false,
                     "link": "expressions.html#error-propagation-expression",
-                    "number": "6.5.3",
+                    "number": "6.5.4",
                     "paragraphs": [
                         {
                             "checksum": "23b7bdb3a6bc1804b5be08868bde733e2b7a97ae0804d7cbc06aea2b59fd6e1d",
                             "id": "fls_8q59wbumrt5s",
                             "link": "expressions.html#fls_8q59wbumrt5s",
-                            "number": "6.5.3:1"
+                            "number": "6.5.4:1"
                         },
                         {
                             "checksum": "c321eada04f83e7afc3cece805698fd21bfa268dd8753424a0c7a6659cf9987d",
                             "id": "fls_mq2h4seoxah",
                             "link": "expressions.html#fls_mq2h4seoxah",
-                            "number": "6.5.3:2"
+                            "number": "6.5.4:2"
                         },
                         {
                             "checksum": "4376b53a0608338ed35c699ced660ca17be38885f5a09a0ced75087fa8c069a9",
                             "id": "fls_ab4vhq4nwn7f",
                             "link": "expressions.html#fls_ab4vhq4nwn7f",
-                            "number": "6.5.3:3"
+                            "number": "6.5.4:3"
                         },
                         {
                             "checksum": "20839942bb00d91e6bb509c17f8e66b69b91f16691c9ab64b82c867f3ae550ff",
                             "id": "fls_z4zikxy2b1em",
                             "link": "expressions.html#fls_z4zikxy2b1em",
-                            "number": "6.5.3:4"
+                            "number": "6.5.4:4"
                         },
                         {
                             "checksum": "a7e8462f6f54586f7016c7be8dece9195cc5ffddcb493c00d9c08dcb1947b255",
                             "id": "fls_a09614kgsspt",
                             "link": "expressions.html#fls_a09614kgsspt",
-                            "number": "6.5.3:5"
+                            "number": "6.5.4:5"
                         },
                         {
                             "checksum": "f98b5452ecf7b2c43aecf121ed351e093743b91ca044e66b807228b56f80051e",
                             "id": "fls_8df018q7y6g",
                             "link": "expressions.html#fls_8df018q7y6g",
-                            "number": "6.5.3:6"
+                            "number": "6.5.4:6"
                         },
                         {
                             "checksum": "9694b3fa6f2fe93dc54f3037b9f53322423ad65d56ae4f6fc00870750dcb0919",
                             "id": "fls_alk4qvfprnvy",
                             "link": "expressions.html#fls_alk4qvfprnvy",
-                            "number": "6.5.3:7"
+                            "number": "6.5.4:7"
                         },
                         {
                             "checksum": "c3d4fd6b18a382defd7363f2c15d2f5d8517d65814a943df98884ccd5012b7e8",
                             "id": "fls_1nnhjcgy8kdh",
                             "link": "expressions.html#fls_1nnhjcgy8kdh",
-                            "number": "6.5.3:8"
+                            "number": "6.5.4:8"
                         }
                     ],
                     "title": "Error Propagation Expression"
@@ -21052,145 +20574,145 @@
                     "id": "fls_wrecura8u5ar",
                     "informational": false,
                     "link": "expressions.html#negation-expression",
-                    "number": "6.5.4",
+                    "number": "6.5.5",
                     "paragraphs": [
                         {
                             "checksum": "af3d9baa2e989c7389736af89273f065db34e0a05d834471606dd19b2928db1d",
                             "id": "fls_pfa81kv2mru8",
                             "link": "expressions.html#fls_pfa81kv2mru8",
-                            "number": "6.5.4:1"
+                            "number": "6.5.5:1"
                         },
                         {
                             "checksum": "4f80e3b87fba67c8d18e93636623e678e1374f94eca9dc69a5534fae37565c34",
                             "id": "fls_plcut8vzdwox",
                             "link": "expressions.html#fls_plcut8vzdwox",
-                            "number": "6.5.4:2"
+                            "number": "6.5.5:2"
                         },
                         {
                             "checksum": "40bf9e05f58749baa5c051ffb2c5e5f8305e58040cd7962de9ad7e669a433737",
                             "id": "fls_ohu0kljfexd3",
                             "link": "expressions.html#fls_ohu0kljfexd3",
-                            "number": "6.5.4:3"
+                            "number": "6.5.5:3"
                         },
                         {
                             "checksum": "c83826e3c7c0a48c572c71ec116e3678b134a80964cb0ded4dee83772bf37e4a",
                             "id": "fls_ghqvj8q71o97",
                             "link": "expressions.html#fls_ghqvj8q71o97",
-                            "number": "6.5.4:4"
+                            "number": "6.5.5:4"
                         },
                         {
                             "checksum": "f58980cc43c3a695e066d1fb882e84d2936c9fc0a9199a672a18e2c278af8165",
                             "id": "fls_3m4mgqnzqhri",
                             "link": "expressions.html#fls_3m4mgqnzqhri",
-                            "number": "6.5.4:5"
+                            "number": "6.5.5:5"
                         },
                         {
                             "checksum": "b610ac74d0d701146031a0ac67bb95dd11a032f059a4c2c7e7b2fd03bc2dd5d1",
                             "id": "fls_u7gzm6n75rzm",
                             "link": "expressions.html#fls_u7gzm6n75rzm",
-                            "number": "6.5.4:6"
+                            "number": "6.5.5:6"
                         },
                         {
                             "checksum": "afd2c64f1c23556dffbaa7b63b76751e5b52d1c9ea207d1c640cdec6d97bbd57",
                             "id": "fls_9rmq7iaf092d",
                             "link": "expressions.html#fls_9rmq7iaf092d",
-                            "number": "6.5.4:7"
+                            "number": "6.5.5:7"
                         },
                         {
                             "checksum": "e14bc33ac51819c14cf0968eead2fd2eb5cb0c7027e5b0b9bcf7ce69add7edbb",
                             "id": "fls_yzt6pcsvj3a",
                             "link": "expressions.html#fls_yzt6pcsvj3a",
-                            "number": "6.5.4:8"
+                            "number": "6.5.5:8"
                         },
                         {
                             "checksum": "f63fca54c6f85459e84fdb4b1ce37d60655697a990bf2eae4b9bea18af1a3f15",
                             "id": "fls_8tgxtprtifrr",
                             "link": "expressions.html#fls_8tgxtprtifrr",
-                            "number": "6.5.4:9"
+                            "number": "6.5.5:9"
                         },
                         {
                             "checksum": "b3e235b910132fd26dffacdb2bad28a792618698a524bd1dd1a6be6065711fa2",
                             "id": "fls_rFFlt33a5RsZ",
                             "link": "expressions.html#fls_rFFlt33a5RsZ",
-                            "number": "6.5.4:10"
+                            "number": "6.5.5:10"
                         },
                         {
                             "checksum": "2c69bf1f447be7c6df6d51e2133843f0d576ab8a81ceb6e4f855ee26ff691a2a",
                             "id": "fls_h7pIl1WZ8Y2t",
                             "link": "expressions.html#fls_h7pIl1WZ8Y2t",
-                            "number": "6.5.4:11"
+                            "number": "6.5.5:11"
                         },
                         {
                             "checksum": "caaeeebd8c8b53c85a4aad7b3c42754cdc3a758b53183433bb57e22937db33f5",
                             "id": "fls_yfK3pGHzUo3x",
                             "link": "expressions.html#fls_yfK3pGHzUo3x",
-                            "number": "6.5.4:12"
+                            "number": "6.5.5:12"
                         },
                         {
                             "checksum": "a9d1fe3dff0cedd21947b255165dadfcf588c30c40a43c6e6ba0c3ec8e196f23",
                             "id": "fls_dcNtgLq2hRZb",
                             "link": "expressions.html#fls_dcNtgLq2hRZb",
-                            "number": "6.5.4:13"
+                            "number": "6.5.5:13"
                         },
                         {
                             "checksum": "6904a946fe2693b6f425ca86a92fede53c0fe6cecc8598127afffce5d7e62417",
                             "id": "fls_sxLwuITs62sN",
                             "link": "expressions.html#fls_sxLwuITs62sN",
-                            "number": "6.5.4:14"
+                            "number": "6.5.5:14"
                         },
                         {
                             "checksum": "aa3cfae510c0f630768b3fdad3056728d6d46645a5e5bc33ed5aae965d9e8029",
                             "id": "fls_gn3dnuxm2h8m",
                             "link": "expressions.html#fls_gn3dnuxm2h8m",
-                            "number": "6.5.4:15"
+                            "number": "6.5.5:15"
                         },
                         {
                             "checksum": "ff435742ce6e2e0ff8240946adf104bd9fcb520098854aa859d04c41ea02d3c0",
                             "id": "fls_tsou6yz4mfte",
                             "link": "expressions.html#fls_tsou6yz4mfte",
-                            "number": "6.5.4:16"
+                            "number": "6.5.5:16"
                         },
                         {
                             "checksum": "4bcd968eda46af59fcb1ea1f55864281f8b0cde92d38561595d95b4e9ac3dd07",
                             "id": "fls_zdfgqky85r1f",
                             "link": "expressions.html#fls_zdfgqky85r1f",
-                            "number": "6.5.4:17"
+                            "number": "6.5.5:17"
                         },
                         {
                             "checksum": "edfa0f8419b3a73e3ff24890c87fd1fd92c6dc6d8818c3fcce02ab05b6c8c1ab",
                             "id": "fls_CutpaCFCGHQs",
                             "link": "expressions.html#fls_CutpaCFCGHQs",
-                            "number": "6.5.4:18"
+                            "number": "6.5.5:18"
                         },
                         {
                             "checksum": "c8effecc440dcf91f96f42e0f04584a5610c1561c24791e2c23b26be12ab80d9",
                             "id": "fls_B2eKGWaJhFKD",
                             "link": "expressions.html#fls_B2eKGWaJhFKD",
-                            "number": "6.5.4:19"
+                            "number": "6.5.5:19"
                         },
                         {
                             "checksum": "8220fff5ef4bb72a0a7dc8f99cfe17f5e5aad6d75e146b2f33ed793b920e580c",
                             "id": "fls_uldh10k77sng",
                             "link": "expressions.html#fls_uldh10k77sng",
-                            "number": "6.5.4:20"
+                            "number": "6.5.5:20"
                         },
                         {
                             "checksum": "a643ba42ae84b70ad7aa7f9e7f43587505202b559c0101e5a40a6823d243e69f",
                             "id": "fls_uo6vv2yf8usx",
                             "link": "expressions.html#fls_uo6vv2yf8usx",
-                            "number": "6.5.4:21"
+                            "number": "6.5.5:21"
                         },
                         {
                             "checksum": "7de9ba1051942b5d4a885fe293560881297b7f87eb22ce3a2900d5c4dddb0326",
                             "id": "fls_hbrg0d98jak5",
                             "link": "expressions.html#fls_hbrg0d98jak5",
-                            "number": "6.5.4:22"
+                            "number": "6.5.5:22"
                         },
                         {
                             "checksum": "5b41d324bf22e4bf196369e2e07e6371340536763b0d1ba7370c3b9ce1e1a3a4",
                             "id": "fls_kqtr9c3jorvg",
                             "link": "expressions.html#fls_kqtr9c3jorvg",
-                            "number": "6.5.4:23"
+                            "number": "6.5.5:23"
                         }
                     ],
                     "title": "Negation Expression"
@@ -21199,307 +20721,307 @@
                     "id": "fls_1k9mkv7rbezi",
                     "informational": false,
                     "link": "expressions.html#arithmetic-expressions",
-                    "number": "6.5.5",
+                    "number": "6.5.6",
                     "paragraphs": [
                         {
                             "checksum": "b0a840a217c602a32cf2e1de752852f1c490c0319cf7abad57d81b59e98690c6",
                             "id": "fls_asibqpe3z95h",
                             "link": "expressions.html#fls_asibqpe3z95h",
-                            "number": "6.5.5:1"
+                            "number": "6.5.6:1"
                         },
                         {
                             "checksum": "7d12112b7a06954bb102320e6b09a084143173d1e444b53abae9c5fccccf151a",
                             "id": "fls_kr8Opj3c7uvb",
                             "link": "expressions.html#fls_kr8Opj3c7uvb",
-                            "number": "6.5.5:2"
+                            "number": "6.5.6:2"
                         },
                         {
                             "checksum": "46e89deb7d936eb2f027aa97f89cfc72b95b5306f81da17435cd5da27b51a05d",
                             "id": "fls_8imzo7agyx0k",
                             "link": "expressions.html#fls_8imzo7agyx0k",
-                            "number": "6.5.5:3"
+                            "number": "6.5.6:3"
                         },
                         {
                             "checksum": "088bf6586c416b8d73b9bfa95d095905a510685c6833c5e231abb1553f25ba1f",
                             "id": "fls_vk17mfv47wk9",
                             "link": "expressions.html#fls_vk17mfv47wk9",
-                            "number": "6.5.5:4"
+                            "number": "6.5.6:4"
                         },
                         {
                             "checksum": "5138acfb60759a1f7d1612cce1be84b6ac9130f47b5c8d8d88bc1f7fa0699d8c",
                             "id": "fls_ryzhdpxgm7ii",
                             "link": "expressions.html#fls_ryzhdpxgm7ii",
-                            "number": "6.5.5:5"
+                            "number": "6.5.6:5"
                         },
                         {
                             "checksum": "c6aae217015f2015f44b8e8dd7508277c0d50120b59d841ff0bde78814a6b441",
                             "id": "fls_dstca76y08ge",
                             "link": "expressions.html#fls_dstca76y08ge",
-                            "number": "6.5.5:6"
+                            "number": "6.5.6:6"
                         },
                         {
                             "checksum": "c84f922867411ee27c2da0f8d55a04f3f4d18514100b2ddc009d42f43f232702",
                             "id": "fls_f1puss9t4btz",
                             "link": "expressions.html#fls_f1puss9t4btz",
-                            "number": "6.5.5:7"
+                            "number": "6.5.6:7"
                         },
                         {
                             "checksum": "ff004ef562c5a5b41f9f7107ffdbbeaec5b9a4f9e5dbfae68f63162161d2e595",
                             "id": "fls_5rdrkvspw57z",
                             "link": "expressions.html#fls_5rdrkvspw57z",
-                            "number": "6.5.5:8"
+                            "number": "6.5.6:8"
                         },
                         {
                             "checksum": "9a473e780a8fde1608816f5ffbb7b41a753411ca82e0752b8963a1997ab35638",
                             "id": "fls_thyq4h55mx55",
                             "link": "expressions.html#fls_thyq4h55mx55",
-                            "number": "6.5.5:9"
+                            "number": "6.5.6:9"
                         },
                         {
                             "checksum": "f9820d8865637e75d0948c7fc41784afa25e79d0df7479395cdc2e53e968549d",
                             "id": "fls_kf41bphvlse3",
                             "link": "expressions.html#fls_kf41bphvlse3",
-                            "number": "6.5.5:10"
+                            "number": "6.5.6:10"
                         },
                         {
                             "checksum": "2b94a36c8d16c7f222b29a99dbbaca845c851d263d6323bb9ae6717955d14294",
                             "id": "fls_hrml95g2txcj",
                             "link": "expressions.html#fls_hrml95g2txcj",
-                            "number": "6.5.5:11"
+                            "number": "6.5.6:11"
                         },
                         {
                             "checksum": "3bc776fd70017a15281d825de3a03c484a509ed361cfb8e529f3a23268837e0b",
                             "id": "fls_ittf4yggk7do",
                             "link": "expressions.html#fls_ittf4yggk7do",
-                            "number": "6.5.5:12"
+                            "number": "6.5.6:12"
                         },
                         {
                             "checksum": "c8ccb208ad9374a8fa9ac34680b8e8ce1fc4e958169b4470ef74cc9cd4116772",
                             "id": "fls_ylqm6wucq2sw",
                             "link": "expressions.html#fls_ylqm6wucq2sw",
-                            "number": "6.5.5:13"
+                            "number": "6.5.6:13"
                         },
                         {
                             "checksum": "40ba6bc4bf5bc64bbf7bdfb7c5bb2be20c50a808893a34a661e9d1453659455f",
                             "id": "fls_3de9ulyzuoa",
                             "link": "expressions.html#fls_3de9ulyzuoa",
-                            "number": "6.5.5:14"
+                            "number": "6.5.6:14"
                         },
                         {
                             "checksum": "3b601294fdc29f47f2d5ea41a53e52158852777635e4e18a61e75b50b4de6e21",
                             "id": "fls_8fbhreyynhid",
                             "link": "expressions.html#fls_8fbhreyynhid",
-                            "number": "6.5.5:15"
+                            "number": "6.5.6:15"
                         },
                         {
                             "checksum": "d5668e3304bc1aac1a9ad7af00aa04e0bab58efad11cd1aee9b877a2ef767129",
                             "id": "fls_u3jwnrqun5kl",
                             "link": "expressions.html#fls_u3jwnrqun5kl",
-                            "number": "6.5.5:16"
+                            "number": "6.5.6:16"
                         },
                         {
                             "checksum": "a801683b49252019ce410e48c11333d669a2e57b9117c6704ffc4f631d98c802",
                             "id": "fls_2ude3wrxji2p",
                             "link": "expressions.html#fls_2ude3wrxji2p",
-                            "number": "6.5.5:17"
+                            "number": "6.5.6:17"
                         },
                         {
                             "checksum": "bc454d1b317c9bc88ad24d821d1e58f9bb10101e1f3e45c7a547cbf1897358a5",
                             "id": "fls_aalxhbvu8kdi",
                             "link": "expressions.html#fls_aalxhbvu8kdi",
-                            "number": "6.5.5:18"
+                            "number": "6.5.6:18"
                         },
                         {
                             "checksum": "11788f05059c59c58cc708654df290bdcff239b6a6b7a3b84598208a77c99b92",
                             "id": "fls_fjcv1nm8tlgf",
                             "link": "expressions.html#fls_fjcv1nm8tlgf",
-                            "number": "6.5.5:19"
+                            "number": "6.5.6:19"
                         },
                         {
                             "checksum": "eca372870d1bb0bc4b820ac177e1b3b7998233a674e7b8397e72d4be23ab0170",
                             "id": "fls_9x2i1zlsm364",
                             "link": "expressions.html#fls_9x2i1zlsm364",
-                            "number": "6.5.5:20"
+                            "number": "6.5.6:20"
                         },
                         {
                             "checksum": "af587b33a56e6a0002edb893987596f76450639deab12d69c665eba6f4bb5f89",
                             "id": "fls_v8vekngd27sz",
                             "link": "expressions.html#fls_v8vekngd27sz",
-                            "number": "6.5.5:21"
+                            "number": "6.5.6:21"
                         },
                         {
                             "checksum": "17701cdba21c6e0baca8f595115ec320e5814b7d0382db5afd011e4815284d9d",
                             "id": "fls_5nsa9zefz9cv",
                             "link": "expressions.html#fls_5nsa9zefz9cv",
-                            "number": "6.5.5:22"
+                            "number": "6.5.6:22"
                         },
                         {
                             "checksum": "ae993e16ae5bc5ab9b01feb24dcc0507bcdfa1575b222fb56cc069f149fb55a2",
                             "id": "fls_u3pstd6xe43y",
                             "link": "expressions.html#fls_u3pstd6xe43y",
-                            "number": "6.5.5:23"
+                            "number": "6.5.6:23"
                         },
                         {
                             "checksum": "73f75644381d149ce6f4e854dd91d95133658735ed4344352f260f806357124a",
                             "id": "fls_jjmc1xgny77",
                             "link": "expressions.html#fls_jjmc1xgny77",
-                            "number": "6.5.5:24"
+                            "number": "6.5.6:24"
                         },
                         {
                             "checksum": "719727efa5d31656dd271a750d883da510fd0dc91a365c055995293e5f4b1d8f",
                             "id": "fls_NcLf4o1dpniS",
                             "link": "expressions.html#fls_NcLf4o1dpniS",
-                            "number": "6.5.5:25"
+                            "number": "6.5.6:25"
                         },
                         {
                             "checksum": "fc135beb54169cc69ddc3205939375bc09adf919e1015819ef3c4d508636e056",
                             "id": "fls_cayhj5hcuhcg",
                             "link": "expressions.html#fls_cayhj5hcuhcg",
-                            "number": "6.5.5:26"
+                            "number": "6.5.6:26"
                         },
                         {
                             "checksum": "45d80850a6d4d455e0d832ccecc3f62d2cebab16d21c41babb61a0500e491507",
                             "id": "fls_43knkymqpj7t",
                             "link": "expressions.html#fls_43knkymqpj7t",
-                            "number": "6.5.5:27"
+                            "number": "6.5.6:27"
                         },
                         {
                             "checksum": "64f326ea0a4ae3117a4678bc9f29eb8da3ffea2053d4d4b342158d5de10d3751",
                             "id": "fls_62gpbubfj30w",
                             "link": "expressions.html#fls_62gpbubfj30w",
-                            "number": "6.5.5:28"
+                            "number": "6.5.6:28"
                         },
                         {
                             "checksum": "4eb93bef00f0c77a5e6ded4b73a4411de3d1597f25e03442d385e8953d179f60",
                             "id": "fls_bveocgaagk1n",
                             "link": "expressions.html#fls_bveocgaagk1n",
-                            "number": "6.5.5:29"
+                            "number": "6.5.6:29"
                         },
                         {
                             "checksum": "c1f131262cc203adffef07cdfd70f939f8e44411b208a3a26e4a8dce1179ae53",
                             "id": "fls_zLroZh43MOtN",
                             "link": "expressions.html#fls_zLroZh43MOtN",
-                            "number": "6.5.5:30"
+                            "number": "6.5.6:30"
                         },
                         {
                             "checksum": "064cfcf4cae6ce4f05d3725a102c1dcef135894bd8cb96bdb7429edfb31ecb0a",
                             "id": "fls_Q9dhNiICGIfr",
                             "link": "expressions.html#fls_Q9dhNiICGIfr",
-                            "number": "6.5.5:31"
+                            "number": "6.5.6:31"
                         },
                         {
                             "checksum": "70fac8b1be1736648aaaa9fee2cab2c655084d862482bc22f6e296c2ab467a7d",
                             "id": "fls_albbLSTYtmyq",
                             "link": "expressions.html#fls_albbLSTYtmyq",
-                            "number": "6.5.5:32"
+                            "number": "6.5.6:32"
                         },
                         {
                             "checksum": "6fd272034cea2fe81833c14eaafe524e4a0767be0c73c47320bcf29b97784202",
                             "id": "fls_qd6ggdgq2hob",
                             "link": "expressions.html#fls_qd6ggdgq2hob",
-                            "number": "6.5.5:33"
+                            "number": "6.5.6:33"
                         },
                         {
                             "checksum": "d0809b66e9fdbbcf0f3f653dea3e490c17584873374daea4e4ca8cf7fb66ab6f",
                             "id": "fls_lr2a21v5en59",
                             "link": "expressions.html#fls_lr2a21v5en59",
-                            "number": "6.5.5:34"
+                            "number": "6.5.6:34"
                         },
                         {
                             "checksum": "c2e708f49bc1463e1f2c04def2f0b217a259a1886909d4af2b6e4abd63af421d",
                             "id": "fls_kpbxcdaflb06",
                             "link": "expressions.html#fls_kpbxcdaflb06",
-                            "number": "6.5.5:35"
+                            "number": "6.5.6:35"
                         },
                         {
                             "checksum": "f678eed2b8bac9c6c67c93c05c9b053cceef52d72d84258ec037eba8a69da58d",
                             "id": "fls_b94ojbfukhvd",
                             "link": "expressions.html#fls_b94ojbfukhvd",
-                            "number": "6.5.5:36"
+                            "number": "6.5.6:36"
                         },
                         {
                             "checksum": "f146d32e9238902885a1de2e40322ffbe37f7d482221f3f29f09cd74aa10c986",
                             "id": "fls_Et5gp1I7VqBX",
                             "link": "expressions.html#fls_Et5gp1I7VqBX",
-                            "number": "6.5.5:37"
+                            "number": "6.5.6:37"
                         },
                         {
                             "checksum": "76949da2fa0e9cc8e7cb9df9af458fb19d53b951678809db92d05e00586ab885",
                             "id": "fls_blyr18iao20n",
                             "link": "expressions.html#fls_blyr18iao20n",
-                            "number": "6.5.5:38"
+                            "number": "6.5.6:38"
                         },
                         {
                             "checksum": "84f604c240681edd7b71b1d29ef8b66a81b3f921feeefd7649950dad7829b18f",
                             "id": "fls_g28igfbnwfe0",
                             "link": "expressions.html#fls_g28igfbnwfe0",
-                            "number": "6.5.5:39"
+                            "number": "6.5.6:39"
                         },
                         {
                             "checksum": "5e2ecaea3a29c5b97b9c76aec758b093b55aca3e89a8ecefee9b691d736ee6cc",
                             "id": "fls_thcumw8n8xbw",
                             "link": "expressions.html#fls_thcumw8n8xbw",
-                            "number": "6.5.5:40"
+                            "number": "6.5.6:40"
                         },
                         {
                             "checksum": "4150ec47e0d0420937471ef411fcb589a50cf6da2b820a72bd39f3be021962f2",
                             "id": "fls_gld1u9fnsj6d",
                             "link": "expressions.html#fls_gld1u9fnsj6d",
-                            "number": "6.5.5:41"
+                            "number": "6.5.6:41"
                         },
                         {
                             "checksum": "3dde9ea78a683c92e2324df8e9c8250ce8017e6273b1110e6b3c1dd01cb638eb",
                             "id": "fls_Kdr6fLrRj0Du",
                             "link": "expressions.html#fls_Kdr6fLrRj0Du",
-                            "number": "6.5.5:42"
+                            "number": "6.5.6:42"
                         },
                         {
                             "checksum": "ddc0c2dfbe1023732c1d00d8ee8a8a13a6ef3fb5f2ec27bf3af56f0f356621d5",
                             "id": "fls_FxLnXeGT2n9u",
                             "link": "expressions.html#fls_FxLnXeGT2n9u",
-                            "number": "6.5.5:43"
+                            "number": "6.5.6:43"
                         },
                         {
                             "checksum": "8ad1f5e38027cf5c40e9d6661d275b0c692946ecbe2be3ff598372545ab1ce72",
                             "id": "fls_kN0HnldvDXSg",
                             "link": "expressions.html#fls_kN0HnldvDXSg",
-                            "number": "6.5.5:44"
+                            "number": "6.5.6:44"
                         },
                         {
                             "checksum": "797469b1ee10b81ac9f4dd20b9f7943570bca6e9aed0f4c09efb4082502be292",
                             "id": "fls_k7lmxvpkxtub",
                             "link": "expressions.html#fls_k7lmxvpkxtub",
-                            "number": "6.5.5:45"
+                            "number": "6.5.6:45"
                         },
                         {
                             "checksum": "cafca8e7b36d756680e784bde8ddc838c4cd8196bd1331ba9e9d82dcaf5944d9",
                             "id": "fls_bndpd66973ev",
                             "link": "expressions.html#fls_bndpd66973ev",
-                            "number": "6.5.5:46"
+                            "number": "6.5.6:46"
                         },
                         {
                             "checksum": "a133ac246b8483e2376fb2e7ff45933a4d073cc42b2f5b2693c18610ab982cb6",
                             "id": "fls_izmfimd4yg27",
                             "link": "expressions.html#fls_izmfimd4yg27",
-                            "number": "6.5.5:47"
+                            "number": "6.5.6:47"
                         },
                         {
                             "checksum": "1bab9420ecb10646e486e92a21e7c194eff5c4c1351ae11ba919d46aa9e8a427",
                             "id": "fls_ad9tc6ki8vcq",
                             "link": "expressions.html#fls_ad9tc6ki8vcq",
-                            "number": "6.5.5:48"
+                            "number": "6.5.6:48"
                         },
                         {
                             "checksum": "df45cf4e04324577c2dcfa776a8bf7431fe98c041a2defa2c83564f63f38542c",
                             "id": "fls_Vy0DyZqfy7Iv",
                             "link": "expressions.html#fls_Vy0DyZqfy7Iv",
-                            "number": "6.5.5:49"
+                            "number": "6.5.6:49"
                         },
                         {
                             "checksum": "5ab58ebe71cc5ede6b8c87248178f2659e27187f857007d8c683d25510b4c2b6",
                             "id": "fls_b9g0r9vc4rou",
                             "link": "expressions.html#fls_b9g0r9vc4rou",
-                            "number": "6.5.5:50"
+                            "number": "6.5.6:50"
                         }
                     ],
                     "title": "Arithmetic Expressions"
@@ -21508,265 +21030,265 @@
                     "id": "fls_abp6tjbz8tpn",
                     "informational": false,
                     "link": "expressions.html#bit-expressions",
-                    "number": "6.5.6",
+                    "number": "6.5.7",
                     "paragraphs": [
                         {
                             "checksum": "84a0bfe9ca4706b367c7fc61ce97d41de1f5b9c8fa6d17d06583fd15bddd1fd3",
                             "id": "fls_3zd59yuywz6l",
                             "link": "expressions.html#fls_3zd59yuywz6l",
-                            "number": "6.5.6:1"
+                            "number": "6.5.7:1"
                         },
                         {
                             "checksum": "2818a1e523dc8c69e39862ea386fbbab5b2558456ad985671a97f66bd39587ca",
                             "id": "fls_f6mmva3lbj1i",
                             "link": "expressions.html#fls_f6mmva3lbj1i",
-                            "number": "6.5.6:2"
+                            "number": "6.5.7:2"
                         },
                         {
                             "checksum": "05fc18fab6da50fb7b2ec1ed8dbdef6ab1d54584dd67eb283424ad2fdd5b1d8d",
                             "id": "fls_cmowpfrcelke",
                             "link": "expressions.html#fls_cmowpfrcelke",
-                            "number": "6.5.6:3"
+                            "number": "6.5.7:3"
                         },
                         {
                             "checksum": "170079796be6e0d966919640fafbf7d613f2a3d98177e61149106bfbff315c2b",
                             "id": "fls_kchprk9z6xun",
                             "link": "expressions.html#fls_kchprk9z6xun",
-                            "number": "6.5.6:4"
+                            "number": "6.5.7:4"
                         },
                         {
                             "checksum": "053daf5a48155d9e3cc897400be3ef219ceba7963682f22e7aab2a9aa6831550",
                             "id": "fls_dimu987fw4kg",
                             "link": "expressions.html#fls_dimu987fw4kg",
-                            "number": "6.5.6:5"
+                            "number": "6.5.7:5"
                         },
                         {
                             "checksum": "303e9f2d1f84be7d40c47e5d8f5742d86856b0d3b15cc3324195a698e9ee7c0f",
                             "id": "fls_3136k1y6x3cu",
                             "link": "expressions.html#fls_3136k1y6x3cu",
-                            "number": "6.5.6:6"
+                            "number": "6.5.7:6"
                         },
                         {
                             "checksum": "952cc40d099771b8eed28464bba01b8eb07d87d3aefd4d8e2615dcb9e0cffe8e",
                             "id": "fls_oo2ynd8e1ys6",
                             "link": "expressions.html#fls_oo2ynd8e1ys6",
-                            "number": "6.5.6:7"
+                            "number": "6.5.7:7"
                         },
                         {
                             "checksum": "ba39428a77c8298ec6d00dde55b54582b28fe2b591511d210c070eeead4f4703",
                             "id": "fls_s6hkt5fg598y",
                             "link": "expressions.html#fls_s6hkt5fg598y",
-                            "number": "6.5.6:8"
+                            "number": "6.5.7:8"
                         },
                         {
                             "checksum": "9dc068ab4f8ff1b86dee141016ae1c63df167f7b1a49de56303ace2d27e01480",
                             "id": "fls_osfse0t6ua8a",
                             "link": "expressions.html#fls_osfse0t6ua8a",
-                            "number": "6.5.6:9"
+                            "number": "6.5.7:9"
                         },
                         {
                             "checksum": "c0cf0a0884aaca56ec02fa11b697bba3c0be007b60befe09c8aebf753f176f71",
                             "id": "fls_j7ujcuthga1i",
                             "link": "expressions.html#fls_j7ujcuthga1i",
-                            "number": "6.5.6:10"
+                            "number": "6.5.7:10"
                         },
                         {
                             "checksum": "da193f8b1e127e029668399614ca332e6b587d0a8f272fb73bbf8edfc6cb0d1e",
                             "id": "fls_fnywefl9nty2",
                             "link": "expressions.html#fls_fnywefl9nty2",
-                            "number": "6.5.6:11"
+                            "number": "6.5.7:11"
                         },
                         {
                             "checksum": "b7308da6bd3cbce68c8acf223b36da8dd80bd6349300ea6f5c635c5ab44eb79c",
                             "id": "fls_4f24nyx0ix0j",
                             "link": "expressions.html#fls_4f24nyx0ix0j",
-                            "number": "6.5.6:12"
+                            "number": "6.5.7:12"
                         },
                         {
                             "checksum": "81582d3dd591be4afd63d14a8950ba0a7886253bc28a6ebdc004af9fda39ce65",
                             "id": "fls_8tb22c6zbp3",
                             "link": "expressions.html#fls_8tb22c6zbp3",
-                            "number": "6.5.6:13"
+                            "number": "6.5.7:13"
                         },
                         {
                             "checksum": "8493aa842fe4a83a4314ce4c5cfdcbc4004dbede23f86bc0726b3cbdce0eea6a",
                             "id": "fls_caxn774ij8lk",
                             "link": "expressions.html#fls_caxn774ij8lk",
-                            "number": "6.5.6:14"
+                            "number": "6.5.7:14"
                         },
                         {
                             "checksum": "5b928c6c679fee56921ceea7439472b9fab36f828c42e529bf0fc44e4a8b12f5",
                             "id": "fls_1f4pc612f2a8",
                             "link": "expressions.html#fls_1f4pc612f2a8",
-                            "number": "6.5.6:15"
+                            "number": "6.5.7:15"
                         },
                         {
                             "checksum": "ad2526669f50751a7b918a4cddeb2300641acf4b2395f4a1a01df29469e7da7f",
                             "id": "fls_8trozue35xe4",
                             "link": "expressions.html#fls_8trozue35xe4",
-                            "number": "6.5.6:16"
+                            "number": "6.5.7:16"
                         },
                         {
                             "checksum": "dc895b6a59e6aa619431f0f93958d1527008c560c57242167f44385670ac0774",
                             "id": "fls_kqntxbwnc58v",
                             "link": "expressions.html#fls_kqntxbwnc58v",
-                            "number": "6.5.6:17"
+                            "number": "6.5.7:17"
                         },
                         {
                             "checksum": "426a9a0ea02cbdf9f6ab017e8d01561de18f041ef2783074463ed902da9419a1",
                             "id": "fls_t709sl4co3al",
                             "link": "expressions.html#fls_t709sl4co3al",
-                            "number": "6.5.6:18"
+                            "number": "6.5.7:18"
                         },
                         {
                             "checksum": "8086917758b14703edbbbf5a445239563fb866350442477479028fab06da0367",
                             "id": "fls_onutb0b9p9zj",
                             "link": "expressions.html#fls_onutb0b9p9zj",
-                            "number": "6.5.6:19"
+                            "number": "6.5.7:19"
                         },
                         {
                             "checksum": "bd305b6ab372b8e874fac3c5a5d7d59ba805cda093af356e1d23ed3bfd23eca5",
                             "id": "fls_yq8rtwfp3nv0",
                             "link": "expressions.html#fls_yq8rtwfp3nv0",
-                            "number": "6.5.6:20"
+                            "number": "6.5.7:20"
                         },
                         {
                             "checksum": "2a93c4b43a488a8715a6346277d3a51967273030d0229e7fec4dbbe3e22cc0b0",
                             "id": "fls_fbazfgd5m1ot",
                             "link": "expressions.html#fls_fbazfgd5m1ot",
-                            "number": "6.5.6:21"
+                            "number": "6.5.7:21"
                         },
                         {
                             "checksum": "94ec1672b5572a206805a5f17f131b2a11dd24534874144bc815364ac11611a3",
                             "id": "fls_f4o8xlu67okn",
                             "link": "expressions.html#fls_f4o8xlu67okn",
-                            "number": "6.5.6:22"
+                            "number": "6.5.7:22"
                         },
                         {
                             "checksum": "53b4736dd567176d0f358e1d043c68e4e7b7ba30fdd04e2c5d27f0cbbf2bbd7a",
                             "id": "fls_kp747xqekyrr",
                             "link": "expressions.html#fls_kp747xqekyrr",
-                            "number": "6.5.6:23"
+                            "number": "6.5.7:23"
                         },
                         {
                             "checksum": "1651f680538ff44533e1024e0f14e3ad9c52d51916584a4901382c966fe46187",
                             "id": "fls_m0pdk78dah6n",
                             "link": "expressions.html#fls_m0pdk78dah6n",
-                            "number": "6.5.6:24"
+                            "number": "6.5.7:24"
                         },
                         {
                             "checksum": "15ed30a8258ed67352118ef07799071f10a8c36492ecfb2f87f7309bbece175c",
                             "id": "fls_m2hsk41hwm2j",
                             "link": "expressions.html#fls_m2hsk41hwm2j",
-                            "number": "6.5.6:25"
+                            "number": "6.5.7:25"
                         },
                         {
                             "checksum": "c598c63b8ad76764d80ce8990c8e92a0a204169649bbe024ea2823b4bbe90baf",
                             "id": "fls_p9rlmjhbnbao",
                             "link": "expressions.html#fls_p9rlmjhbnbao",
-                            "number": "6.5.6:26"
+                            "number": "6.5.7:26"
                         },
                         {
                             "checksum": "fae86360a1b7d2d77fbbc4365c5e99fbf0ed4a4fcac2256690e7c3d50bbff467",
                             "id": "fls_vprp53kv64q6",
                             "link": "expressions.html#fls_vprp53kv64q6",
-                            "number": "6.5.6:27"
+                            "number": "6.5.7:27"
                         },
                         {
                             "checksum": "31252eaded45baa2ec5ff1465a0523416c26773b13a971aeca24c9f54a1ff1fa",
                             "id": "fls_d456ummq6vrk",
                             "link": "expressions.html#fls_d456ummq6vrk",
-                            "number": "6.5.6:28"
+                            "number": "6.5.7:28"
                         },
                         {
                             "checksum": "537cc3ef62eb6da99fd065eb8f9f9876eb47dfe3405d33c7b4e02a9dedc27559",
                             "id": "fls_n269ufyesndz",
                             "link": "expressions.html#fls_n269ufyesndz",
-                            "number": "6.5.6:29"
+                            "number": "6.5.7:29"
                         },
                         {
                             "checksum": "7c1f43885f0acb0412658c413bc3e27945ab92404fde60121712fc4b1b414a64",
                             "id": "fls_i9iqtobheivu",
                             "link": "expressions.html#fls_i9iqtobheivu",
-                            "number": "6.5.6:30"
+                            "number": "6.5.7:30"
                         },
                         {
                             "checksum": "4263fb211a3cf3f26ebc3048404cb784bfcdb6e89e7b8c3509d9bade52286fa2",
                             "id": "fls_htw2tpujktwt",
                             "link": "expressions.html#fls_htw2tpujktwt",
-                            "number": "6.5.6:31"
+                            "number": "6.5.7:31"
                         },
                         {
                             "checksum": "e23d86a834fd2dc7ebe1e6d37fc6932e7ecb671e5814d5513513d720e300795e",
                             "id": "fls_gf9tyu1idpjk",
                             "link": "expressions.html#fls_gf9tyu1idpjk",
-                            "number": "6.5.6:32"
+                            "number": "6.5.7:32"
                         },
                         {
                             "checksum": "94cf2ccd91455de09c6784e79c76de895f6d11481f8ba1d2c6343e06bfc3dc6b",
                             "id": "fls_u5irwqswbsvu",
                             "link": "expressions.html#fls_u5irwqswbsvu",
-                            "number": "6.5.6:33"
+                            "number": "6.5.7:33"
                         },
                         {
                             "checksum": "26b785a04cf74035de814d871a9df90c21744413f8775bf806fd138b7504702f",
                             "id": "fls_2kkpr955i4lm",
                             "link": "expressions.html#fls_2kkpr955i4lm",
-                            "number": "6.5.6:34"
+                            "number": "6.5.7:34"
                         },
                         {
                             "checksum": "8d85229b2eb69a1cb33e8b332567f95078b56f70367895493bb53b3da0931f5c",
                             "id": "fls_7p64lgnjxylz",
                             "link": "expressions.html#fls_7p64lgnjxylz",
-                            "number": "6.5.6:35"
+                            "number": "6.5.7:35"
                         },
                         {
                             "checksum": "a9e77d70b03d9ad5d13456e3b4ea3a9a40479bd0354018ceb716a20e5f0f6c29",
                             "id": "fls_ieh1itrkcnf6",
                             "link": "expressions.html#fls_ieh1itrkcnf6",
-                            "number": "6.5.6:36"
+                            "number": "6.5.7:36"
                         },
                         {
                             "checksum": "4aed6e88a6e901c2ed2d0bd2376c733b44f5dec1fc0fe669c9d9964e76938ded",
                             "id": "fls_f0p70y92k14f",
                             "link": "expressions.html#fls_f0p70y92k14f",
-                            "number": "6.5.6:37"
+                            "number": "6.5.7:37"
                         },
                         {
                             "checksum": "358c4099d274cb05fdeab2e021a025cc0501667fc7247b7f0f7f6ae5882c5d3f",
                             "id": "fls_8QGbl2SBU3R0",
                             "link": "expressions.html#fls_8QGbl2SBU3R0",
-                            "number": "6.5.6:38"
+                            "number": "6.5.7:38"
                         },
                         {
                             "checksum": "9ba04ea8d40c1a25a4642aed3c24bc53d56619c51958bd4387bf76dbd994ca14",
                             "id": "fls_303r0u6ug215",
                             "link": "expressions.html#fls_303r0u6ug215",
-                            "number": "6.5.6:39"
+                            "number": "6.5.7:39"
                         },
                         {
                             "checksum": "df76cca7b83071a4072c0bcd99560eedf1d831230c5514f371df536f276f60e9",
                             "id": "fls_4gxj18t6cnzq",
                             "link": "expressions.html#fls_4gxj18t6cnzq",
-                            "number": "6.5.6:40"
+                            "number": "6.5.7:40"
                         },
                         {
                             "checksum": "e5cdfefed3d182d5a193d06aa0c5b4d2b467c3186aa0cfba1bb680a1f789e7a7",
                             "id": "fls_gurl2ve58drz",
                             "link": "expressions.html#fls_gurl2ve58drz",
-                            "number": "6.5.6:41"
+                            "number": "6.5.7:41"
                         },
                         {
                             "checksum": "1d00645665d4d5dd23d178bfb885638c4089bd2897473b19b42d346c9d7ec695",
                             "id": "fls_r02OGonXp93A",
                             "link": "expressions.html#fls_r02OGonXp93A",
-                            "number": "6.5.6:42"
+                            "number": "6.5.7:42"
                         },
                         {
                             "checksum": "2714e290acc8d3dc33e18078b03bd9f296e96275f0de65305d842aa79fd4ce38",
                             "id": "fls_xkyj83mcb9d5",
                             "link": "expressions.html#fls_xkyj83mcb9d5",
-                            "number": "6.5.6:43"
+                            "number": "6.5.7:43"
                         }
                     ],
                     "title": "Bit Expressions"
@@ -21775,277 +21297,277 @@
                     "id": "fls_nsvzzbldhq53",
                     "informational": false,
                     "link": "expressions.html#comparison-expressions",
-                    "number": "6.5.7",
+                    "number": "6.5.8",
                     "paragraphs": [
                         {
                             "checksum": "9d05d4defa794088d8cb55f8f3dc1300dc4a1e8881df85cc8431e6b4bc9c6491",
                             "id": "fls_yzuceqx6nxwa",
                             "link": "expressions.html#fls_yzuceqx6nxwa",
-                            "number": "6.5.7:1"
+                            "number": "6.5.8:1"
                         },
                         {
                             "checksum": "2a968cd3870a6603c37177067762adc544e4e07ad6b804a2c2aab38ae902eccf",
                             "id": "fls_asfrqemqviad",
                             "link": "expressions.html#fls_asfrqemqviad",
-                            "number": "6.5.7:2"
+                            "number": "6.5.8:2"
                         },
                         {
                             "checksum": "8026571732f9f6267928a67e769b7dd425f07122736917f16cee06caacc37f28",
                             "id": "fls_9s4re3ujnfis",
                             "link": "expressions.html#fls_9s4re3ujnfis",
-                            "number": "6.5.7:3"
+                            "number": "6.5.8:3"
                         },
                         {
                             "checksum": "f9b985b336990cc31ae368d531d7c4ea08e1aa780e9d702aeadd46e677aff9d9",
                             "id": "fls_ruyho6cu7rxg",
                             "link": "expressions.html#fls_ruyho6cu7rxg",
-                            "number": "6.5.7:4"
+                            "number": "6.5.8:4"
                         },
                         {
                             "checksum": "ce0053741951cdd2317168496b52090a75e5599bf46bb0b35ae36c85311c1ae9",
                             "id": "fls_8echqk9po1cf",
                             "link": "expressions.html#fls_8echqk9po1cf",
-                            "number": "6.5.7:5"
+                            "number": "6.5.8:5"
                         },
                         {
                             "checksum": "be7491a2b9729f338f90e0d71cdf9327852297b9681bdeb1fcdcbd07f3a42e9e",
                             "id": "fls_d62qfloqk2ub",
                             "link": "expressions.html#fls_d62qfloqk2ub",
-                            "number": "6.5.7:6"
+                            "number": "6.5.8:6"
                         },
                         {
                             "checksum": "d6831a752e2853991b540a6f71184363bd1495dcc4b3d792cc390c0e46566584",
                             "id": "fls_wapl0ir7uvbp",
                             "link": "expressions.html#fls_wapl0ir7uvbp",
-                            "number": "6.5.7:7"
+                            "number": "6.5.8:7"
                         },
                         {
                             "checksum": "a8d5305ac628e58fe4ccbd9c03c6a69b6c8fe5f5fb5849aca647efffba438ed3",
                             "id": "fls_x2s6ydvj5zyd",
                             "link": "expressions.html#fls_x2s6ydvj5zyd",
-                            "number": "6.5.7:8"
+                            "number": "6.5.8:8"
                         },
                         {
                             "checksum": "75c0bf567470cc284caa31e9a7cedafdab95750ec0c3d4493082eb5ae7390ec4",
                             "id": "fls_pso38dowbk91",
                             "link": "expressions.html#fls_pso38dowbk91",
-                            "number": "6.5.7:9"
+                            "number": "6.5.8:9"
                         },
                         {
                             "checksum": "ef1a2911b0a4a2bd1fc9f0ead5a226ba5699ae02b2dcd42ecabdf631202d784e",
                             "id": "fls_7n5gol6a8lod",
                             "link": "expressions.html#fls_7n5gol6a8lod",
-                            "number": "6.5.7:10"
+                            "number": "6.5.8:10"
                         },
                         {
                             "checksum": "0c6bb79a3001d63bf961a7f98a2b350801a2eee43c89c0af2af810b535fee371",
                             "id": "fls_hholzcbp5u3n",
                             "link": "expressions.html#fls_hholzcbp5u3n",
-                            "number": "6.5.7:11"
+                            "number": "6.5.8:11"
                         },
                         {
                             "checksum": "710411bab59ddc74d93bd9ff61bb2d8646a61f62f3bde811cf3d41bd58366173",
                             "id": "fls_wytygse41vzm",
                             "link": "expressions.html#fls_wytygse41vzm",
-                            "number": "6.5.7:12"
+                            "number": "6.5.8:12"
                         },
                         {
                             "checksum": "13bbc37a51d96873f70deac55cdbabc1b905394b23a3972b2c0551da7e10a040",
                             "id": "fls_yd4qqi39w248",
                             "link": "expressions.html#fls_yd4qqi39w248",
-                            "number": "6.5.7:13"
+                            "number": "6.5.8:13"
                         },
                         {
                             "checksum": "b2fe01f1e7bd73ec40381b1feffe64d54c4a73adf9833a8973e8545b4a22735a",
                             "id": "fls_ynibdcke3etb",
                             "link": "expressions.html#fls_ynibdcke3etb",
-                            "number": "6.5.7:14"
+                            "number": "6.5.8:14"
                         },
                         {
                             "checksum": "5c1c6dbb92fa6d031c159a452bc02516ab56200edd7b1829912ab9e1dedf582c",
                             "id": "fls_xmtxkit3qpw7",
                             "link": "expressions.html#fls_xmtxkit3qpw7",
-                            "number": "6.5.7:15"
+                            "number": "6.5.8:15"
                         },
                         {
                             "checksum": "aa2489e740ac7fa0927e1ebf58ee7859f6c7fcb1c27a1fed065269e34d58945b",
                             "id": "fls_yxwe1o27u6ns",
                             "link": "expressions.html#fls_yxwe1o27u6ns",
-                            "number": "6.5.7:16"
+                            "number": "6.5.8:16"
                         },
                         {
                             "checksum": "4246d899aae58ccec5761931073223131d6bb1fdfbead0fe71e27bac795785dd",
                             "id": "fls_6dgfieyxdan0",
                             "link": "expressions.html#fls_6dgfieyxdan0",
-                            "number": "6.5.7:17"
+                            "number": "6.5.8:17"
                         },
                         {
                             "checksum": "71f44b658d5f60358888166477d893099556625a56856efc9601af1b23ee44da",
                             "id": "fls_7pfsqby2saag",
                             "link": "expressions.html#fls_7pfsqby2saag",
-                            "number": "6.5.7:18"
+                            "number": "6.5.8:18"
                         },
                         {
                             "checksum": "8974278dc5b60a16754de7eb076364e82284313e621b4c49992c20c6a9c63ae1",
                             "id": "fls_w71j7i3n1kit",
                             "link": "expressions.html#fls_w71j7i3n1kit",
-                            "number": "6.5.7:19"
+                            "number": "6.5.8:19"
                         },
                         {
                             "checksum": "8aa4fbe8cdd3993316bc9797d2e9c0eae2606dcf347454c5e8420d364eb6db51",
                             "id": "fls_qzo1torhv5i3",
                             "link": "expressions.html#fls_qzo1torhv5i3",
-                            "number": "6.5.7:20"
+                            "number": "6.5.8:20"
                         },
                         {
                             "checksum": "61a081ab60d564acf7dac7b48da5bf545566ae3c1c82613770c74aa2155c8be7",
                             "id": "fls_kodwkh58hmdv",
                             "link": "expressions.html#fls_kodwkh58hmdv",
-                            "number": "6.5.7:21"
+                            "number": "6.5.8:21"
                         },
                         {
                             "checksum": "0881ded68a87d9c91315127f344b19aa1c1ba7a415be695e64255be1cd5f14dd",
                             "id": "fls_ydt9zvh0h5ex",
                             "link": "expressions.html#fls_ydt9zvh0h5ex",
-                            "number": "6.5.7:22"
+                            "number": "6.5.8:22"
                         },
                         {
                             "checksum": "e9d81054725f03fed4f879928978ad1c981033f08f7d0018ee97c430cd1526ed",
                             "id": "fls_4vbrc31r0o60",
                             "link": "expressions.html#fls_4vbrc31r0o60",
-                            "number": "6.5.7:23"
+                            "number": "6.5.8:23"
                         },
                         {
                             "checksum": "dcc537a9126843947883cb7463f2aa089ffdb70c3ce806d15282d128254e00ce",
                             "id": "fls_hyy974ksbbrq",
                             "link": "expressions.html#fls_hyy974ksbbrq",
-                            "number": "6.5.7:24"
+                            "number": "6.5.8:24"
                         },
                         {
                             "checksum": "790b5f2286f9006f773c5cee8a79277c939604dbc045305f68dba735d4a8fab3",
                             "id": "fls_htrjqxiv3avh",
                             "link": "expressions.html#fls_htrjqxiv3avh",
-                            "number": "6.5.7:25"
+                            "number": "6.5.8:25"
                         },
                         {
                             "checksum": "ffdd939b68f5c1dc9c76bb481300346a0b76d4c1af150b24ba7a6ca40f85db37",
                             "id": "fls_1udbc4aom6ok",
                             "link": "expressions.html#fls_1udbc4aom6ok",
-                            "number": "6.5.7:26"
+                            "number": "6.5.8:26"
                         },
                         {
                             "checksum": "9c5002f8931d3abbba38e2af25c9e26fde9574a782a54098d5c7b21336a27cd7",
                             "id": "fls_96mt7gx5ogo0",
                             "link": "expressions.html#fls_96mt7gx5ogo0",
-                            "number": "6.5.7:27"
+                            "number": "6.5.8:27"
                         },
                         {
                             "checksum": "1f09a7d5f20dfa920da6816904f1d9a952d7223cadcbd1a2e02bc92e2eb8b6e5",
                             "id": "fls_or0i2cqxwl8o",
                             "link": "expressions.html#fls_or0i2cqxwl8o",
-                            "number": "6.5.7:28"
+                            "number": "6.5.8:28"
                         },
                         {
                             "checksum": "b26f1ae4bb9ca5706067a0dc7fcc96ff7d0a837066c3103acdef5036c0c54662",
                             "id": "fls_udnhkbxpk83m",
                             "link": "expressions.html#fls_udnhkbxpk83m",
-                            "number": "6.5.7:29"
+                            "number": "6.5.8:29"
                         },
                         {
                             "checksum": "d7ad85bcfcd0d633bf1608e3af7008ca9e2f70b1bb1f98771a1ec739acb3b24f",
                             "id": "fls_mab6yirx77zl",
                             "link": "expressions.html#fls_mab6yirx77zl",
-                            "number": "6.5.7:30"
+                            "number": "6.5.8:30"
                         },
                         {
                             "checksum": "0575886e7dc22f4c493b7d181fe07b8cadec4b14adea5fce90f5cded24a50f61",
                             "id": "fls_2ggb7a7nhrk9",
                             "link": "expressions.html#fls_2ggb7a7nhrk9",
-                            "number": "6.5.7:31"
+                            "number": "6.5.8:31"
                         },
                         {
                             "checksum": "227845ddcd0a132d50d7dd61e7a564d46335b6a22d2ce74a288f7d9200ae7c54",
                             "id": "fls_ukm97arfzsk1",
                             "link": "expressions.html#fls_ukm97arfzsk1",
-                            "number": "6.5.7:32"
+                            "number": "6.5.8:32"
                         },
                         {
                             "checksum": "0ea88b20932e8a1ac321f37c0f71648e487ba64d4a8a174357f45c0a361a030b",
                             "id": "fls_wrftg7onlkmm",
                             "link": "expressions.html#fls_wrftg7onlkmm",
-                            "number": "6.5.7:33"
+                            "number": "6.5.8:33"
                         },
                         {
                             "checksum": "fc5c6a6f5d2c2fbd69a96faa707b88b69a02ec46f571e54abbba5b94262db700",
                             "id": "fls_irlqykpbtvd",
                             "link": "expressions.html#fls_irlqykpbtvd",
-                            "number": "6.5.7:34"
+                            "number": "6.5.8:34"
                         },
                         {
                             "checksum": "5db519b4a3862ea81b67712e174ac1e631a8afb3913654c28c367cc6e4a717bc",
                             "id": "fls_udonl4c7f6pz",
                             "link": "expressions.html#fls_udonl4c7f6pz",
-                            "number": "6.5.7:35"
+                            "number": "6.5.8:35"
                         },
                         {
                             "checksum": "26071802062bc2b37291010d1f9f8dee33a117f0cec69c457650ba59560c6743",
                             "id": "fls_ebvyhqbb921g",
                             "link": "expressions.html#fls_ebvyhqbb921g",
-                            "number": "6.5.7:36"
+                            "number": "6.5.8:36"
                         },
                         {
                             "checksum": "3f1dc50e13776facbc3ca274a5ef46f7a078bc0e1d73003d0eb034fbe9ae7e33",
                             "id": "fls_rfomib80bnn2",
                             "link": "expressions.html#fls_rfomib80bnn2",
-                            "number": "6.5.7:37"
+                            "number": "6.5.8:37"
                         },
                         {
                             "checksum": "9047368a8239de0933ecc3949594279fa3de51e000bd4842cb09bdbb2abea448",
                             "id": "fls_6cb4wg59wmef",
                             "link": "expressions.html#fls_6cb4wg59wmef",
-                            "number": "6.5.7:38"
+                            "number": "6.5.8:38"
                         },
                         {
                             "checksum": "2d9093eb49a4246b73dd600878aa12b7b93aa41605f6119cd2763faaa323dc9a",
                             "id": "fls_dkbjn7noq8n2",
                             "link": "expressions.html#fls_dkbjn7noq8n2",
-                            "number": "6.5.7:39"
+                            "number": "6.5.8:39"
                         },
                         {
                             "checksum": "15967dc98aa0ed7f84bf158358e5aadd9b853a956daa8e9c622ee666a262302a",
                             "id": "fls_kezynx2xc1q7",
                             "link": "expressions.html#fls_kezynx2xc1q7",
-                            "number": "6.5.7:40"
+                            "number": "6.5.8:40"
                         },
                         {
                             "checksum": "b01336b9511f2f0bcdd400438da1f991279c25423b3694339c0c2a56de3297cc",
                             "id": "fls_8luq5sellcaq",
                             "link": "expressions.html#fls_8luq5sellcaq",
-                            "number": "6.5.7:41"
+                            "number": "6.5.8:41"
                         },
                         {
                             "checksum": "b47d020a4bf52e4092fc90d68fef4ef1a455a67b8988333b6f7ef74fcd608744",
                             "id": "fls_c93pacid548a",
                             "link": "expressions.html#fls_c93pacid548a",
-                            "number": "6.5.7:42"
+                            "number": "6.5.8:42"
                         },
                         {
                             "checksum": "b1d67e27cd64bff665fa4abe27d7bb3ffa248e472df78975e3e9b414d3abc215",
                             "id": "fls_gqy6uuowij9e",
                             "link": "expressions.html#fls_gqy6uuowij9e",
-                            "number": "6.5.7:43"
+                            "number": "6.5.8:43"
                         },
                         {
                             "checksum": "74d5290848e5b132492e37c5a878b393585ab57f6861801568b33dd97e99350e",
                             "id": "fls_s6sq6p8th5nt",
                             "link": "expressions.html#fls_s6sq6p8th5nt",
-                            "number": "6.5.7:44"
+                            "number": "6.5.8:44"
                         },
                         {
                             "checksum": "e8c6085c7317b0b22333a5e89d1757cb4024590c46e44ba9d2e121f9f7c30b94",
                             "id": "fls_kdga59xx4nx3",
                             "link": "expressions.html#fls_kdga59xx4nx3",
-                            "number": "6.5.7:45"
+                            "number": "6.5.8:45"
                         }
                     ],
                     "title": "Comparison Expressions"
@@ -22054,169 +21576,94 @@
                     "id": "fls_lstusiu2c8lu",
                     "informational": false,
                     "link": "expressions.html#lazy-boolean-expressions",
-                    "number": "6.5.8",
+                    "number": "6.5.9",
                     "paragraphs": [
                         {
                             "checksum": "d083fa2a4b23d69ebf79cb39b3b435aecaa477f6e2bcddfaa6e8f2cad7ef9fcf",
                             "id": "fls_gpbvus89iy4c",
                             "link": "expressions.html#fls_gpbvus89iy4c",
-                            "number": "6.5.8:1"
+                            "number": "6.5.9:1"
                         },
                         {
                             "checksum": "d94febcd9c5097860d17e1a524ae04bbe93e6476a617726293f8e7d45f048f81",
                             "id": "fls_40jya46h62yi",
                             "link": "expressions.html#fls_40jya46h62yi",
-                            "number": "6.5.8:2"
+                            "number": "6.5.9:2"
                         },
                         {
                             "checksum": "1c05b5e8f145c2821e9391efa0203c3fbde926b15242438460e0cdf1976780b1",
                             "id": "fls_k8u77ow5bb6c",
                             "link": "expressions.html#fls_k8u77ow5bb6c",
-                            "number": "6.5.8:3"
+                            "number": "6.5.9:3"
                         },
                         {
                             "checksum": "fdd6553d09d1a0c51cd9641afb80879d25d7066040d8a352725884773f92d2a9",
                             "id": "fls_u0gwo0s2l0tn",
                             "link": "expressions.html#fls_u0gwo0s2l0tn",
-                            "number": "6.5.8:4"
+                            "number": "6.5.9:4"
                         },
                         {
                             "checksum": "ddd627fc1c34fe282518e5540e51987966234a13145ad8bae553177ac3d8dfaa",
                             "id": "fls_zas0lizgq2hn",
                             "link": "expressions.html#fls_zas0lizgq2hn",
-                            "number": "6.5.8:5"
+                            "number": "6.5.9:5"
                         },
                         {
                             "checksum": "5fedecca69f448e516ad8fdd4b22e1d9538dabd703fdf0c4881e56e12b0ffd02",
                             "id": "fls_xdgvrd58nkoa",
                             "link": "expressions.html#fls_xdgvrd58nkoa",
-                            "number": "6.5.8:6"
+                            "number": "6.5.9:6"
                         },
                         {
                             "checksum": "b099b2fe899cf3d319f0a36dd5af2427e1c29cc5f8afbe3e514a07bb160b21a6",
                             "id": "fls_ufre0ko2cwh2",
                             "link": "expressions.html#fls_ufre0ko2cwh2",
-                            "number": "6.5.8:7"
+                            "number": "6.5.9:7"
                         },
                         {
                             "checksum": "5e0c86a6b40357d25e18747cafd06d04626afc595a9d1d43986abadb34f378cc",
                             "id": "fls_jugckad775kq",
                             "link": "expressions.html#fls_jugckad775kq",
-                            "number": "6.5.8:8"
+                            "number": "6.5.9:8"
                         },
                         {
                             "checksum": "2c38f5ee0dee81eba992210bde3a9c3e5e17845a49afa11bf5ecb756e07b012d",
                             "id": "fls_tmfmu3syxp2q",
                             "link": "expressions.html#fls_tmfmu3syxp2q",
-                            "number": "6.5.8:9"
+                            "number": "6.5.9:9"
                         },
                         {
                             "checksum": "e16cc48f8ee8a84751ce4195d3680e9168f423ceac46d85cb7d9ade46e838061",
                             "id": "fls_srfv1d4idxy9",
                             "link": "expressions.html#fls_srfv1d4idxy9",
-                            "number": "6.5.8:10"
+                            "number": "6.5.9:10"
                         },
                         {
                             "checksum": "8aa3b1677686a272d98a21454e1e94aea43ab1745f3b214fe1d274e1b1d44913",
                             "id": "fls_tflikh8cmxvc",
                             "link": "expressions.html#fls_tflikh8cmxvc",
-                            "number": "6.5.8:11"
+                            "number": "6.5.9:11"
                         },
                         {
                             "checksum": "081904a7612047457f00462adab410432028cf313a537c7d3eb899885660028b",
                             "id": "fls_p0rafjsridre",
                             "link": "expressions.html#fls_p0rafjsridre",
-                            "number": "6.5.8:12"
+                            "number": "6.5.9:12"
                         },
                         {
                             "checksum": "a7e87563c4a367cf52d29f70b5299ee79561d872ffbcb53680929c57d329ac75",
                             "id": "fls_yg1348rlziw3",
                             "link": "expressions.html#fls_yg1348rlziw3",
-                            "number": "6.5.8:13"
+                            "number": "6.5.9:13"
                         },
                         {
                             "checksum": "53ea72e1adfc38c6b9633432eff3b00824a954e6db484fb79fe14639eacc879d",
                             "id": "fls_yffozo2vq5xz",
                             "link": "expressions.html#fls_yffozo2vq5xz",
-                            "number": "6.5.8:14"
+                            "number": "6.5.9:14"
                         }
                     ],
                     "title": "Lazy Boolean Expressions"
-                },
-                {
-                    "id": "fls_vxguvrwolbee",
-                    "informational": false,
-                    "link": "expressions.html#raw-borrow-expression",
-                    "number": "6.5.9",
-                    "paragraphs": [
-                        {
-                            "checksum": "b814a9dc3d1a1ae28c4f466bc7f6fd0f2cc398c5143dd1dcee45e6d0b560437a",
-                            "id": "fls_TS6DvMon5h27",
-                            "link": "expressions.html#fls_TS6DvMon5h27",
-                            "number": "6.5.9:1"
-                        },
-                        {
-                            "checksum": "d334a2ea162c08a078c9efc96c54353ef243a320da1fd9b5bc5e34daf57fa170",
-                            "id": "fls_UtjWrE2qeplQ",
-                            "link": "expressions.html#fls_UtjWrE2qeplQ",
-                            "number": "6.5.9:2"
-                        },
-                        {
-                            "checksum": "6beab888d8d4e129466aace5f4c4d4f0a64c369b021794667ee23cced979415a",
-                            "id": "fls_4e7EE4a8Yvmy",
-                            "link": "expressions.html#fls_4e7EE4a8Yvmy",
-                            "number": "6.5.9:3"
-                        },
-                        {
-                            "checksum": "53bac137d0858ec7798957d5b5f811dafdc5533e54987f7f4ae62fc781c20de6",
-                            "id": "fls_gOXUWePymgGV",
-                            "link": "expressions.html#fls_gOXUWePymgGV",
-                            "number": "6.5.9:4"
-                        },
-                        {
-                            "checksum": "65c60bbe30206c4ae6a03c51cde6e5c3ec57379e3447a75bc2039f6b3e9377de",
-                            "id": "fls_YBC8GrIBzZbi",
-                            "link": "expressions.html#fls_YBC8GrIBzZbi",
-                            "number": "6.5.9:5"
-                        },
-                        {
-                            "checksum": "6794a4fddaa7211478879f5cdd3ae1c71df8de74d488900101a10651053b94d4",
-                            "id": "fls_Twkre8IzUa8S",
-                            "link": "expressions.html#fls_Twkre8IzUa8S",
-                            "number": "6.5.9:6"
-                        },
-                        {
-                            "checksum": "c25b5c85bea772da45b8bbde270d8e9d0c815f2033ee2999da28bf4d44abd7b8",
-                            "id": "fls_Ki4FOzJMqtvJ",
-                            "link": "expressions.html#fls_Ki4FOzJMqtvJ",
-                            "number": "6.5.9:7"
-                        },
-                        {
-                            "checksum": "03f1f3f42dac7107312066bd913be7d440b55121130a80d435439cce504429ae",
-                            "id": "fls_DJxQDBsO9hc7",
-                            "link": "expressions.html#fls_DJxQDBsO9hc7",
-                            "number": "6.5.9:8"
-                        },
-                        {
-                            "checksum": "0e8388d16705508711d3aa9c46c8130b8545d7596fb8b731db0a05119c249858",
-                            "id": "fls_WlXB0AHifCdd",
-                            "link": "expressions.html#fls_WlXB0AHifCdd",
-                            "number": "6.5.9:9"
-                        },
-                        {
-                            "checksum": "a3e29c3e339b22b3ed3f65266a969681e92a742e338b7866361d8519390d386c",
-                            "id": "fls_qQrV8QuGGcVO",
-                            "link": "expressions.html#fls_qQrV8QuGGcVO",
-                            "number": "6.5.9:10"
-                        },
-                        {
-                            "checksum": "7752805d169b4ea002c92d0b378112418e8556fd751db36982e0a87c1575999c",
-                            "id": "fls_dTABiwAPGhdZ",
-                            "link": "expressions.html#fls_dTABiwAPGhdZ",
-                            "number": "6.5.9:11"
-                        }
-                    ],
-                    "title": "Raw Borrow Expression"
                 },
                 {
                     "id": "fls_1qhsun1vyarz",
@@ -25512,653 +24959,325 @@
         },
         {
             "informational": false,
-            "link": "functions.html",
+            "link": "implementations.html",
             "sections": [
                 {
-                    "id": "fls_qcb1n9c0e5hz",
+                    "id": "fls_fk2m2irwpeof",
                     "informational": false,
-                    "link": "functions.html",
-                    "number": "9",
+                    "link": "implementations.html",
+                    "number": "11",
                     "paragraphs": [
                         {
-                            "checksum": "d85148abd62f72e649abbb14ec33bcf5dd833660e6d429978a1233e8aa19e739",
-                            "id": "fls_gn1ngtx2tp2s",
-                            "link": "functions.html#fls_gn1ngtx2tp2s",
-                            "number": "9:1"
+                            "checksum": "68d68054bfe8ffe57002321f94f09f2c21faac92f10052af0b8ebb6bb2e4bdd4",
+                            "id": "fls_ivxpoxggy7s6",
+                            "link": "implementations.html#fls_ivxpoxggy7s6",
+                            "number": "11:1"
                         },
                         {
-                            "checksum": "0b7f0bc4680d19a82f2a03e22ab8228330095ac38f768e6138b1fa061209b0cd",
-                            "id": "fls_bdx9gnnjxru3",
-                            "link": "functions.html#fls_bdx9gnnjxru3",
-                            "number": "9:2"
+                            "checksum": "a88885418df7946e8facb892e33e099cc8789c354fbf7bd977f460e40ec2089d",
+                            "id": "fls_yopmjbnw8tbl",
+                            "link": "implementations.html#fls_yopmjbnw8tbl",
+                            "number": "11:2"
                         },
                         {
-                            "checksum": "4ef42a17784ccf912f1917cdc894f87abaa5c3ae6bbc330e5d97884670ee69a3",
-                            "id": "fls_87jnkimc15gi",
-                            "link": "functions.html#fls_87jnkimc15gi",
-                            "number": "9:3"
+                            "checksum": "28523ce67d9161886a6bbdc6415a2a18a12cac0bd7cf96d2e560d4acaa243c96",
+                            "id": "fls_eIHc8Y9fBtr0",
+                            "link": "implementations.html#fls_eIHc8Y9fBtr0",
+                            "number": "11:3"
                         },
                         {
-                            "checksum": "1be13228840af974c47c9d4a16fb932edc3efcbbb1b5a5d8261d4eb3d4db1df5",
-                            "id": "fls_nwywh1vjt6rr",
-                            "link": "functions.html#fls_nwywh1vjt6rr",
-                            "number": "9:4"
+                            "checksum": "073aeb6b836eee108b5b6d5a5ded4f1b8df8ab96ec075686dca1d2b7fc6c1b34",
+                            "id": "fls_Mcpdzzcw43M7",
+                            "link": "implementations.html#fls_Mcpdzzcw43M7",
+                            "number": "11:4"
                         },
                         {
-                            "checksum": "e7bbdbb6cf00db43de1e27fe5b39e71062d7737351b11ee44c1f02ab45beabfb",
-                            "id": "fls_uwuthzfgslif",
-                            "link": "functions.html#fls_uwuthzfgslif",
-                            "number": "9:5"
+                            "checksum": "6d7038fd93f535f1a95c93f6917f3cebd5b30ad181afde8d89173856ec36d502",
+                            "id": "fls_v0n0bna40dqr",
+                            "link": "implementations.html#fls_v0n0bna40dqr",
+                            "number": "11:5"
                         },
                         {
-                            "checksum": "d6307364051e9afc70d6e0e3e277a7a096ecb2eb1db51e356303d7ee87537a12",
-                            "id": "fls_ymeo93t4mz4",
-                            "link": "functions.html#fls_ymeo93t4mz4",
-                            "number": "9:6"
+                            "checksum": "e18c1caa38c5924e033a0026fc017b1c792df55f87c598c5783efe25cb62819f",
+                            "id": "fls_797etpdk5dyb",
+                            "link": "implementations.html#fls_797etpdk5dyb",
+                            "number": "11:6"
                         },
                         {
-                            "checksum": "2119a7ea0e7b937c1318f8b7cb342aea3ec7249cab773a35ff4b8a0701d43f4b",
-                            "id": "fls_ijbt4tgnl95n",
-                            "link": "functions.html#fls_ijbt4tgnl95n",
-                            "number": "9:7"
+                            "checksum": "74cac3914710c2f1a1f624a3c5a1c9aaf33da46b9946695f9bee4eaeb22c5e42",
+                            "id": "fls_ry3an0mwb63g",
+                            "link": "implementations.html#fls_ry3an0mwb63g",
+                            "number": "11:7"
                         },
                         {
-                            "checksum": "b7ee5ce366f421f0fae995e21d17b77d938b59f2f8a07975cb3aa3486b963304",
-                            "id": "fls_AAYJDCNMJgTq",
-                            "link": "functions.html#fls_AAYJDCNMJgTq",
-                            "number": "9:8"
+                            "checksum": "dd34aa75e7947124723372145385a391a6527acf3d57821cf6bfb3530926d0df",
+                            "id": "fls_8pwr7ibvhmhu",
+                            "link": "implementations.html#fls_8pwr7ibvhmhu",
+                            "number": "11:8"
                         },
                         {
-                            "checksum": "29b6ace4daea786064b460a8bf0c7ddbe2b6800631188e26b46177257bf8fa33",
-                            "id": "fls_PGtp39f6gJwU",
-                            "link": "functions.html#fls_PGtp39f6gJwU",
-                            "number": "9:9"
+                            "checksum": "ba2818ea733c9b43c0160165759dc06495876220780d457240575201aebbf397",
+                            "id": "fls_47x0ep8of8wr",
+                            "link": "implementations.html#fls_47x0ep8of8wr",
+                            "number": "11:9"
                         },
                         {
-                            "checksum": "2205b3649789767c105c262228a48536d8d9af2734351fcab5e8650eed044f19",
-                            "id": "fls_yZ2yIXxmy2ri",
-                            "link": "functions.html#fls_yZ2yIXxmy2ri",
-                            "number": "9:10"
+                            "checksum": "8223ac177e0dcc171dbac1fb21b191141842026a92038b9694be40797d2bdad8",
+                            "id": "fls_agitlryvyc16",
+                            "link": "implementations.html#fls_agitlryvyc16",
+                            "number": "11:10"
                         },
                         {
-                            "checksum": "00ff6766b53e2501ce67b57b21ac801f24b86208afab3a509a0cd92439b2f346",
-                            "id": "fls_35aSvBxBnIzm",
-                            "link": "functions.html#fls_35aSvBxBnIzm",
-                            "number": "9:11"
+                            "checksum": "0ecbb270fa78be720b325ddc3197182ea1ca39be3069bd7d37f201389c9b3991",
+                            "id": "fls_mx5xjcejwa6u",
+                            "link": "implementations.html#fls_mx5xjcejwa6u",
+                            "number": "11:11"
                         },
                         {
-                            "checksum": "d44af44daa180c96d7c066dd036be5c2217e9ef54e5440a28226f4155da1fbd9",
-                            "id": "fls_Ogziu8S01qPQ",
-                            "link": "functions.html#fls_Ogziu8S01qPQ",
-                            "number": "9:12"
+                            "checksum": "7ec52a2c02f0e55bea6e0a3c728c22e5720e34bdeabc0740d52707774946acbe",
+                            "id": "fls_z78dg261oob6",
+                            "link": "implementations.html#fls_z78dg261oob6",
+                            "number": "11:12"
                         },
                         {
-                            "checksum": "e007c5d5fe350258fe85248f1a507b573c634bb18cf907d6b83babb1a8a98f5d",
-                            "id": "fls_xCSsxYUZUFed",
-                            "link": "functions.html#fls_xCSsxYUZUFed",
-                            "number": "9:13"
+                            "checksum": "1f973a701dba719c9b5c7879e8f7e39c271e60ebd4708b781a5ec557ca35bb6b",
+                            "id": "fls_89yNjGNB7KI3",
+                            "link": "implementations.html#fls_89yNjGNB7KI3",
+                            "number": "11:13"
                         },
                         {
-                            "checksum": "afcad007b988dd4e9a7ae77d05318b5818905bf05921cd7d14070abe83ebb9b2",
-                            "id": "fls_lxzinvqveuqh",
-                            "link": "functions.html#fls_lxzinvqveuqh",
-                            "number": "9:14"
+                            "checksum": "94597e560f592f649b38ef27778a62819bc7e5c2e01faa0ef53fa29225d8083c",
+                            "id": "fls_yuyesijndu9n",
+                            "link": "implementations.html#fls_yuyesijndu9n",
+                            "number": "11:14"
                         },
                         {
-                            "checksum": "af44866222e3ba28adab818deff3cff0fe079c936325cb39ed958ac977eaf988",
-                            "id": "fls_kcAbTPZXQ5Y8",
-                            "link": "functions.html#fls_kcAbTPZXQ5Y8",
-                            "number": "9:15"
+                            "checksum": "7093aa443b2d63b8c3ad1d99dc26a6f1df03d367428b954e62e372eab3d4f569",
+                            "id": "fls_o62i75sjzp9y",
+                            "link": "implementations.html#fls_o62i75sjzp9y",
+                            "number": "11:15"
                         },
                         {
-                            "checksum": "a6f8a428953b804ae4d9a530c1659087e99139633acc2e99d4315bf792bf123a",
-                            "id": "fls_PGDKWK7nPvgw",
-                            "link": "functions.html#fls_PGDKWK7nPvgw",
-                            "number": "9:16"
-                        },
-                        {
-                            "checksum": "681f0328a6e3f3599494c7ab05e29ca62e56c28c57ecde0bbe7cd5b96d6db84d",
-                            "id": "fls_o4uSLPo00KUg",
-                            "link": "functions.html#fls_o4uSLPo00KUg",
-                            "number": "9:17"
-                        },
-                        {
-                            "checksum": "2a3652b695660398bf0fcad1529e0346fed7c9fa6809502c46ecdb89c2bf93d6",
-                            "id": "fls_icdzs1mjh0n4",
-                            "link": "functions.html#fls_icdzs1mjh0n4",
-                            "number": "9:18"
-                        },
-                        {
-                            "checksum": "408643016febf0219e0809cd2e92e018cab38026b8e8612741262fc29b5daa00",
-                            "id": "fls_OR85NVifPwjr",
-                            "link": "functions.html#fls_OR85NVifPwjr",
-                            "number": "9:19"
-                        },
-                        {
-                            "checksum": "4bc2a2eb8ccee2c72bf5174dc901116ca5cf7ed223c6d8860b2bfbca11943925",
-                            "id": "fls_4s2IdfYDzPrX",
-                            "link": "functions.html#fls_4s2IdfYDzPrX",
-                            "number": "9:20"
-                        },
-                        {
-                            "checksum": "fca8a97c468b1b73283de8c4f98ad8e13873aba97f8c10a0392dab4826a7fe00",
-                            "id": "fls_ZJJppPfiJRou",
-                            "link": "functions.html#fls_ZJJppPfiJRou",
-                            "number": "9:21"
-                        },
-                        {
-                            "checksum": "7dd1d3308749e298f5b2a22e71ac500637ce35b2d9cf6ccf24634f53e2885f12",
-                            "id": "fls_jOyZh9ujWWHQ",
-                            "link": "functions.html#fls_jOyZh9ujWWHQ",
-                            "number": "9:22"
-                        },
-                        {
-                            "checksum": "99c1950124ddc4f31f88a1064b15e1cb78f9e374abb2eece4a801f0648c89300",
-                            "id": "fls_Xdr0bFwxhWiB",
-                            "link": "functions.html#fls_Xdr0bFwxhWiB",
-                            "number": "9:23"
-                        },
-                        {
-                            "checksum": "898ff3d8792a073b155387b8ee5e51b48f03b4ad15845d393f6162730578c4a3",
-                            "id": "fls_DpTFEHZAABdD",
-                            "link": "functions.html#fls_DpTFEHZAABdD",
-                            "number": "9:24"
-                        },
-                        {
-                            "checksum": "421ab0ac3cb998e26b832f6f921db20f8d80617dce79045d9906b460e2dbbadb",
-                            "id": "fls_b7FTlWfnX2OI",
-                            "link": "functions.html#fls_b7FTlWfnX2OI",
-                            "number": "9:25"
-                        },
-                        {
-                            "checksum": "eda198b5564690046f7225520acae5222abaccf175ac28f4c3b8b13d0d0bbf14",
-                            "id": "fls_6urL6fZ5cpaA",
-                            "link": "functions.html#fls_6urL6fZ5cpaA",
-                            "number": "9:26"
-                        },
-                        {
-                            "checksum": "513827ea79b2bb852e3a03fc1d52ad23aaa08dccee280c50059a7e31df7d6139",
-                            "id": "fls_TMOzb6cYIOlH",
-                            "link": "functions.html#fls_TMOzb6cYIOlH",
-                            "number": "9:27"
-                        },
-                        {
-                            "checksum": "15571a856ea4d62c8fe363b440ddf0f1a63e654322bf5c97a6fbc7973c16420e",
-                            "id": "fls_eHPWHrvs7ETl",
-                            "link": "functions.html#fls_eHPWHrvs7ETl",
-                            "number": "9:28"
-                        },
-                        {
-                            "checksum": "42a5a6b2aef837c0262688bbc4f2dae48d988fd49bcbcbcd7a84175224069dd8",
-                            "id": "fls_mjCrvmikm58M",
-                            "link": "functions.html#fls_mjCrvmikm58M",
-                            "number": "9:29"
-                        },
-                        {
-                            "checksum": "1b8b316d3d56bf10df2d8521160902a8137f08c3a5c8d39d5bf8f22900dac035",
-                            "id": "fls_4EUb9zFatZ97",
-                            "link": "functions.html#fls_4EUb9zFatZ97",
-                            "number": "9:30"
-                        },
-                        {
-                            "checksum": "a2e6957d275225e3cb26e75af5b4e0d3d31afa9b43a77eaef4117c78d920ac52",
-                            "id": "fls_4B4B5FIqAes9",
-                            "link": "functions.html#fls_4B4B5FIqAes9",
-                            "number": "9:31"
-                        },
-                        {
-                            "checksum": "b82bf4578023aa2218ec01202b93d193cbb48fd8b53d740a5c9d3bb482caaf10",
-                            "id": "fls_vljy4mm0zca2",
-                            "link": "functions.html#fls_vljy4mm0zca2",
-                            "number": "9:32"
-                        },
-                        {
-                            "checksum": "b89caf540730b919c47a1f20bdd5dc9302aca3ec99300e25098600be2e706acf",
-                            "id": "fls_EqJb3Jl3vK8K",
-                            "link": "functions.html#fls_EqJb3Jl3vK8K",
-                            "number": "9:33"
-                        },
-                        {
-                            "checksum": "e2ca22f3a68ea69c89d5499ab8bfaff4ea879242e37d601e8b78939484e3fbd9",
-                            "id": "fls_C7dvzcXcpQCy",
-                            "link": "functions.html#fls_C7dvzcXcpQCy",
-                            "number": "9:34"
-                        },
-                        {
-                            "checksum": "2f2202efc417e1cd3118f5b446cf8c8a375b6e5f8ebaed72a0201aa9d161578a",
-                            "id": "fls_J8X8ahnJLrMo",
-                            "link": "functions.html#fls_J8X8ahnJLrMo",
-                            "number": "9:35"
-                        },
-                        {
-                            "checksum": "f01d77c3faa9dafff3f5a3ca3928a29d60e2867a2438140aaaa4cbceb25da31b",
-                            "id": "fls_927nfm5mkbsp",
-                            "link": "functions.html#fls_927nfm5mkbsp",
-                            "number": "9:36"
-                        },
-                        {
-                            "checksum": "a8e601de98599b419876278ab5521c5cc49ae6bfdacfe061350c283e236e211f",
-                            "id": "fls_yfm0jh62oaxr",
-                            "link": "functions.html#fls_yfm0jh62oaxr",
-                            "number": "9:37"
-                        },
-                        {
-                            "checksum": "45189d0422353cd31d5e3d1460ac0bf25731cc9f464574e6acf3ba0a8661dffb",
-                            "id": "fls_bHwy8FLzEUi3",
-                            "link": "functions.html#fls_bHwy8FLzEUi3",
-                            "number": "9:38"
-                        },
-                        {
-                            "checksum": "1952dd7798e9fd4d8fb5f525eedc05613f2ef1a660b93bfa8f24167e67f839bb",
-                            "id": "fls_5Q861wb08DU3",
-                            "link": "functions.html#fls_5Q861wb08DU3",
-                            "number": "9:39"
-                        },
-                        {
-                            "checksum": "a336a489c323ad22b7aa3059350a2400bb8e41f5eef6ce02b17682c438a9fd09",
-                            "id": "fls_owdlsaaygtho",
-                            "link": "functions.html#fls_owdlsaaygtho",
-                            "number": "9:40"
-                        },
-                        {
-                            "checksum": "4355b34dd22393af15f6fad33ae3c69fc7091736b751b78d2b18cb15ceb7b3cc",
-                            "id": "fls_2049qu3ji5x7",
-                            "link": "functions.html#fls_2049qu3ji5x7",
-                            "number": "9:41"
-                        },
-                        {
-                            "checksum": "515666a67e5b60858568348fd8b4c6021e49484b778d6ccd6c357f9b792643d1",
-                            "id": "fls_7mlanuh5mvpn",
-                            "link": "functions.html#fls_7mlanuh5mvpn",
-                            "number": "9:42"
-                        },
-                        {
-                            "checksum": "4ccbc87469f1565c32bef31f5909da4c2b2f1febaf71e3b0216053540e2732c4",
-                            "id": "fls_otr3hgp8lj1q",
-                            "link": "functions.html#fls_otr3hgp8lj1q",
-                            "number": "9:43"
-                        },
-                        {
-                            "checksum": "45a75ca66fc48e3abbe4a9b46d1599f9ecbcfae9fbc5df35e1b5d8939f41f8c4",
-                            "id": "fls_m3jiunibqj81",
-                            "link": "functions.html#fls_m3jiunibqj81",
-                            "number": "9:44"
-                        },
-                        {
-                            "checksum": "388876fffc5a50a274a155691b5fe0142ca2651fe1ce20d17301a9682d3638f6",
-                            "id": "fls_7vogmqyd87ey",
-                            "link": "functions.html#fls_7vogmqyd87ey",
-                            "number": "9:45"
-                        },
-                        {
-                            "checksum": "a0ec3be9336e08cd1fca0ed1ac63762201261a4c25b465370a9c89d2c35e0647",
-                            "id": "fls_7ucwmzqtittv",
-                            "link": "functions.html#fls_7ucwmzqtittv",
-                            "number": "9:46"
-                        },
-                        {
-                            "checksum": "77e3105531c29da1bb23103569cc04ef5d3377e723b9f8adcf7603d91463ceae",
-                            "id": "fls_nUADhgcfvvGC",
-                            "link": "functions.html#fls_nUADhgcfvvGC",
-                            "number": "9:47"
-                        },
-                        {
-                            "checksum": "fbf5fb05e9efc647400ab22d0002c1bc09b999d239850236501817c8374a143c",
-                            "id": "fls_5hn8fkf7rcvz",
-                            "link": "functions.html#fls_5hn8fkf7rcvz",
-                            "number": "9:48"
+                            "checksum": "8ad70788c23781cfbb4cc77f8e9b280870f2088b7f3522cf5adf7a4030b29b48",
+                            "id": "fls_a2utf0tmuhy4",
+                            "link": "implementations.html#fls_a2utf0tmuhy4",
+                            "number": "11:16"
                         }
                     ],
-                    "title": "Functions"
+                    "title": "Implementations"
+                },
+                {
+                    "id": "fls_46ork6fz5o2e",
+                    "informational": false,
+                    "link": "implementations.html#implementation-coherence",
+                    "number": "11.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "f593f63f6406327889e137ab55ec05d98a6d439176ec14afafae261241a14f1c",
+                            "id": "fls_fv1l4yjuut7p",
+                            "link": "implementations.html#fls_fv1l4yjuut7p",
+                            "number": "11.1:1"
+                        },
+                        {
+                            "checksum": "1452e1e4d864f7a4178e6f1be77e9694766805cd6a0556f67f5314caf0a5d8de",
+                            "id": "fls_swdusjwzgksx",
+                            "link": "implementations.html#fls_swdusjwzgksx",
+                            "number": "11.1:2"
+                        },
+                        {
+                            "checksum": "9763aff40d5e4ca431a133884a391a71d1e3434b2dd8e6ab1c928ba846346526",
+                            "id": "fls_ir7hp941ky8t",
+                            "link": "implementations.html#fls_ir7hp941ky8t",
+                            "number": "11.1:3"
+                        },
+                        {
+                            "checksum": "3a7e9191eb41e4bba88408faba2f7f149137b7df440996588e945fad99c82867",
+                            "id": "fls_3tbm20k2ixol",
+                            "link": "implementations.html#fls_3tbm20k2ixol",
+                            "number": "11.1:4"
+                        },
+                        {
+                            "checksum": "46b1fe27e9a10a5a463205624c88ba78b4851fbf47c3d1e31d45026df49b1774",
+                            "id": "fls_lscc9ileg3gm",
+                            "link": "implementations.html#fls_lscc9ileg3gm",
+                            "number": "11.1:5"
+                        },
+                        {
+                            "checksum": "90514614f2da8202c20d849b7c71d72ae95423a582d7fcb612d03343c5ce1b8a",
+                            "id": "fls_9klwbsh3vlxu",
+                            "link": "implementations.html#fls_9klwbsh3vlxu",
+                            "number": "11.1:6"
+                        },
+                        {
+                            "checksum": "79f486e433c0cc3589e42f1efbdc6df12866131778c2b136b5be7d27ff1b67ec",
+                            "id": "fls_9gmc1tcscq9v",
+                            "link": "implementations.html#fls_9gmc1tcscq9v",
+                            "number": "11.1:7"
+                        },
+                        {
+                            "checksum": "6b6dac78cb7d28fe378157a5827ca98ef8996833871c9acbbad28e04b8781132",
+                            "id": "fls_UkQhjEWSJpDq",
+                            "link": "implementations.html#fls_UkQhjEWSJpDq",
+                            "number": "11.1:8"
+                        },
+                        {
+                            "checksum": "cbf8117eb6e59dd31ff3217f236513679c4236d8d108c4451693dfdeb766d3d2",
+                            "id": "fls_fSybUG40hA5r",
+                            "link": "implementations.html#fls_fSybUG40hA5r",
+                            "number": "11.1:9"
+                        },
+                        {
+                            "checksum": "35936abe2e47a3f84e6b97c5b8773f0e57035b2a2311e2ec92b001e91f057096",
+                            "id": "fls_z8APl0CEF7a0",
+                            "link": "implementations.html#fls_z8APl0CEF7a0",
+                            "number": "11.1:10"
+                        },
+                        {
+                            "checksum": "16c8bf3ad79c585e2a19ab5043608ba5cdfbe59b334ba09913fe7cb101ef98a0",
+                            "id": "fls_RJJafhpVsi6M",
+                            "link": "implementations.html#fls_RJJafhpVsi6M",
+                            "number": "11.1:11"
+                        },
+                        {
+                            "checksum": "bd35a79daaebf148b48f637a939718b4e78fe6d95ec05e092dabf33c372e5045",
+                            "id": "fls_dtUJxhNkl8Ty",
+                            "link": "implementations.html#fls_dtUJxhNkl8Ty",
+                            "number": "11.1:12"
+                        },
+                        {
+                            "checksum": "8e6a64bbe4e6692fa29ab6cab825bed32aa92944541ab8b3cab95f46ec47ae1a",
+                            "id": "fls_zJKovQrXQWdU",
+                            "link": "implementations.html#fls_zJKovQrXQWdU",
+                            "number": "11.1:13"
+                        },
+                        {
+                            "checksum": "881eb7081d32bca6dd31a402732083c1a10cfbb0703d65d4903481c9df0fa6cc",
+                            "id": "fls_V6R8yQtsqNyv",
+                            "link": "implementations.html#fls_V6R8yQtsqNyv",
+                            "number": "11.1:14"
+                        },
+                        {
+                            "checksum": "0bff693cd5c7bd24006d97966faf22d8ad51776dd27b155aa3c4c53705f1e230",
+                            "id": "fls_CpC6XQN1iWqU",
+                            "link": "implementations.html#fls_CpC6XQN1iWqU",
+                            "number": "11.1:15"
+                        },
+                        {
+                            "checksum": "3a1f51af690831f150b9917ff7ed785fc0ad8572bfdb024cbbe419e2b1536063",
+                            "id": "fls_dj7YGw4e4i4H",
+                            "link": "implementations.html#fls_dj7YGw4e4i4H",
+                            "number": "11.1:16"
+                        },
+                        {
+                            "checksum": "a69a7eba188277ac25d75030529f9289094778fd2d87d38a1ed7ab9c1871938e",
+                            "id": "fls_koy70k770ayu",
+                            "link": "implementations.html#fls_koy70k770ayu",
+                            "number": "11.1:17"
+                        }
+                    ],
+                    "title": "Implementation Coherence"
+                },
+                {
+                    "id": "fls_e1pgdlv81vul",
+                    "informational": false,
+                    "link": "implementations.html#implementation-conformance",
+                    "number": "11.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "235dcfef5a150c402f42c33dd6eabd7189375ddb2bb8e3cd3cc162fe22a53e9a",
+                            "id": "fls_YyUSuAYG4lX6",
+                            "link": "implementations.html#fls_YyUSuAYG4lX6",
+                            "number": "11.2:1"
+                        },
+                        {
+                            "checksum": "5f1a4f88e1dd9fd77d93c773080c7b2e8fa3179f7d8e4de72e39d0ff16a2a387",
+                            "id": "fls_v31idwjau90d",
+                            "link": "implementations.html#fls_v31idwjau90d",
+                            "number": "11.2:2"
+                        },
+                        {
+                            "checksum": "f18161b732608a6732ea2886b4c609dc56b7dde6df16c57cf321542c887aa1d8",
+                            "id": "fls_k3wfh5japmyw",
+                            "link": "implementations.html#fls_k3wfh5japmyw",
+                            "number": "11.2:3"
+                        },
+                        {
+                            "checksum": "428b016d82301c34cac20a058d8e9f87628abcd977fc4d1ff1557bc1bf2d24f8",
+                            "id": "fls_11qrqfuc3rmh",
+                            "link": "implementations.html#fls_11qrqfuc3rmh",
+                            "number": "11.2:4"
+                        },
+                        {
+                            "checksum": "7e921c53c7799271e80ccbadf2d47a340d1ef1bd9326fe4e2bdf54e5dcf2d127",
+                            "id": "fls_qmhduwunxww0",
+                            "link": "implementations.html#fls_qmhduwunxww0",
+                            "number": "11.2:5"
+                        },
+                        {
+                            "checksum": "aa4594177b713ab6ee2d502e2c0f20256ac5a5e546fab64bcc52db72ee407c5d",
+                            "id": "fls_2500ivh0cc3y",
+                            "link": "implementations.html#fls_2500ivh0cc3y",
+                            "number": "11.2:6"
+                        },
+                        {
+                            "checksum": "f3fb2ce2caeb76b89e224e1c88594d2dc95ddc66e180f8cb6d50b428f01eedcf",
+                            "id": "fls_18gimgfy0kw9",
+                            "link": "implementations.html#fls_18gimgfy0kw9",
+                            "number": "11.2:7"
+                        },
+                        {
+                            "checksum": "0b6f276c677931c78d760ff5def7e67a7e4cbd817e1f21f0343edb674c80e0b4",
+                            "id": "fls_fi4qmauirlsm",
+                            "link": "implementations.html#fls_fi4qmauirlsm",
+                            "number": "11.2:8"
+                        },
+                        {
+                            "checksum": "31bad81c5be19c117a8675a891a00247edb13fe1ab49a36e1f439da9b3123b6f",
+                            "id": "fls_2s8lh3k4rw6u",
+                            "link": "implementations.html#fls_2s8lh3k4rw6u",
+                            "number": "11.2:9"
+                        },
+                        {
+                            "checksum": "fe5486ca02f9ffadaed847c11ea13af8afba0eb18ea38527ec5b8cc5d45cbf83",
+                            "id": "fls_bb874uu2alt3",
+                            "link": "implementations.html#fls_bb874uu2alt3",
+                            "number": "11.2:10"
+                        },
+                        {
+                            "checksum": "43150bf6a5f61f75ca365a77174d7d659f67e1c8cd00dcd74b3f72cdc7282045",
+                            "id": "fls_so8em6rphkhv",
+                            "link": "implementations.html#fls_so8em6rphkhv",
+                            "number": "11.2:11"
+                        },
+                        {
+                            "checksum": "2928f339f8abfbe9b10de44c5ab57f730fdc2e7881dc3cce685844a2ada75373",
+                            "id": "fls_ldu9bmb9cy10",
+                            "link": "implementations.html#fls_ldu9bmb9cy10",
+                            "number": "11.2:12"
+                        },
+                        {
+                            "checksum": "1a07917d9eeb24596f2800e26f4930f6ecc94fc0027f33f7cce840c026ee28a5",
+                            "id": "fls_5cr6un2gzdft",
+                            "link": "implementations.html#fls_5cr6un2gzdft",
+                            "number": "11.2:13"
+                        },
+                        {
+                            "checksum": "dc51b8a6f90c2e32e2ec099057c7d4745f9082e4521e0f0cb64ba03ac87c95ed",
+                            "id": "fls_pshfe3ioh0mg",
+                            "link": "implementations.html#fls_pshfe3ioh0mg",
+                            "number": "11.2:14"
+                        },
+                        {
+                            "checksum": "bc54fae0d59dee07617ca65931de1869df56a18c8afe575dcc287c8d2d9305ed",
+                            "id": "fls_8yq1g7nzv9px",
+                            "link": "implementations.html#fls_8yq1g7nzv9px",
+                            "number": "11.2:15"
+                        }
+                    ],
+                    "title": "Implementation Conformance"
                 }
             ],
-            "title": "Functions"
-        },
-        {
-            "informational": false,
-            "link": "ffi.html",
-            "sections": [
-                {
-                    "id": "fls_osd6c4utyjb3",
-                    "informational": false,
-                    "link": "ffi.html",
-                    "number": "21",
-                    "paragraphs": [
-                        {
-                            "checksum": "9dbb89c33be2fd11861ca905be788d903d72880fdf1dece1bc8a63747a947445",
-                            "id": "fls_djlglv2eaihl",
-                            "link": "ffi.html#fls_djlglv2eaihl",
-                            "number": "21:1"
-                        },
-                        {
-                            "checksum": "33f23ecced9a34c5f1aaaa909380603062d763f33056c5a2998e61ba20e81e21",
-                            "id": "fls_k1hiwghzxtfa",
-                            "link": "ffi.html#fls_k1hiwghzxtfa",
-                            "number": "21:2"
-                        },
-                        {
-                            "checksum": "e6918e7d46ef5f24647902726d860e1abaf15c6b4f3e50771748abe1156acb4a",
-                            "id": "fls_3cgtdk4698hm",
-                            "link": "ffi.html#fls_3cgtdk4698hm",
-                            "number": "21:3"
-                        },
-                        {
-                            "checksum": "b297f2f7182e518adc328b76e8e51549d74fd016d982e945f3afad959b8e4fee",
-                            "id": "fls_shzmgci4f7o5",
-                            "link": "ffi.html#fls_shzmgci4f7o5",
-                            "number": "21:4"
-                        },
-                        {
-                            "checksum": "fc67b06bdfa241b1112995e95bea87b539fd31dee8c24e402fcd9d7af65eed2f",
-                            "id": "fls_m7x5odt4nb23",
-                            "link": "ffi.html#fls_m7x5odt4nb23",
-                            "number": "21:5"
-                        },
-                        {
-                            "checksum": "ed6db46b8be18e820fbb6dfc0dd19df1bb2ac9687dacf002b00c217d8ddbf625",
-                            "id": "fls_4akfvpq1yg4g",
-                            "link": "ffi.html#fls_4akfvpq1yg4g",
-                            "number": "21:6"
-                        },
-                        {
-                            "checksum": "a0f18eb2fe8db99bebeadf847111b16dfaa78ebdbaec8e8f7b364e6a40966ebf",
-                            "id": "fls_9d8v0xeyi0f",
-                            "link": "ffi.html#fls_9d8v0xeyi0f",
-                            "number": "21:7"
-                        }
-                    ],
-                    "title": "FFI"
-                },
-                {
-                    "id": "fls_usgd0xlijoxv",
-                    "informational": false,
-                    "link": "ffi.html#abi",
-                    "number": "21.1",
-                    "paragraphs": [
-                        {
-                            "checksum": "5907d37d1b47c67dacab00d10295ab91ec2974c77016fc225a28413fdcecf896",
-                            "id": "fls_xangrq3tfze0",
-                            "link": "ffi.html#fls_xangrq3tfze0",
-                            "number": "21.1:1"
-                        },
-                        {
-                            "checksum": "303e206ff87fda7c72da6833ecc1035fb2e1bc4de71a73e3c1d6fce85b12b068",
-                            "id": "fls_2w0xi6rxw3uz",
-                            "link": "ffi.html#fls_2w0xi6rxw3uz",
-                            "number": "21.1:2"
-                        },
-                        {
-                            "checksum": "a7324b60f99f6fb51284703d13f58460e71099e1fae889aca7365c5c7c1b5976",
-                            "id": "fls_9zitf1fvvfk8",
-                            "link": "ffi.html#fls_9zitf1fvvfk8",
-                            "number": "21.1:3"
-                        },
-                        {
-                            "checksum": "9deadcb79842b0adc5ae917673a5a388d2bd4ed4c1732bf5a25e4e650395ca87",
-                            "id": "fls_x7ct9k82fpgn",
-                            "link": "ffi.html#fls_x7ct9k82fpgn",
-                            "number": "21.1:4"
-                        },
-                        {
-                            "checksum": "c336142c062c3b0f4238fbadf03105300bfcc6e13ec8c02ac9c02aa0bb4dcf50",
-                            "id": "fls_LfjvLXvI6TFL",
-                            "link": "ffi.html#fls_LfjvLXvI6TFL",
-                            "number": "21.1:5"
-                        },
-                        {
-                            "checksum": "39df1027aa9c166e4e50895b0a788131e1f5f2323e7cfd31b5e06e5b3c128c65",
-                            "id": "fls_a2d8ltpgtvn6",
-                            "link": "ffi.html#fls_a2d8ltpgtvn6",
-                            "number": "21.1:6"
-                        },
-                        {
-                            "checksum": "fad916b90d4bdea5184053e8d62af2714330ad0086c48776b03afe27e57d7e80",
-                            "id": "fls_8m7pc3riokst",
-                            "link": "ffi.html#fls_8m7pc3riokst",
-                            "number": "21.1:7"
-                        },
-                        {
-                            "checksum": "1e90ce91871f63afbcb47fc5716511ce8ef86c066f3b8bb81d43bc7856c543a8",
-                            "id": "fls_NQAzj5ai1La5",
-                            "link": "ffi.html#fls_NQAzj5ai1La5",
-                            "number": "21.1:8"
-                        },
-                        {
-                            "checksum": "bde0533495e75b4ceb809bb02e397e0d5daa1d7c3d1977865fcaf0ff5f4d989a",
-                            "id": "fls_r2drzo3dixe4",
-                            "link": "ffi.html#fls_r2drzo3dixe4",
-                            "number": "21.1:9"
-                        },
-                        {
-                            "checksum": "907e87e17820da8559bd8a486992acf18956b1456ecc61cb90278065e01374ca",
-                            "id": "fls_z2kzyin8dyr7",
-                            "link": "ffi.html#fls_z2kzyin8dyr7",
-                            "number": "21.1:10"
-                        },
-                        {
-                            "checksum": "c2d1059fcd1026468253d1771f735c5e6a5bab43177231babeb00190e68633a2",
-                            "id": "fls_j6pqchx27ast",
-                            "link": "ffi.html#fls_j6pqchx27ast",
-                            "number": "21.1:11"
-                        },
-                        {
-                            "checksum": "1454a6149650f43e10f4254d309ba83ae39d3052b579c45d26bed5c429ce1bc4",
-                            "id": "fls_dbbfqaqa80r8",
-                            "link": "ffi.html#fls_dbbfqaqa80r8",
-                            "number": "21.1:12"
-                        },
-                        {
-                            "checksum": "3015fb781cf27af98cfdb17a199fc06a282c4995bf513e4f23460aa87a24fefd",
-                            "id": "fls_UippZpUyYpHl",
-                            "link": "ffi.html#fls_UippZpUyYpHl",
-                            "number": "21.1:13"
-                        },
-                        {
-                            "checksum": "1da7fe0a23d93d524fed3110b8c116e9b7fe7f1563c51830ffd8b98ce562b9dd",
-                            "id": "fls_36qrs2fxxvi7",
-                            "link": "ffi.html#fls_36qrs2fxxvi7",
-                            "number": "21.1:14"
-                        },
-                        {
-                            "checksum": "d0f9c8d00a857e8d69b98fadc01f1222ca7838660e92dbf4c571d07df302a222",
-                            "id": "fls_CIyK8BYzzo26",
-                            "link": "ffi.html#fls_CIyK8BYzzo26",
-                            "number": "21.1:15"
-                        },
-                        {
-                            "checksum": "42ee2288dd6a0bde172c2aa19bdd6c764e4c21913a22a4d9d65065b478aa14ba",
-                            "id": "fls_6rtj6rwqxojh",
-                            "link": "ffi.html#fls_6rtj6rwqxojh",
-                            "number": "21.1:16"
-                        },
-                        {
-                            "checksum": "a81529042a5b1033d4dfd23dc355a422cafc5e8a94dac4134dcc1cdbe6d6b01d",
-                            "id": "fls_d3nmpc5mtg27",
-                            "link": "ffi.html#fls_d3nmpc5mtg27",
-                            "number": "21.1:17"
-                        },
-                        {
-                            "checksum": "fab1088ce02afa3c8566f0f5033efbd1b6cfec69fc639a64273cc39e32f479e5",
-                            "id": "fls_7t7yxh94wnbl",
-                            "link": "ffi.html#fls_7t7yxh94wnbl",
-                            "number": "21.1:18"
-                        },
-                        {
-                            "checksum": "5d748e814d1f01129f8b66ffb05acc435c309ab75eeff0b4e74925cc1e8b786b",
-                            "id": "fls_ccFdnlX5HIYk",
-                            "link": "ffi.html#fls_ccFdnlX5HIYk",
-                            "number": "21.1:19"
-                        },
-                        {
-                            "checksum": "aa45e16b2c9fb1e7d7ecf23ca38806bc2f369b1d1be518e74d28e24e6b54a8b4",
-                            "id": "fls_sxj4vy39sj4g",
-                            "link": "ffi.html#fls_sxj4vy39sj4g",
-                            "number": "21.1:20"
-                        },
-                        {
-                            "checksum": "563032c0e9c472e10f9c487c70925926c24107c3258cc003fb04dd03b00c21af",
-                            "id": "fls_tyjs1x4j8ovp",
-                            "link": "ffi.html#fls_tyjs1x4j8ovp",
-                            "number": "21.1:21"
-                        },
-                        {
-                            "checksum": "985fd96881b7c12b952e2f2a81cdc5713cd19ec157141a68232ac19172c96907",
-                            "id": "fls_xrCRprWS13R1",
-                            "link": "ffi.html#fls_xrCRprWS13R1",
-                            "number": "21.1:22"
-                        },
-                        {
-                            "checksum": "f392bf3391787b024699ac732bffa8db2661c5d3f6e13335913304f6b7f38b20",
-                            "id": "fls_JHlqXjn4Sf07",
-                            "link": "ffi.html#fls_JHlqXjn4Sf07",
-                            "number": "21.1:23"
-                        },
-                        {
-                            "checksum": "2eb97e47f68715623197b729da4072c1fd6dd94cc8a38e41f135832c8ac7312e",
-                            "id": "fls_M4LqHf8hbPA8",
-                            "link": "ffi.html#fls_M4LqHf8hbPA8",
-                            "number": "21.1:24"
-                        }
-                    ],
-                    "title": "ABI"
-                },
-                {
-                    "id": "fls_tmoh3y9oyqsy",
-                    "informational": false,
-                    "link": "ffi.html#external-blocks",
-                    "number": "21.2",
-                    "paragraphs": [
-                        {
-                            "checksum": "5690487aad48826d0fbca987e21993dde238a0492461e8b3e35e3f49b1810f50",
-                            "id": "fls_4dje9t5y2dia",
-                            "link": "ffi.html#fls_4dje9t5y2dia",
-                            "number": "21.2:1"
-                        },
-                        {
-                            "checksum": "e9d30e0c8d7251366fcba4b5a93322f61b5d415d8ea85b870b7a8de0eae5728d",
-                            "id": "fls_8ltVLtAfvy0m",
-                            "link": "ffi.html#fls_8ltVLtAfvy0m",
-                            "number": "21.2:2"
-                        },
-                        {
-                            "checksum": "8fa9f3206c1f1e9af22942ab5569d11a808e99fcb06365a0c2f5be68d1af8497",
-                            "id": "fls_Nz0l16hMxqTd",
-                            "link": "ffi.html#fls_Nz0l16hMxqTd",
-                            "number": "21.2:3"
-                        },
-                        {
-                            "checksum": "be19b76230f53b9d539f838eb6c73119e8210045835c5c82f58a9bd1876de4b7",
-                            "id": "fls_4XOoiFloXM7t",
-                            "link": "ffi.html#fls_4XOoiFloXM7t",
-                            "number": "21.2:4"
-                        },
-                        {
-                            "checksum": "dd7c836fa590b14a7da0c87f48b6eb0d11c83010e9f4ac1e0615ebecc9ba7eb3",
-                            "id": "fls_PBsepNHImJKH",
-                            "link": "ffi.html#fls_PBsepNHImJKH",
-                            "number": "21.2:5"
-                        }
-                    ],
-                    "title": "External Blocks"
-                },
-                {
-                    "id": "fls_yztwtek0y34v",
-                    "informational": false,
-                    "link": "ffi.html#external-functions",
-                    "number": "21.3",
-                    "paragraphs": [
-                        {
-                            "checksum": "0104ba914d1d2a6dafc2b7914cc94254e1ab3678864a25c1864a89740a54294f",
-                            "id": "fls_v24ino4hix3m",
-                            "link": "ffi.html#fls_v24ino4hix3m",
-                            "number": "21.3:1"
-                        },
-                        {
-                            "checksum": "f42fee85a3cead90e0424d6ae591a72b9d777fa19fdaee7718a36a484f0a8166",
-                            "id": "fls_l88r9fj82650",
-                            "link": "ffi.html#fls_l88r9fj82650",
-                            "number": "21.3:2"
-                        },
-                        {
-                            "checksum": "9abb006e22c228a40953b442c54e63fd9a10cc675390d5e7d61b1fb7221ec353",
-                            "id": "fls_qwchgvvnp0qe",
-                            "link": "ffi.html#fls_qwchgvvnp0qe",
-                            "number": "21.3:3"
-                        },
-                        {
-                            "checksum": "af35e63fe34e63713827f5525caee153a033f726c0cf64300b5612781daf29fc",
-                            "id": "fls_w00qi1gx204e",
-                            "link": "ffi.html#fls_w00qi1gx204e",
-                            "number": "21.3:4"
-                        },
-                        {
-                            "checksum": "9ff777cfdc4b91eb8472493cfbc9e96b5e66329d621fb37d3c8603b420f63f79",
-                            "id": "fls_m7tu4w4lk8v",
-                            "link": "ffi.html#fls_m7tu4w4lk8v",
-                            "number": "21.3:5"
-                        },
-                        {
-                            "checksum": "69809b6272d266f36a20ad706492a4e3561e0afa136d36145d8804f83456d978",
-                            "id": "fls_rdu4723vp0oo",
-                            "link": "ffi.html#fls_rdu4723vp0oo",
-                            "number": "21.3:6"
-                        },
-                        {
-                            "checksum": "8a5942ade1d1568f8a2e335a8767ab295816829fc64e2c4ef250f53feee9ec69",
-                            "id": "fls_9div9yusw64h",
-                            "link": "ffi.html#fls_9div9yusw64h",
-                            "number": "21.3:7"
-                        },
-                        {
-                            "checksum": "0e21072dc94fa05d0ff274b95c7cdfe5e96a5fddabfd26720dd20bcd7aecbf38",
-                            "id": "fls_juob30rst11r",
-                            "link": "ffi.html#fls_juob30rst11r",
-                            "number": "21.3:8"
-                        }
-                    ],
-                    "title": "External Functions"
-                },
-                {
-                    "id": "fls_s4yt19sptl7d",
-                    "informational": false,
-                    "link": "ffi.html#external-statics",
-                    "number": "21.4",
-                    "paragraphs": [
-                        {
-                            "checksum": "a342af289e2343c6a6c563bb75a44dd7f003efc17cc5dddaf9db25fc1395f17c",
-                            "id": "fls_8ddsytjr4il6",
-                            "link": "ffi.html#fls_8ddsytjr4il6",
-                            "number": "21.4:1"
-                        },
-                        {
-                            "checksum": "7456ec21405a4f2629a47ca17fd031b08d4bf3cde66139fe81c3b11248264ca1",
-                            "id": "fls_H0cg9XMaGz0y",
-                            "link": "ffi.html#fls_H0cg9XMaGz0y",
-                            "number": "21.4:2"
-                        },
-                        {
-                            "checksum": "6bfbc90ac6b0ebe2bf403b473eb2876a892442339359bafeb4fa203aa258570c",
-                            "id": "fls_fo9with6xumo",
-                            "link": "ffi.html#fls_fo9with6xumo",
-                            "number": "21.4:3"
-                        },
-                        {
-                            "checksum": "1e3dcb44d797a493ed568db4d4a7c292794fa22ef50cc810f94492b86ec20c75",
-                            "id": "fls_tr7purzcldn0",
-                            "link": "ffi.html#fls_tr7purzcldn0",
-                            "number": "21.4:4"
-                        },
-                        {
-                            "checksum": "0fb23c674fc5c6699fc7b3869fdc36f00d967880169275042498442dc58a8872",
-                            "id": "fls_en2h09ehj0j3",
-                            "link": "ffi.html#fls_en2h09ehj0j3",
-                            "number": "21.4:5"
-                        }
-                    ],
-                    "title": "External Statics"
-                }
-            ],
-            "title": "FFI"
+            "title": "Implementations"
         },
         {
             "informational": false,
@@ -40286,6 +39405,887 @@
                 }
             ],
             "title": "Glossary"
+        },
+        {
+            "informational": false,
+            "link": "ffi.html",
+            "sections": [
+                {
+                    "id": "fls_osd6c4utyjb3",
+                    "informational": false,
+                    "link": "ffi.html",
+                    "number": "21",
+                    "paragraphs": [
+                        {
+                            "checksum": "9dbb89c33be2fd11861ca905be788d903d72880fdf1dece1bc8a63747a947445",
+                            "id": "fls_djlglv2eaihl",
+                            "link": "ffi.html#fls_djlglv2eaihl",
+                            "number": "21:1"
+                        },
+                        {
+                            "checksum": "33f23ecced9a34c5f1aaaa909380603062d763f33056c5a2998e61ba20e81e21",
+                            "id": "fls_k1hiwghzxtfa",
+                            "link": "ffi.html#fls_k1hiwghzxtfa",
+                            "number": "21:2"
+                        },
+                        {
+                            "checksum": "e6918e7d46ef5f24647902726d860e1abaf15c6b4f3e50771748abe1156acb4a",
+                            "id": "fls_3cgtdk4698hm",
+                            "link": "ffi.html#fls_3cgtdk4698hm",
+                            "number": "21:3"
+                        },
+                        {
+                            "checksum": "b297f2f7182e518adc328b76e8e51549d74fd016d982e945f3afad959b8e4fee",
+                            "id": "fls_shzmgci4f7o5",
+                            "link": "ffi.html#fls_shzmgci4f7o5",
+                            "number": "21:4"
+                        },
+                        {
+                            "checksum": "fc67b06bdfa241b1112995e95bea87b539fd31dee8c24e402fcd9d7af65eed2f",
+                            "id": "fls_m7x5odt4nb23",
+                            "link": "ffi.html#fls_m7x5odt4nb23",
+                            "number": "21:5"
+                        },
+                        {
+                            "checksum": "ed6db46b8be18e820fbb6dfc0dd19df1bb2ac9687dacf002b00c217d8ddbf625",
+                            "id": "fls_4akfvpq1yg4g",
+                            "link": "ffi.html#fls_4akfvpq1yg4g",
+                            "number": "21:6"
+                        },
+                        {
+                            "checksum": "a0f18eb2fe8db99bebeadf847111b16dfaa78ebdbaec8e8f7b364e6a40966ebf",
+                            "id": "fls_9d8v0xeyi0f",
+                            "link": "ffi.html#fls_9d8v0xeyi0f",
+                            "number": "21:7"
+                        }
+                    ],
+                    "title": "FFI"
+                },
+                {
+                    "id": "fls_usgd0xlijoxv",
+                    "informational": false,
+                    "link": "ffi.html#abi",
+                    "number": "21.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "5907d37d1b47c67dacab00d10295ab91ec2974c77016fc225a28413fdcecf896",
+                            "id": "fls_xangrq3tfze0",
+                            "link": "ffi.html#fls_xangrq3tfze0",
+                            "number": "21.1:1"
+                        },
+                        {
+                            "checksum": "303e206ff87fda7c72da6833ecc1035fb2e1bc4de71a73e3c1d6fce85b12b068",
+                            "id": "fls_2w0xi6rxw3uz",
+                            "link": "ffi.html#fls_2w0xi6rxw3uz",
+                            "number": "21.1:2"
+                        },
+                        {
+                            "checksum": "a7324b60f99f6fb51284703d13f58460e71099e1fae889aca7365c5c7c1b5976",
+                            "id": "fls_9zitf1fvvfk8",
+                            "link": "ffi.html#fls_9zitf1fvvfk8",
+                            "number": "21.1:3"
+                        },
+                        {
+                            "checksum": "9deadcb79842b0adc5ae917673a5a388d2bd4ed4c1732bf5a25e4e650395ca87",
+                            "id": "fls_x7ct9k82fpgn",
+                            "link": "ffi.html#fls_x7ct9k82fpgn",
+                            "number": "21.1:4"
+                        },
+                        {
+                            "checksum": "c336142c062c3b0f4238fbadf03105300bfcc6e13ec8c02ac9c02aa0bb4dcf50",
+                            "id": "fls_LfjvLXvI6TFL",
+                            "link": "ffi.html#fls_LfjvLXvI6TFL",
+                            "number": "21.1:5"
+                        },
+                        {
+                            "checksum": "39df1027aa9c166e4e50895b0a788131e1f5f2323e7cfd31b5e06e5b3c128c65",
+                            "id": "fls_a2d8ltpgtvn6",
+                            "link": "ffi.html#fls_a2d8ltpgtvn6",
+                            "number": "21.1:6"
+                        },
+                        {
+                            "checksum": "fad916b90d4bdea5184053e8d62af2714330ad0086c48776b03afe27e57d7e80",
+                            "id": "fls_8m7pc3riokst",
+                            "link": "ffi.html#fls_8m7pc3riokst",
+                            "number": "21.1:7"
+                        },
+                        {
+                            "checksum": "1e90ce91871f63afbcb47fc5716511ce8ef86c066f3b8bb81d43bc7856c543a8",
+                            "id": "fls_NQAzj5ai1La5",
+                            "link": "ffi.html#fls_NQAzj5ai1La5",
+                            "number": "21.1:8"
+                        },
+                        {
+                            "checksum": "bde0533495e75b4ceb809bb02e397e0d5daa1d7c3d1977865fcaf0ff5f4d989a",
+                            "id": "fls_r2drzo3dixe4",
+                            "link": "ffi.html#fls_r2drzo3dixe4",
+                            "number": "21.1:9"
+                        },
+                        {
+                            "checksum": "907e87e17820da8559bd8a486992acf18956b1456ecc61cb90278065e01374ca",
+                            "id": "fls_z2kzyin8dyr7",
+                            "link": "ffi.html#fls_z2kzyin8dyr7",
+                            "number": "21.1:10"
+                        },
+                        {
+                            "checksum": "c2d1059fcd1026468253d1771f735c5e6a5bab43177231babeb00190e68633a2",
+                            "id": "fls_j6pqchx27ast",
+                            "link": "ffi.html#fls_j6pqchx27ast",
+                            "number": "21.1:11"
+                        },
+                        {
+                            "checksum": "1454a6149650f43e10f4254d309ba83ae39d3052b579c45d26bed5c429ce1bc4",
+                            "id": "fls_dbbfqaqa80r8",
+                            "link": "ffi.html#fls_dbbfqaqa80r8",
+                            "number": "21.1:12"
+                        },
+                        {
+                            "checksum": "3015fb781cf27af98cfdb17a199fc06a282c4995bf513e4f23460aa87a24fefd",
+                            "id": "fls_UippZpUyYpHl",
+                            "link": "ffi.html#fls_UippZpUyYpHl",
+                            "number": "21.1:13"
+                        },
+                        {
+                            "checksum": "1da7fe0a23d93d524fed3110b8c116e9b7fe7f1563c51830ffd8b98ce562b9dd",
+                            "id": "fls_36qrs2fxxvi7",
+                            "link": "ffi.html#fls_36qrs2fxxvi7",
+                            "number": "21.1:14"
+                        },
+                        {
+                            "checksum": "d0f9c8d00a857e8d69b98fadc01f1222ca7838660e92dbf4c571d07df302a222",
+                            "id": "fls_CIyK8BYzzo26",
+                            "link": "ffi.html#fls_CIyK8BYzzo26",
+                            "number": "21.1:15"
+                        },
+                        {
+                            "checksum": "42ee2288dd6a0bde172c2aa19bdd6c764e4c21913a22a4d9d65065b478aa14ba",
+                            "id": "fls_6rtj6rwqxojh",
+                            "link": "ffi.html#fls_6rtj6rwqxojh",
+                            "number": "21.1:16"
+                        },
+                        {
+                            "checksum": "a81529042a5b1033d4dfd23dc355a422cafc5e8a94dac4134dcc1cdbe6d6b01d",
+                            "id": "fls_d3nmpc5mtg27",
+                            "link": "ffi.html#fls_d3nmpc5mtg27",
+                            "number": "21.1:17"
+                        },
+                        {
+                            "checksum": "fab1088ce02afa3c8566f0f5033efbd1b6cfec69fc639a64273cc39e32f479e5",
+                            "id": "fls_7t7yxh94wnbl",
+                            "link": "ffi.html#fls_7t7yxh94wnbl",
+                            "number": "21.1:18"
+                        },
+                        {
+                            "checksum": "5d748e814d1f01129f8b66ffb05acc435c309ab75eeff0b4e74925cc1e8b786b",
+                            "id": "fls_ccFdnlX5HIYk",
+                            "link": "ffi.html#fls_ccFdnlX5HIYk",
+                            "number": "21.1:19"
+                        },
+                        {
+                            "checksum": "aa45e16b2c9fb1e7d7ecf23ca38806bc2f369b1d1be518e74d28e24e6b54a8b4",
+                            "id": "fls_sxj4vy39sj4g",
+                            "link": "ffi.html#fls_sxj4vy39sj4g",
+                            "number": "21.1:20"
+                        },
+                        {
+                            "checksum": "563032c0e9c472e10f9c487c70925926c24107c3258cc003fb04dd03b00c21af",
+                            "id": "fls_tyjs1x4j8ovp",
+                            "link": "ffi.html#fls_tyjs1x4j8ovp",
+                            "number": "21.1:21"
+                        },
+                        {
+                            "checksum": "985fd96881b7c12b952e2f2a81cdc5713cd19ec157141a68232ac19172c96907",
+                            "id": "fls_xrCRprWS13R1",
+                            "link": "ffi.html#fls_xrCRprWS13R1",
+                            "number": "21.1:22"
+                        },
+                        {
+                            "checksum": "f392bf3391787b024699ac732bffa8db2661c5d3f6e13335913304f6b7f38b20",
+                            "id": "fls_JHlqXjn4Sf07",
+                            "link": "ffi.html#fls_JHlqXjn4Sf07",
+                            "number": "21.1:23"
+                        },
+                        {
+                            "checksum": "2eb97e47f68715623197b729da4072c1fd6dd94cc8a38e41f135832c8ac7312e",
+                            "id": "fls_M4LqHf8hbPA8",
+                            "link": "ffi.html#fls_M4LqHf8hbPA8",
+                            "number": "21.1:24"
+                        }
+                    ],
+                    "title": "ABI"
+                },
+                {
+                    "id": "fls_tmoh3y9oyqsy",
+                    "informational": false,
+                    "link": "ffi.html#external-blocks",
+                    "number": "21.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "5690487aad48826d0fbca987e21993dde238a0492461e8b3e35e3f49b1810f50",
+                            "id": "fls_4dje9t5y2dia",
+                            "link": "ffi.html#fls_4dje9t5y2dia",
+                            "number": "21.2:1"
+                        },
+                        {
+                            "checksum": "e9d30e0c8d7251366fcba4b5a93322f61b5d415d8ea85b870b7a8de0eae5728d",
+                            "id": "fls_8ltVLtAfvy0m",
+                            "link": "ffi.html#fls_8ltVLtAfvy0m",
+                            "number": "21.2:2"
+                        },
+                        {
+                            "checksum": "8fa9f3206c1f1e9af22942ab5569d11a808e99fcb06365a0c2f5be68d1af8497",
+                            "id": "fls_Nz0l16hMxqTd",
+                            "link": "ffi.html#fls_Nz0l16hMxqTd",
+                            "number": "21.2:3"
+                        },
+                        {
+                            "checksum": "be19b76230f53b9d539f838eb6c73119e8210045835c5c82f58a9bd1876de4b7",
+                            "id": "fls_4XOoiFloXM7t",
+                            "link": "ffi.html#fls_4XOoiFloXM7t",
+                            "number": "21.2:4"
+                        },
+                        {
+                            "checksum": "dd7c836fa590b14a7da0c87f48b6eb0d11c83010e9f4ac1e0615ebecc9ba7eb3",
+                            "id": "fls_PBsepNHImJKH",
+                            "link": "ffi.html#fls_PBsepNHImJKH",
+                            "number": "21.2:5"
+                        }
+                    ],
+                    "title": "External Blocks"
+                },
+                {
+                    "id": "fls_yztwtek0y34v",
+                    "informational": false,
+                    "link": "ffi.html#external-functions",
+                    "number": "21.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "0104ba914d1d2a6dafc2b7914cc94254e1ab3678864a25c1864a89740a54294f",
+                            "id": "fls_v24ino4hix3m",
+                            "link": "ffi.html#fls_v24ino4hix3m",
+                            "number": "21.3:1"
+                        },
+                        {
+                            "checksum": "f42fee85a3cead90e0424d6ae591a72b9d777fa19fdaee7718a36a484f0a8166",
+                            "id": "fls_l88r9fj82650",
+                            "link": "ffi.html#fls_l88r9fj82650",
+                            "number": "21.3:2"
+                        },
+                        {
+                            "checksum": "9abb006e22c228a40953b442c54e63fd9a10cc675390d5e7d61b1fb7221ec353",
+                            "id": "fls_qwchgvvnp0qe",
+                            "link": "ffi.html#fls_qwchgvvnp0qe",
+                            "number": "21.3:3"
+                        },
+                        {
+                            "checksum": "af35e63fe34e63713827f5525caee153a033f726c0cf64300b5612781daf29fc",
+                            "id": "fls_w00qi1gx204e",
+                            "link": "ffi.html#fls_w00qi1gx204e",
+                            "number": "21.3:4"
+                        },
+                        {
+                            "checksum": "9ff777cfdc4b91eb8472493cfbc9e96b5e66329d621fb37d3c8603b420f63f79",
+                            "id": "fls_m7tu4w4lk8v",
+                            "link": "ffi.html#fls_m7tu4w4lk8v",
+                            "number": "21.3:5"
+                        },
+                        {
+                            "checksum": "69809b6272d266f36a20ad706492a4e3561e0afa136d36145d8804f83456d978",
+                            "id": "fls_rdu4723vp0oo",
+                            "link": "ffi.html#fls_rdu4723vp0oo",
+                            "number": "21.3:6"
+                        },
+                        {
+                            "checksum": "8a5942ade1d1568f8a2e335a8767ab295816829fc64e2c4ef250f53feee9ec69",
+                            "id": "fls_9div9yusw64h",
+                            "link": "ffi.html#fls_9div9yusw64h",
+                            "number": "21.3:7"
+                        },
+                        {
+                            "checksum": "0e21072dc94fa05d0ff274b95c7cdfe5e96a5fddabfd26720dd20bcd7aecbf38",
+                            "id": "fls_juob30rst11r",
+                            "link": "ffi.html#fls_juob30rst11r",
+                            "number": "21.3:8"
+                        }
+                    ],
+                    "title": "External Functions"
+                },
+                {
+                    "id": "fls_s4yt19sptl7d",
+                    "informational": false,
+                    "link": "ffi.html#external-statics",
+                    "number": "21.4",
+                    "paragraphs": [
+                        {
+                            "checksum": "a342af289e2343c6a6c563bb75a44dd7f003efc17cc5dddaf9db25fc1395f17c",
+                            "id": "fls_8ddsytjr4il6",
+                            "link": "ffi.html#fls_8ddsytjr4il6",
+                            "number": "21.4:1"
+                        },
+                        {
+                            "checksum": "7456ec21405a4f2629a47ca17fd031b08d4bf3cde66139fe81c3b11248264ca1",
+                            "id": "fls_H0cg9XMaGz0y",
+                            "link": "ffi.html#fls_H0cg9XMaGz0y",
+                            "number": "21.4:2"
+                        },
+                        {
+                            "checksum": "6bfbc90ac6b0ebe2bf403b473eb2876a892442339359bafeb4fa203aa258570c",
+                            "id": "fls_fo9with6xumo",
+                            "link": "ffi.html#fls_fo9with6xumo",
+                            "number": "21.4:3"
+                        },
+                        {
+                            "checksum": "1e3dcb44d797a493ed568db4d4a7c292794fa22ef50cc810f94492b86ec20c75",
+                            "id": "fls_tr7purzcldn0",
+                            "link": "ffi.html#fls_tr7purzcldn0",
+                            "number": "21.4:4"
+                        },
+                        {
+                            "checksum": "0fb23c674fc5c6699fc7b3869fdc36f00d967880169275042498442dc58a8872",
+                            "id": "fls_en2h09ehj0j3",
+                            "link": "ffi.html#fls_en2h09ehj0j3",
+                            "number": "21.4:5"
+                        }
+                    ],
+                    "title": "External Statics"
+                }
+            ],
+            "title": "FFI"
+        },
+        {
+            "informational": true,
+            "link": "general.html",
+            "sections": [
+                {
+                    "id": "fls_48qldfwwh493",
+                    "informational": false,
+                    "link": "general.html",
+                    "number": "1",
+                    "paragraphs": [
+                        {
+                            "checksum": "b56c8be8103d8226bbdec210a97ca8f2c38405d36f65f17b15936a1a8284b26c",
+                            "id": "fls_c4ry0kgmvk9z",
+                            "link": "general.html#fls_c4ry0kgmvk9z",
+                            "number": "1:1"
+                        },
+                        {
+                            "checksum": "4a8fd448c0e40fd0675f5d82c36b6f963f99259021c6022cc9bd5104c20fbdeb",
+                            "id": "fls_gxqbj0qoiaio",
+                            "link": "general.html#fls_gxqbj0qoiaio",
+                            "number": "1:2"
+                        },
+                        {
+                            "checksum": "02be35a62aff5e48d56d3fb05c75ade724aff55d6ad8278715bd7fac8adbe03f",
+                            "id": "fls_u8k9zr8da30",
+                            "link": "general.html#fls_u8k9zr8da30",
+                            "number": "1:3"
+                        },
+                        {
+                            "checksum": "11a39a0b407d0ca45db7639f588e85fe27910624c6c508283f983229a6aad5db",
+                            "id": "fls_8mt9iigoboba",
+                            "link": "general.html#fls_8mt9iigoboba",
+                            "number": "1:4"
+                        },
+                        {
+                            "checksum": "cd1b728c4e56af1dd90836a76afce9239d07ea2aa3095cbeedf8693a22f14caf",
+                            "id": "fls_suhf2g3fatfa",
+                            "link": "general.html#fls_suhf2g3fatfa",
+                            "number": "1:5"
+                        },
+                        {
+                            "checksum": "8b4dce11b14d66a6a1177ef131384957fe6a887c388d56a1902e09ee60f80af0",
+                            "id": "fls_jjr5kbn0wuco",
+                            "link": "general.html#fls_jjr5kbn0wuco",
+                            "number": "1:6"
+                        },
+                        {
+                            "checksum": "3a278c9aaaabec045a6eede8eb5a0beab745d8b84b098a39b6cdf2e167bc5178",
+                            "id": "fls_4dfcjyprkzbx",
+                            "link": "general.html#fls_4dfcjyprkzbx",
+                            "number": "1:7"
+                        },
+                        {
+                            "checksum": "1e02dbccc64818a6cebcc7d6331d8281a24621e813178d0f5be9d0b3356c7a22",
+                            "id": "fls_tq9jcv5ddvwn",
+                            "link": "general.html#fls_tq9jcv5ddvwn",
+                            "number": "1:8"
+                        }
+                    ],
+                    "title": "General"
+                },
+                {
+                    "id": "fls_fo1c7pg2mw1",
+                    "informational": false,
+                    "link": "general.html#scope",
+                    "number": "1.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "cd56fca25aa434be193f4140fb7a1cd61650876d6446d93d81093eaad448d442",
+                            "id": "fls_srdq4mota5pr",
+                            "link": "general.html#fls_srdq4mota5pr",
+                            "number": "1.1:1"
+                        },
+                        {
+                            "checksum": "b3cdec704c28577193c03cd2eb90cec360e5651ed07b259d112673a67dc0200d",
+                            "id": "fls_dv1qish8svc",
+                            "link": "general.html#fls_dv1qish8svc",
+                            "number": "1.1:2"
+                        }
+                    ],
+                    "title": "Scope"
+                },
+                {
+                    "id": "fls_10yukmkhl0ng",
+                    "informational": false,
+                    "link": "general.html#extent",
+                    "number": "1.1.1",
+                    "paragraphs": [
+                        {
+                            "checksum": "07358ef439d78086f970b0606b6da177cb6cc2e64318f27af92832c21a67be43",
+                            "id": "fls_x78yd1sszydv",
+                            "link": "general.html#fls_x78yd1sszydv",
+                            "number": "1.1.1:1"
+                        },
+                        {
+                            "checksum": "818ed40aac2e52250ea0014e5de7fbcbcf1e8f325b74a015ac0085699523a43d",
+                            "id": "fls_9e032738udnb",
+                            "link": "general.html#fls_9e032738udnb",
+                            "number": "1.1.1:2"
+                        },
+                        {
+                            "checksum": "85861dc839d41712fe2a39712eb1dcfd1dc88ba30f3782f92bd1986fe355c196",
+                            "id": "fls_jk7scu5xs17z",
+                            "link": "general.html#fls_jk7scu5xs17z",
+                            "number": "1.1.1:3"
+                        },
+                        {
+                            "checksum": "dc11c0150f1c1ea89b5e2e31e3d90c45c62fa5d26005eb9ed3a16e3f7a3fb68c",
+                            "id": "fls_jiryupa5fxgf",
+                            "link": "general.html#fls_jiryupa5fxgf",
+                            "number": "1.1.1:4"
+                        },
+                        {
+                            "checksum": "4ce6c16caad38e7ccb47adc109089c53cc047073ebba0a06457cbeded05f68e0",
+                            "id": "fls_sph1a3sapinh",
+                            "link": "general.html#fls_sph1a3sapinh",
+                            "number": "1.1.1:5"
+                        },
+                        {
+                            "checksum": "7c348ba84b24afee5a0a39c44f15af8c05a07208877750c9a766d44ab767da7b",
+                            "id": "fls_7tm19jxtffc8",
+                            "link": "general.html#fls_7tm19jxtffc8",
+                            "number": "1.1.1:6"
+                        },
+                        {
+                            "checksum": "585a289861cd9b12366dc2314022378903323fea3cdbd6863a2e5bd96ed69446",
+                            "id": "fls_5pbrl8lhuth1",
+                            "link": "general.html#fls_5pbrl8lhuth1",
+                            "number": "1.1.1:7"
+                        },
+                        {
+                            "checksum": "fc97ac93c58134f54e07f9f6ff5334dbf3afdc8b1e707525ddd8eb232a915c74",
+                            "id": "fls_o8fc3e53vp7g",
+                            "link": "general.html#fls_o8fc3e53vp7g",
+                            "number": "1.1.1:8"
+                        },
+                        {
+                            "checksum": "8adc0c63aa968e623b7251ecc0776057325470f81d39879bb6dfb23d1985a407",
+                            "id": "fls_rw0y5t13y6gs",
+                            "link": "general.html#fls_rw0y5t13y6gs",
+                            "number": "1.1.1:9"
+                        },
+                        {
+                            "checksum": "2f2276e84ea3e0251d343a2c859bafeefc4eb09d8d7222774ce538650c01980b",
+                            "id": "fls_x7c3o621qj9z",
+                            "link": "general.html#fls_x7c3o621qj9z",
+                            "number": "1.1.1:10"
+                        },
+                        {
+                            "checksum": "cd7a1f68c81b43b8536b355596a13da9ddc2e33d7b37a18af00eee2456c3fd06",
+                            "id": "fls_5y2b6yjcl1vz",
+                            "link": "general.html#fls_5y2b6yjcl1vz",
+                            "number": "1.1.1:11"
+                        },
+                        {
+                            "checksum": "a695d7fe1b36b6516b8530ec034376b8c43e7aa53cd0795f48e39482be5a38cf",
+                            "id": "fls_8dennhk2dha",
+                            "link": "general.html#fls_8dennhk2dha",
+                            "number": "1.1.1:12"
+                        },
+                        {
+                            "checksum": "65c2d0a375d2b29b8836f90cfdf174fc8fe72f5198073097bb9401add5d0880b",
+                            "id": "fls_j2gs3hrbxtyx",
+                            "link": "general.html#fls_j2gs3hrbxtyx",
+                            "number": "1.1.1:13"
+                        },
+                        {
+                            "checksum": "94c8f2e37b34e95fffa62df717bbcd7d87653a8506a65f52d91e1706e0dfe9d8",
+                            "id": "fls_gy2c7vfwkd8j",
+                            "link": "general.html#fls_gy2c7vfwkd8j",
+                            "number": "1.1.1:14"
+                        }
+                    ],
+                    "title": "Extent"
+                },
+                {
+                    "id": "fls_xscgklvg1wd2",
+                    "informational": false,
+                    "link": "general.html#structure",
+                    "number": "1.1.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "9d1641a50a597e4ce0553ceca94bbf6c254d57933639a13b9b13f852c10f4640",
+                            "id": "fls_6lrqailxjb02",
+                            "link": "general.html#fls_6lrqailxjb02",
+                            "number": "1.1.2:1"
+                        },
+                        {
+                            "checksum": "13aa072e39fbda618587953663ec86d1a188fe0eb4db97252b906ca8e9c2fe51",
+                            "id": "fls_tys7ciqnp8bn",
+                            "link": "general.html#fls_tys7ciqnp8bn",
+                            "number": "1.1.2:2"
+                        },
+                        {
+                            "checksum": "934ba26ee073ed0a5cbaf9b98cf9005d3786c907b9de25f60f31c18a1d5ddb1c",
+                            "id": "fls_3ubhkaheu8i1",
+                            "link": "general.html#fls_3ubhkaheu8i1",
+                            "number": "1.1.2:3"
+                        },
+                        {
+                            "checksum": "b9623aca56a3fe17319f63a0b550b6405ad21f99012d17ae6f6ce41d1f1605d4",
+                            "id": "fls_xw3grr2g5zgi",
+                            "link": "general.html#fls_xw3grr2g5zgi",
+                            "number": "1.1.2:4"
+                        },
+                        {
+                            "checksum": "11c90805ef23752a416f5a6a8b69230febfdf97b68edaf26f6517bd359492443",
+                            "id": "fls_6srbinvnyd54",
+                            "link": "general.html#fls_6srbinvnyd54",
+                            "number": "1.1.2:5"
+                        },
+                        {
+                            "checksum": "fdcfcebd0c9395a151b773b35ef5d5e2720a08080c54f279652f7668a0182897",
+                            "id": "fls_ciixfg9jhv42",
+                            "link": "general.html#fls_ciixfg9jhv42",
+                            "number": "1.1.2:6"
+                        },
+                        {
+                            "checksum": "25a56f970c722a9217989c3250b9b75798453ac229d32dc74b97c2a6c84a2109",
+                            "id": "fls_ej94lm2682kg",
+                            "link": "general.html#fls_ej94lm2682kg",
+                            "number": "1.1.2:7"
+                        },
+                        {
+                            "checksum": "1531d2cfb29ab712e3adf7fc798c2342b8977bae5175dda990efd578592d2454",
+                            "id": "fls_xgk91jrbpyoc",
+                            "link": "general.html#fls_xgk91jrbpyoc",
+                            "number": "1.1.2:8"
+                        },
+                        {
+                            "checksum": "db3c5f8206004bb2cca82ca219a417ec2a4fe259773ae667ab3d10114d5740ee",
+                            "id": "fls_jc4upf6685bw",
+                            "link": "general.html#fls_jc4upf6685bw",
+                            "number": "1.1.2:9"
+                        },
+                        {
+                            "checksum": "1594b619675d7802bccfee40ca10262be9916e29f70d8f7fecbf5dddd00246f4",
+                            "id": "fls_oxzjqxgejx9t",
+                            "link": "general.html#fls_oxzjqxgejx9t",
+                            "number": "1.1.2:10"
+                        },
+                        {
+                            "checksum": "acf02a4a250adb8e29284b356a6f4a386a936d32f0e85d3b304e708863f10929",
+                            "id": "fls_gmx688d6ek1o",
+                            "link": "general.html#fls_gmx688d6ek1o",
+                            "number": "1.1.2:11"
+                        },
+                        {
+                            "checksum": "7f053104dd4947498f1bb5121b9fe28a23d78ead65d37dd580df0111d558d8dd",
+                            "id": "fls_5zdjikp1jhc",
+                            "link": "general.html#fls_5zdjikp1jhc",
+                            "number": "1.1.2:12"
+                        },
+                        {
+                            "checksum": "44025e9b54bdddecd35c847f5628ffddbfc9e4721cd733f41c9186c904ef15b1",
+                            "id": "fls_as5bhc5t285g",
+                            "link": "general.html#fls_as5bhc5t285g",
+                            "number": "1.1.2:13"
+                        },
+                        {
+                            "checksum": "6efef41c7a703e3b3562b12e95047110a954b19026060d22099de222c142ed8b",
+                            "id": "fls_70qjvaqoz007",
+                            "link": "general.html#fls_70qjvaqoz007",
+                            "number": "1.1.2:14"
+                        },
+                        {
+                            "checksum": "525edc88be77e71d6777eef00907902bcd024abb3c401a92d67f1ca997971c5a",
+                            "id": "fls_o4rdsbc7u98",
+                            "link": "general.html#fls_o4rdsbc7u98",
+                            "number": "1.1.2:15"
+                        },
+                        {
+                            "checksum": "3ab99fa52627e6796ca7e01a7242052885523e5e0f93b9dd98ec22d483688e60",
+                            "id": "fls_w8j575w2hmc8",
+                            "link": "general.html#fls_w8j575w2hmc8",
+                            "number": "1.1.2:16"
+                        }
+                    ],
+                    "title": "Structure"
+                },
+                {
+                    "id": "fls_99b7xi1bkgih",
+                    "informational": false,
+                    "link": "general.html#conformity",
+                    "number": "1.1.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "42aa78f31bd39d9d54d95d846fc09f42910052efc6f2cb7eb50a7b34706f7c97",
+                            "id": "fls_kdyqtnc6loam",
+                            "link": "general.html#fls_kdyqtnc6loam",
+                            "number": "1.1.3:1"
+                        },
+                        {
+                            "checksum": "1b1e377b795c593c09c9e640deb4d270fad22997bd2c697ee3bb4b3c4109ecca",
+                            "id": "fls_dBKu9jgx3OyH",
+                            "link": "general.html#fls_dBKu9jgx3OyH",
+                            "number": "1.1.3:2"
+                        },
+                        {
+                            "checksum": "8ade643b2872a946f749a6125849c9d9af29cb64ca9c611b05332fae6c4ceacb",
+                            "id": "fls_faRvWyJJpno8",
+                            "link": "general.html#fls_faRvWyJJpno8",
+                            "number": "1.1.3:3"
+                        },
+                        {
+                            "checksum": "581e966a0c27c9ea6c0cbfb6d1bf739d24fb579f2495fc002947b3e93977c231",
+                            "id": "fls_GZmxrO61eiJ1",
+                            "link": "general.html#fls_GZmxrO61eiJ1",
+                            "number": "1.1.3:4"
+                        },
+                        {
+                            "checksum": "1f8c2956cb9f8b946f0f56053a038a9ab8efaf6dd7881bb5d1d65e1c87b05900",
+                            "id": "fls_nnmx2qsu14ft",
+                            "link": "general.html#fls_nnmx2qsu14ft",
+                            "number": "1.1.3:5"
+                        },
+                        {
+                            "checksum": "adb8b69470c26508c51b735aa65a30d464dae4eecafb85f3cad7b62450557213",
+                            "id": "fls_gu3331rmv2ho",
+                            "link": "general.html#fls_gu3331rmv2ho",
+                            "number": "1.1.3:6"
+                        },
+                        {
+                            "checksum": "030c86e984b66288b589337553d3375d3fdecc0dfab304381123495642596b20",
+                            "id": "fls_AR8ZIYlDRSNs",
+                            "link": "general.html#fls_AR8ZIYlDRSNs",
+                            "number": "1.1.3:7"
+                        },
+                        {
+                            "checksum": "09785f4e7f3719f15b9790de8e8388bce97f35323591af71ed34b453c9b2ef30",
+                            "id": "fls_xAYhvEh7WWel",
+                            "link": "general.html#fls_xAYhvEh7WWel",
+                            "number": "1.1.3:8"
+                        },
+                        {
+                            "checksum": "01a005ca17491af3519bb4e745fbef2a83ce55109d5787034a94659c1dd03f36",
+                            "id": "fls_QvFpU8v5p8Hb",
+                            "link": "general.html#fls_QvFpU8v5p8Hb",
+                            "number": "1.1.3:9"
+                        },
+                        {
+                            "checksum": "849ea928df375ac126378ee4fd16534119a4f03f42721cd25145edc4d7850294",
+                            "id": "fls_pl0fyjcwslqm",
+                            "link": "general.html#fls_pl0fyjcwslqm",
+                            "number": "1.1.3:10"
+                        },
+                        {
+                            "checksum": "534de23af559805d2b96e284fdd9afc9838e9e3f65b120c5401aa7cf130d439b",
+                            "id": "fls_lkdm0mdghppv",
+                            "link": "general.html#fls_lkdm0mdghppv",
+                            "number": "1.1.3:11"
+                        },
+                        {
+                            "checksum": "f87533ba7b47cb56f59c27e8d99d031d3c5c35b16c4d3ae271ddb9b3ee18c33b",
+                            "id": "fls_d07x1mbhgpsd",
+                            "link": "general.html#fls_d07x1mbhgpsd",
+                            "number": "1.1.3:12"
+                        }
+                    ],
+                    "title": "Conformity"
+                },
+                {
+                    "id": "fls_79rl6ylmct07",
+                    "informational": false,
+                    "link": "general.html#method-of-description-and-syntax-notation",
+                    "number": "1.1.4",
+                    "paragraphs": [
+                        {
+                            "checksum": "8811c1ef8e9707861f67d171dc813cc290188343fde68d68304072ab9d422c41",
+                            "id": "fls_mc4a28do6kcp",
+                            "link": "general.html#fls_mc4a28do6kcp",
+                            "number": "1.1.4:1"
+                        },
+                        {
+                            "checksum": "e62cf2d485b81b81793c685b6fef64ad6d407da40349a45129bfd298fb8d0258",
+                            "id": "fls_ioyp4wux6skt",
+                            "link": "general.html#fls_ioyp4wux6skt",
+                            "number": "1.1.4:2"
+                        },
+                        {
+                            "checksum": "5be24f2bcda1727c3b6e1ad27d2d7c8ffe6e487d292f2b48bd528e411c2ae1be",
+                            "id": "fls_jsflt7691ye4",
+                            "link": "general.html#fls_jsflt7691ye4",
+                            "number": "1.1.4:3"
+                        },
+                        {
+                            "checksum": "15f27fa3164d4f34e687dff0589a9406f64fd304a5cbac1d917e215a3420b24d",
+                            "id": "fls_98fm7z04lq9",
+                            "link": "general.html#fls_98fm7z04lq9",
+                            "number": "1.1.4:4"
+                        },
+                        {
+                            "checksum": "bf197e4e3db74f8f9189b2d39392b793c47f8e26908e5ff493a91d3567e2e58d",
+                            "id": "fls_ceb5a8t6cakr",
+                            "link": "general.html#fls_ceb5a8t6cakr",
+                            "number": "1.1.4:5"
+                        },
+                        {
+                            "checksum": "e53521056d56c3f85475811368708e304047e64d39a20604584fa7f38d9c7f86",
+                            "id": "fls_pts29mb5ld68",
+                            "link": "general.html#fls_pts29mb5ld68",
+                            "number": "1.1.4:6"
+                        },
+                        {
+                            "checksum": "48013ee45666937c8ad55fb39de161c383ead549216e3bdc9e2882e83bcf0a90",
+                            "id": "fls_gqjo5oh7vn3b",
+                            "link": "general.html#fls_gqjo5oh7vn3b",
+                            "number": "1.1.4:7"
+                        },
+                        {
+                            "checksum": "f6d36c515bd4436ca87447bc369bb7b1c69b50ca9215b1d6981dabce39f33593",
+                            "id": "fls_1dz634xp8xp5",
+                            "link": "general.html#fls_1dz634xp8xp5",
+                            "number": "1.1.4:8"
+                        },
+                        {
+                            "checksum": "949f3857c5bbb056b780f44c08df02afc05d59db42be92d94a86c97a20ae4943",
+                            "id": "fls_pp9vtjlyblrl",
+                            "link": "general.html#fls_pp9vtjlyblrl",
+                            "number": "1.1.4:9"
+                        },
+                        {
+                            "checksum": "d7b7b2e401f1bc24ffd16c1f417d18c3d12336cc2d2325ecc1c07d77ea0e513e",
+                            "id": "fls_6e2vd9fvhsmk",
+                            "link": "general.html#fls_6e2vd9fvhsmk",
+                            "number": "1.1.4:10"
+                        },
+                        {
+                            "checksum": "0eda08ae37976f0d7d15570d790c9bc3107ea4533794e554872ea0d77af06d9c",
+                            "id": "fls_4onq0kkrt6qv",
+                            "link": "general.html#fls_4onq0kkrt6qv",
+                            "number": "1.1.4:11"
+                        },
+                        {
+                            "checksum": "bf1b757e4fec099109dc75529b8709e0177c379698e8c762c5c27fe8fe0ac2d3",
+                            "id": "fls_qu4rsmnq659w",
+                            "link": "general.html#fls_qu4rsmnq659w",
+                            "number": "1.1.4:12"
+                        },
+                        {
+                            "checksum": "ca3586f81ab3962899f5a1a79386ef8637003025a729a5b76bebdb5d1e43cb28",
+                            "id": "fls_rllu7aksf17e",
+                            "link": "general.html#fls_rllu7aksf17e",
+                            "number": "1.1.4:13"
+                        },
+                        {
+                            "checksum": "87380f5c66b721c614a404b1852a6c1f93b93d02b04517c8be6e401f85832f82",
+                            "id": "fls_blvsfqeevosr",
+                            "link": "general.html#fls_blvsfqeevosr",
+                            "number": "1.1.4:14"
+                        },
+                        {
+                            "checksum": "d05cec36bfece44c3203af30f098975bd0f3d0cccd9687f0956cd9eca66c810f",
+                            "id": "fls_lwcjq3wzjyvb",
+                            "link": "general.html#fls_lwcjq3wzjyvb",
+                            "number": "1.1.4:15"
+                        },
+                        {
+                            "checksum": "9a579e74f8de12da445c5197e2555aab86fc739d0defc1f685c0aa5dfb44cebc",
+                            "id": "fls_v7wd5yk00im6",
+                            "link": "general.html#fls_v7wd5yk00im6",
+                            "number": "1.1.4:16"
+                        },
+                        {
+                            "checksum": "afb0e775413f09199a584413d501b6ec88d107c1be87cac6e07bc33ecce6ad74",
+                            "id": "fls_nf8alga8uz6c",
+                            "link": "general.html#fls_nf8alga8uz6c",
+                            "number": "1.1.4:17"
+                        }
+                    ],
+                    "title": "Method of Description and Syntax Notation"
+                },
+                {
+                    "id": "fls_9cd746qe40ag",
+                    "informational": false,
+                    "link": "general.html#versioning",
+                    "number": "1.2",
+                    "paragraphs": [
+                        {
+                            "checksum": "ac30f10574356a3a3472c8858b8b13e8b8ef034312c5823a3674a594b4e4e468",
+                            "id": "fls_l80e3kdwnldc",
+                            "link": "general.html#fls_l80e3kdwnldc",
+                            "number": "1.2:1"
+                        }
+                    ],
+                    "title": "Versioning"
+                },
+                {
+                    "id": "fls_ijzgf4h0mp3c",
+                    "informational": false,
+                    "link": "general.html#definitions",
+                    "number": "1.3",
+                    "paragraphs": [
+                        {
+                            "checksum": "34f82930e1b6b4af471b30519f81d43725341882ad0a3e8e36d85ab7b3f5713b",
+                            "id": "fls_sm2kexes5pr7",
+                            "link": "general.html#fls_sm2kexes5pr7",
+                            "number": "1.3:1"
+                        },
+                        {
+                            "checksum": "397ee14d96917a0a9033a587347a2246e4118f1270d64cce0f7eefeeaf565980",
+                            "id": "fls_2o98zw29xc46",
+                            "link": "general.html#fls_2o98zw29xc46",
+                            "number": "1.3:2"
+                        },
+                        {
+                            "checksum": "969a1f3b691a3118abcd815618a71feba07fdd5be4c2a12ce37d0b49595d013a",
+                            "id": "fls_lon5qffd65fi",
+                            "link": "general.html#fls_lon5qffd65fi",
+                            "number": "1.3:3"
+                        },
+                        {
+                            "checksum": "0d6e2d5075e9ccebe0f79ee2d1d393c07fae6b8d4b6cbf7fbf59b1348185fc5d",
+                            "id": "fls_qeolgxvcy75",
+                            "link": "general.html#fls_qeolgxvcy75",
+                            "number": "1.3:4"
+                        },
+                        {
+                            "checksum": "70b86c11c1708aa3d4d6b52af002352aebaef77835c4b45ebc4233a789844230",
+                            "id": "fls_h2m244agxaxs",
+                            "link": "general.html#fls_h2m244agxaxs",
+                            "number": "1.3:5"
+                        },
+                        {
+                            "checksum": "c669dced28f1bb44dbac7e17e855e184b1f14baecfa15e22b21d2379a5998be6",
+                            "id": "fls_47svine904xk",
+                            "link": "general.html#fls_47svine904xk",
+                            "number": "1.3:6"
+                        }
+                    ],
+                    "title": "Definitions"
+                }
+            ],
+            "title": "General"
         }
     ]
 }


### PR DESCRIPTION
1) The two div-by-zero guidelines are related to https://rust-lang.github.io/fls/expressions.html#fls_Q9dhNiICGIfr
This element of the FLS hasn't significantly changed (dividing by 0 still results in panic).

2) One very old pointer guideline is related to https://rust-lang.github.io/fls/expressions.html#fls_9wgldua1u8yt
This element, as far as I can tell, hasn't changed significantly either (dereferencing dangling or unaligned pointers has been UB for a while).