### PR TITLE
fix(reviewer-bot): auto-reconcile fork PR approvals via workflow_run

### DIFF
--- a/.github/workflows/reviewer-bot-reconcile.yml
+++ b/.github/workflows/reviewer-bot-reconcile.yml
@@ -1,0 +1,41 @@
+name: Reviewer Bot Reconcile
+
+on:
+  workflow_run:
+    workflows: ["Reviewer Bot"]
+    types: [completed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+env:
+  STATE_ISSUE_NUMBER: "314"
+
+jobs:
+  reconcile:
+    if: ${{ github.event.workflow_run.event == 'pull_request_review' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Run reviewer bot reconcile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATE_ISSUE_NUMBER: ${{ env.STATE_ISSUE_NUMBER }}
+          EVENT_NAME: workflow_run
+          EVENT_ACTION: ${{ github.event.action }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_REPO_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          uv run python scripts/reviewer_bot.py


### PR DESCRIPTION
## Root cause
- Fork PR `pull_request_review` runs for Reviewer Bot can execute with read-only token permissions (`Issues: read`, `PullRequests: read`).
- In that mode, the bot sees approval but cannot persist issue `#314` state, so review remains incomplete until manual `/rectify`.

## What changed
- Added `Reviewer Bot Reconcile`, a second-hop workflow triggered by `workflow_run` completion of `Reviewer Bot` when the source event is `pull_request_review`.
- Added workflow-run reconciliation support in `scripts/reviewer_bot.py`, including PR number resolution from `WORKFLOW_RUN_PULL_REQUESTS` with fallback lookup by head owner and branch.
- Reused reconcile logic in workflow-run mode without requiring `IS_PULL_REQUEST=true`, and persisted completion source as `workflow_run:pull_request_review`.

## Validation
- Baseline evidence from PR `#397` run `21839660732` shows read-only token scope and deferral log; issue `#314` entry for `397` remained `review_completed_at: null`.
- `uv run ruff check --fix`
- `uv run pytest .github/reviewer-bot-tests` (72 passed)