### PR TITLE
fix: post workflow_run reconcile comment when state changes

### DIFF
--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -2429,6 +2429,14 @@ def handle_workflow_run_event(state: dict) -> bool:
         raise RuntimeError(
             f"Workflow_run reconcile failed for pull request #{issue_number}: {message}"
         )
+
+    if state_changed and not post_comment(issue_number, message):
+        print(
+            "WARNING: Workflow_run reconcile changed state but failed to post "
+            f"comment on pull request #{issue_number}.",
+            file=sys.stderr,
+        )
+
     return state_changed
 
 


### PR DESCRIPTION
## Summary
- post the workflow_run reconcile result as a PR comment when reconcile updates state
- keep idempotent no-op reconcile behavior so already-complete entries do not post comments
- add tests covering comment emission, no-op behavior, and non-fatal comment-post failures

## Validation
- uv run ruff check --fix
- uv run pytest .github/reviewer-bot-tests