### PR TITLE
fix: add /rectify reconciliation path for reviewer-bot state

### DIFF
--- a/.github/workflows/reviewer-bot.yml
+++ b/.github/workflows/reviewer-bot.yml
@@ -95,6 +95,7 @@ jobs:
           # Review context (for pull_request_review events)
           REVIEW_STATE: ${{ github.event.review.state }}
           REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          PR_IS_CROSS_REPOSITORY: ${{ github.event.pull_request != null && github.event.pull_request.head.repo.full_name != github.repository }}
           # For manual dispatch
           MANUAL_ACTION: ${{ github.event.inputs.action }}
           # Repository info


### PR DESCRIPTION
## Summary
- add `/rectify` command routing and per-PR reconcile logic based on the assigned reviewer's latest review
- defer cross-repo `pull_request_review` persistence with explicit logs directing maintainers to `/rectify`
- fail reviewer-bot runs when state persistence fails to avoid silent success
- keep scope to `scripts/reviewer_bot.py`, `.github/workflows/reviewer-bot.yml`, and reviewer-bot tests

## Validation
- `uv run ruff check --fix`
- `uv run pytest .github/reviewer-bot-tests`
- `uv run pytest .github/guideline-from-issue-tests`
- `uv run pytest`