### PR TITLE
fix(reviewer-bot): fail closed state reads and guard schedule wipes

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -38,6 +38,7 @@ def clear_env():
         "COMMENT_BODY",
         "COMMENT_AUTHOR",
         "COMMENT_ID",
+        "ALLOW_EMPTY_ACTIVE_REVIEWS_WRITE",
         "EVENT_ACTION",
         "EVENT_NAME",
         "ISSUE_NUMBER",
@@ -151,6 +152,83 @@ def test_load_state_applies_defaults(monkeypatch):
     assert state["pass_until"] == []
     assert state["recent_assignments"] == []
     assert state["active_reviews"] == {}
+
+
+def test_load_state_fails_closed_when_required_and_unavailable(monkeypatch):
+    monkeypatch.setattr(reviewer_bot, "get_state_issue", lambda: None)
+
+    with pytest.raises(RuntimeError):
+        reviewer_bot.load_state(fail_on_unavailable=True)
+
+
+def test_get_state_issue_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr(reviewer_bot, "STATE_ISSUE_NUMBER", 314)
+
+    responses = [
+        reviewer_bot.GitHubApiResult(
+            status_code=502,
+            payload=None,
+            headers={},
+            text="bad gateway",
+            ok=False,
+        ),
+        reviewer_bot.GitHubApiResult(
+            status_code=503,
+            payload=None,
+            headers={},
+            text="service unavailable",
+            ok=False,
+        ),
+        reviewer_bot.GitHubApiResult(
+            status_code=200,
+            payload={"body": "ok"},
+            headers={},
+            text="",
+            ok=True,
+        ),
+    ]
+    calls = {"value": 0}
+    sleeps: list[float] = []
+
+    def fake_request(*args, **kwargs):
+        calls["value"] += 1
+        return responses.pop(0)
+
+    monkeypatch.setattr(reviewer_bot, "github_api_request", fake_request)
+    monkeypatch.setattr(reviewer_bot.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    issue = reviewer_bot.get_state_issue()
+
+    assert isinstance(issue, dict)
+    assert issue.get("body") == "ok"
+    assert calls["value"] == 3
+    assert len(sleeps) == 2
+
+
+def test_get_state_issue_retry_exhaustion_returns_none(monkeypatch):
+    monkeypatch.setattr(reviewer_bot, "STATE_ISSUE_NUMBER", 314)
+
+    calls = {"value": 0}
+    sleeps: list[float] = []
+
+    def fake_request(*args, **kwargs):
+        calls["value"] += 1
+        return reviewer_bot.GitHubApiResult(
+            status_code=502,
+            payload=None,
+            headers={},
+            text="bad gateway",
+            ok=False,
+        )
+
+    monkeypatch.setattr(reviewer_bot, "github_api_request", fake_request)
+    monkeypatch.setattr(reviewer_bot.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    issue = reviewer_bot.get_state_issue()
+
+    assert issue is None
+    assert calls["value"] == reviewer_bot.STATE_READ_RETRY_LIMIT
+    assert len(sleeps) == reviewer_bot.STATE_READ_RETRY_LIMIT - 1
 
 
 def test_save_state_formats_issue_body(monkeypatch):
@@ -1718,7 +1796,7 @@ def test_main_cross_repo_review_does_not_acquire_lock(monkeypatch):
         raise AssertionError("acquire_state_issue_lease_lock should not be called")
 
     monkeypatch.setattr(reviewer_bot, "acquire_state_issue_lease_lock", fail_if_called)
-    monkeypatch.setattr(reviewer_bot, "load_state", lambda: make_state())
+    monkeypatch.setattr(reviewer_bot, "load_state", lambda *args, **kwargs: make_state())
     monkeypatch.setattr(reviewer_bot, "handle_pull_request_review_event", lambda state: False)
 
     reviewer_bot.main()
@@ -1747,7 +1825,7 @@ def test_main_same_repo_review_acquires_lock(monkeypatch):
 
     monkeypatch.setattr(reviewer_bot, "acquire_state_issue_lease_lock", fake_acquire)
     monkeypatch.setattr(reviewer_bot, "release_state_issue_lease_lock", lambda: True)
-    monkeypatch.setattr(reviewer_bot, "load_state", lambda: make_state())
+    monkeypatch.setattr(reviewer_bot, "load_state", lambda *args, **kwargs: make_state())
     monkeypatch.setattr(reviewer_bot, "process_pass_until_expirations", lambda state: (state, []))
     monkeypatch.setattr(reviewer_bot, "sync_members_with_queue", lambda state: (state, []))
     monkeypatch.setattr(reviewer_bot, "handle_pull_request_review_event", lambda state: False)
@@ -1762,7 +1840,7 @@ def test_main_fails_when_save_state_fails(monkeypatch):
     monkeypatch.setenv("EVENT_ACTION", "created")
     monkeypatch.setattr(reviewer_bot, "acquire_state_issue_lease_lock", lambda: None)
     monkeypatch.setattr(reviewer_bot, "release_state_issue_lease_lock", lambda: True)
-    monkeypatch.setattr(reviewer_bot, "load_state", lambda: make_state())
+    monkeypatch.setattr(reviewer_bot, "load_state", lambda *args, **kwargs: make_state())
     monkeypatch.setattr(reviewer_bot, "process_pass_until_expirations", lambda state: (state, []))
     monkeypatch.setattr(reviewer_bot, "sync_members_with_queue", lambda state: (state, []))
     monkeypatch.setattr(reviewer_bot, "handle_comment_event", lambda state: True)
@@ -1780,7 +1858,7 @@ def test_main_workflow_run_fails_closed_on_invalid_context(monkeypatch):
     monkeypatch.setenv("WORKFLOW_RUN_EVENT", "pull_request_review")
     monkeypatch.setattr(reviewer_bot, "acquire_state_issue_lease_lock", lambda: None)
     monkeypatch.setattr(reviewer_bot, "release_state_issue_lease_lock", lambda: True)
-    monkeypatch.setattr(reviewer_bot, "load_state", lambda: make_state())
+    monkeypatch.setattr(reviewer_bot, "load_state", lambda *args, **kwargs: make_state())
     monkeypatch.setattr(reviewer_bot, "process_pass_until_expirations", lambda state: (state, []))
     monkeypatch.setattr(reviewer_bot, "sync_members_with_queue", lambda state: (state, []))
 
@@ -1788,3 +1866,110 @@ def test_main_workflow_run_fails_closed_on_invalid_context(monkeypatch):
         reviewer_bot.main()
 
     assert excinfo.value.code == 1
+
+
+def test_main_mutating_event_fails_closed_when_state_unavailable(monkeypatch):
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("EVENT_ACTION", "created")
+    monkeypatch.setattr(reviewer_bot, "acquire_state_issue_lease_lock", lambda: None)
+    monkeypatch.setattr(reviewer_bot, "release_state_issue_lease_lock", lambda: True)
+
+    def fail_load(*, fail_on_unavailable=False):
+        assert fail_on_unavailable is True
+        raise RuntimeError("state unavailable")
+
+    monkeypatch.setattr(reviewer_bot, "load_state", fail_load)
+
+    with pytest.raises(SystemExit) as excinfo:
+        reviewer_bot.main()
+
+    assert excinfo.value.code == 1
+
+
+def test_main_mutating_event_does_not_sync_or_save_when_state_unavailable(monkeypatch):
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("EVENT_ACTION", "created")
+    monkeypatch.setattr(reviewer_bot, "acquire_state_issue_lease_lock", lambda: None)
+    monkeypatch.setattr(reviewer_bot, "release_state_issue_lease_lock", lambda: True)
+
+    called = {
+        "pass_until": False,
+        "sync": False,
+        "handler": False,
+        "save": False,
+    }
+
+    def fail_load(*, fail_on_unavailable=False):
+        assert fail_on_unavailable is True
+        raise RuntimeError("state unavailable")
+
+    def track_pass_until(state):
+        called["pass_until"] = True
+        return state, []
+
+    def track_sync(state):
+        called["sync"] = True
+        return state, []
+
+    def track_handler(state):
+        called["handler"] = True
+        return True
+
+    def track_save(state):
+        called["save"] = True
+        return True
+
+    monkeypatch.setattr(reviewer_bot, "load_state", fail_load)
+    monkeypatch.setattr(reviewer_bot, "process_pass_until_expirations", track_pass_until)
+    monkeypatch.setattr(reviewer_bot, "sync_members_with_queue", track_sync)
+    monkeypatch.setattr(reviewer_bot, "handle_comment_event", track_handler)
+    monkeypatch.setattr(reviewer_bot, "save_state", track_save)
+
+    with pytest.raises(SystemExit) as excinfo:
+        reviewer_bot.main()
+
+    assert excinfo.value.code == 1
+    assert called == {
+        "pass_until": False,
+        "sync": False,
+        "handler": False,
+        "save": False,
+    }
+
+
+def test_schedule_guard_blocks_empty_active_reviews_wipe(monkeypatch):
+    monkeypatch.setenv("EVENT_NAME", "schedule")
+    monkeypatch.setenv("EVENT_ACTION", "")
+    monkeypatch.setattr(reviewer_bot, "acquire_state_issue_lease_lock", lambda: None)
+    monkeypatch.setattr(reviewer_bot, "release_state_issue_lease_lock", lambda: True)
+
+    state = make_state()
+    state["active_reviews"] = {
+        "42": {
+            "current_reviewer": "alice",
+            "assigned_at": "2026-01-01T00:00:00+00:00",
+            "last_reviewer_activity": "2026-01-01T00:00:00+00:00",
+        }
+    }
+
+    def wipe_active_reviews(input_state):
+        input_state["active_reviews"] = {}
+        return True
+
+    save_called = {"value": False}
+
+    def track_save(_state):
+        save_called["value"] = True
+        return True
+
+    monkeypatch.setattr(reviewer_bot, "load_state", lambda *args, **kwargs: state)
+    monkeypatch.setattr(reviewer_bot, "process_pass_until_expirations", lambda current: (current, []))
+    monkeypatch.setattr(reviewer_bot, "sync_members_with_queue", lambda current: (current, []))
+    monkeypatch.setattr(reviewer_bot, "handle_scheduled_check", wipe_active_reviews)
+    monkeypatch.setattr(reviewer_bot, "save_state", track_save)
+
+    with pytest.raises(SystemExit) as excinfo:
+        reviewer_bot.main()
+
+    assert excinfo.value.code == 1
+    assert save_called["value"] is False

--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -96,6 +96,10 @@ LOCK_LEASE_TTL_SECONDS = int(os.environ.get("REVIEWER_BOT_LOCK_TTL_SECONDS", "30
 LOCK_RETRY_BASE_SECONDS = float(os.environ.get("REVIEWER_BOT_LOCK_RETRY_SECONDS", "2"))
 LOCK_MAX_WAIT_SECONDS = int(os.environ.get("REVIEWER_BOT_LOCK_MAX_WAIT_SECONDS", "1200"))
 LOCK_API_RETRY_LIMIT = int(os.environ.get("REVIEWER_BOT_LOCK_API_RETRY_LIMIT", "5"))
+STATE_READ_RETRY_LIMIT = int(os.environ.get("REVIEWER_BOT_STATE_READ_RETRY_LIMIT", "4"))
+STATE_READ_RETRY_BASE_SECONDS = float(
+    os.environ.get("REVIEWER_BOT_STATE_READ_RETRY_SECONDS", "1")
+)
 LOCK_RENEWAL_WINDOW_SECONDS = int(
     os.environ.get("REVIEWER_BOT_LOCK_RENEWAL_WINDOW_SECONDS", "60")
 )
@@ -620,12 +624,64 @@ def fetch_members() -> list[dict]:
 
 
 def get_state_issue() -> dict | None:
-    """Fetch the state issue from GitHub."""
+    """Fetch the state issue from GitHub with retry for transient failures."""
     if not STATE_ISSUE_NUMBER:
         print("ERROR: STATE_ISSUE_NUMBER not set", file=sys.stderr)
         return None
 
-    return github_api("GET", f"issues/{STATE_ISSUE_NUMBER}")
+    for attempt in range(1, STATE_READ_RETRY_LIMIT + 1):
+        response = github_api_request(
+            "GET",
+            f"issues/{STATE_ISSUE_NUMBER}",
+            suppress_error_log=True,
+        )
+
+        if response.status_code == 200:
+            if not isinstance(response.payload, dict):
+                print(
+                    "ERROR: State issue response payload was not an object",
+                    file=sys.stderr,
+                )
+                return None
+            return response.payload
+
+        if response.status_code in {401, 403, 404}:
+            print(
+                "ERROR: Failed to fetch state issue "
+                f"#{STATE_ISSUE_NUMBER} (status {response.status_code}): {response.text}",
+                file=sys.stderr,
+            )
+            return None
+
+        if response.status_code == 429 or response.status_code >= 500:
+            if attempt < STATE_READ_RETRY_LIMIT:
+                delay = STATE_READ_RETRY_BASE_SECONDS + random.uniform(0, STATE_READ_RETRY_BASE_SECONDS)
+                print(
+                    "WARNING: Retryable state issue read failure "
+                    f"(status {response.status_code}); retrying ({attempt}/{STATE_READ_RETRY_LIMIT})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                continue
+            print(
+                "ERROR: Exhausted retries while fetching state issue "
+                f"#{STATE_ISSUE_NUMBER}; last status {response.status_code}: {response.text}",
+                file=sys.stderr,
+            )
+            return None
+
+        print(
+            "ERROR: Unexpected status while fetching state issue "
+            f"#{STATE_ISSUE_NUMBER}: {response.status_code} {response.text}",
+            file=sys.stderr,
+        )
+        return None
+
+    print(
+        f"ERROR: Failed to fetch state issue #{STATE_ISSUE_NUMBER} after retries",
+        file=sys.stderr,
+    )
+    return None
 
 
 def default_state_issue_prefix() -> str:
@@ -885,8 +941,11 @@ def assert_lock_held(operation: str) -> None:
         raise RuntimeError(f"Mutating path reached without lease lock: {operation}")
 
 
-def load_state() -> dict:
-    """Load the current state from the state issue."""
+def load_state(*, fail_on_unavailable: bool = False) -> dict:
+    """Load the current state from the state issue.
+
+    When fail_on_unavailable=True, inability to fetch state is a hard failure.
+    """
     default_state = {
         "last_updated": None,
         "current_index": 0,
@@ -898,6 +957,11 @@ def load_state() -> dict:
     
     issue = get_state_issue()
     if not issue:
+        if fail_on_unavailable:
+            raise RuntimeError(
+                "State issue is unavailable for a mutating event; refusing to continue "
+                "with fallback defaults."
+            )
         print("WARNING: Could not fetch state issue, using defaults", file=sys.stderr)
         return default_state
     
@@ -4228,6 +4292,7 @@ def main():
     state_changed = False
     sync_changes: list[str] = []
     restored: list[str] = []
+    loaded_active_reviews_count = 0
 
     try:
         if lock_required:
@@ -4235,7 +4300,10 @@ def main():
             lock_acquired = True
 
         # Load current state
-        state = load_state()
+        state = load_state(fail_on_unavailable=lock_required)
+        active_reviews = state.get("active_reviews")
+        if isinstance(active_reviews, dict):
+            loaded_active_reviews_count = len(active_reviews)
 
         if lock_required:
             # Process any expired pass-until entries
@@ -4297,6 +4365,25 @@ def main():
                     "State mutation reached save path without lease lock. "
                     "Acquire lock before mutating state."
                 )
+
+            if event_name == "schedule":
+                current_active_reviews = state.get("active_reviews")
+                current_active_reviews_count = (
+                    len(current_active_reviews) if isinstance(current_active_reviews, dict) else 0
+                )
+                allow_empty_override = (
+                    os.environ.get("ALLOW_EMPTY_ACTIVE_REVIEWS_WRITE", "").strip().lower() == "true"
+                )
+                if (
+                    loaded_active_reviews_count > 0
+                    and current_active_reviews_count == 0
+                    and not allow_empty_override
+                ):
+                    raise RuntimeError(
+                        "STATE_GUARD_BLOCKED_EMPTY_ACTIVE_REVIEWS: refusing to persist schedule "
+                        f"state update that drops active_reviews from {loaded_active_reviews_count} "
+                        "to 0. Set ALLOW_EMPTY_ACTIVE_REVIEWS_WRITE=true to override."
+                    )
 
             print("State updates detected; attempting to persist reviewer-bot state.")
             if not save_state(state):


### PR DESCRIPTION
## Summary
- Fail closed on mutating events when the state issue cannot be fetched, instead of falling back to defaults.
- Add retry and backoff for state issue reads on retryable API failures.
- Add a schedule-path guard that blocks persisting an accidental drop from non-empty `active_reviews` to empty unless explicitly overridden.
- Add regression tests for fail-closed behavior, read retries, and schedule wipe guardrails.

## Validation
- `uv run ruff check --fix scripts/reviewer_bot.py .github/reviewer-bot-tests/test_reviewer_bot.py`
- `uv run pytest .github/reviewer-bot-tests`

## Incident Tracking
- Closes #424
- Full incident report: https://github.com/rustfoundation/safety-critical-rust-coding-guidelines/issues/424#issuecomment-3992788033
