### PR TITLE
Fix reviewer-bot runtime compatibility exports

### DIFF
--- a/.github/reviewer-bot-tests/test_main.py
+++ b/.github/reviewer-bot-tests/test_main.py
@@ -20,6 +20,34 @@ def make_state():
     }
 
 
+def test_reviewer_bot_exports_compatibility_modules():
+    assert reviewer_bot.json is not None
+    assert reviewer_bot.os is not None
+    assert reviewer_bot.yaml is not None
+    assert reviewer_bot.requests is not None
+    assert reviewer_bot.sys is not None
+    assert reviewer_bot.datetime is not None
+    assert reviewer_bot.timezone is not None
+
+
+def test_render_lock_commit_message_uses_json_compatibility_surface():
+    rendered = reviewer_bot.render_lock_commit_message({"lock_state": "unlocked"})
+    assert reviewer_bot.LOCK_COMMIT_MARKER in rendered
+
+
+def test_main_show_state_uses_yaml_compatibility_surface(monkeypatch, capsys):
+    monkeypatch.setenv("EVENT_NAME", "workflow_dispatch")
+    monkeypatch.setenv("EVENT_ACTION", "")
+    monkeypatch.setenv("MANUAL_ACTION", "show-state")
+    monkeypatch.setattr(reviewer_bot, "load_state", lambda *args, **kwargs: make_state())
+
+    reviewer_bot.main()
+
+    output = capsys.readouterr().out
+    assert "Current state:" in output
+    assert "freshness_runtime_epoch" in output
+
+
 def test_classify_event_intent_cross_repo_review_is_non_mutating_defer(monkeypatch):
     monkeypatch.setenv("PR_IS_CROSS_REPOSITORY", "true")
     intent = reviewer_bot.classify_event_intent("pull_request_review", "submitted")

--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -54,6 +54,8 @@ All commands must be prefixed with @guidelines-bot /<command>:
     - Show all available commands
 """
 
+import json  # noqa: F401
+import os  # noqa: F401
 import sys
 from collections.abc import Iterable
 from datetime import datetime, timezone
@@ -61,6 +63,7 @@ from pathlib import Path
 from typing import Any
 
 # GitHub API interaction
+import yaml  # noqa: F401
 
 try:
     import scripts.reviewer_bot_lib.automation as automation_module


### PR DESCRIPTION
## Summary
- restore the module-level compatibility exports expected by extracted reviewer-bot helpers
- add regression coverage for the compatibility surface and maintenance-path usage
- prevent live workflow crashes on lock-acquiring and show-state paths after the reviewer-bot refactor

## What Changed
- re-export json, os, and yaml from scripts/reviewer_bot.py so extracted helpers that use the main bot module namespace can resolve them at runtime
- add focused regression tests in .github/reviewer-bot-tests/test_main.py covering:
  - the expected compatibility module surface
  - lock message rendering through the lease-lock helper
  - the show-state workflow-dispatch path

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Context
- follow-up to #435 after the first live Reviewer Bot Issues run exposed a missing compatibility export on the bot module namespace
