### PR TITLE
Fix reviewer-bot exported guidance helper surface

### DIFF
--- a/.github/reviewer-bot-tests/test_main.py
+++ b/.github/reviewer-bot-tests/test_main.py
@@ -35,6 +35,12 @@ def test_render_lock_commit_message_uses_json_compatibility_surface():
     assert reviewer_bot.LOCK_COMMIT_MARKER in rendered
 
 
+def test_reviewer_bot_exports_guidance_helpers():
+    assert reviewer_bot.get_issue_guidance is not None
+    assert reviewer_bot.get_pr_guidance is not None
+    assert reviewer_bot.get_fls_audit_guidance is not None
+
+
 def test_main_show_state_uses_yaml_compatibility_surface(monkeypatch, capsys):
     monkeypatch.setenv("EVENT_NAME", "workflow_dispatch")
     monkeypatch.setenv("EVENT_ACTION", "")

--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -70,6 +70,7 @@ try:
     import scripts.reviewer_bot_lib.commands as commands_module
     import scripts.reviewer_bot_lib.events as events_module
     import scripts.reviewer_bot_lib.github_api as github_api_module
+    import scripts.reviewer_bot_lib.guidance as guidance_module
     import scripts.reviewer_bot_lib.lease_lock as lease_lock_module
     import scripts.reviewer_bot_lib.reviews as reviews_module
     import scripts.reviewer_bot_lib.state_store as state_store_module
@@ -156,6 +157,7 @@ except ImportError:
     import reviewer_bot_lib.commands as commands_module
     import reviewer_bot_lib.events as events_module
     import reviewer_bot_lib.github_api as github_api_module
+    import reviewer_bot_lib.guidance as guidance_module
     import reviewer_bot_lib.lease_lock as lease_lock_module
     import reviewer_bot_lib.reviews as reviews_module
     import reviewer_bot_lib.state_store as state_store_module
@@ -623,6 +625,18 @@ def handle_label_command(issue_number: int, label_string: str) -> tuple[str, boo
 
 def parse_issue_labels() -> list[str]:
     return commands_module.parse_issue_labels()
+
+
+def get_issue_guidance(reviewer: str, issue_author: str) -> str:
+    return guidance_module.get_issue_guidance(reviewer, issue_author)
+
+
+def get_pr_guidance(reviewer: str, pr_author: str) -> str:
+    return guidance_module.get_pr_guidance(reviewer, pr_author)
+
+
+def get_fls_audit_guidance(reviewer: str, issue_author: str) -> str:
+    return guidance_module.get_fls_audit_guidance(reviewer, issue_author)
 
 
 def run_command(command: list[str], cwd: Path, check: bool = True) -> Any:


### PR DESCRIPTION
## Summary
- restore the exported guidance helper surface expected by extracted reviewer-bot event handlers
- keep the explicit compatibility module exports for extracted helpers that use the bot module as a namespace
- add regression coverage for the helper surface used by trusted issue lifecycle handling

## What Changed
- re-export guidance helpers from scripts/reviewer_bot.py so trusted issue and PR lifecycle handlers can resolve them at runtime:
  - get_issue_guidance
  - get_pr_guidance
  - get_fls_audit_guidance
- keep explicit exported compatibility bindings for json, os, and yaml on the bot module namespace
- extend .github/reviewer-bot-tests/test_main.py to assert both the compatibility modules and the exported guidance helper surface

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Context
- follow-up to #436 after the first post-merge issue lifecycle validation attempt failed on the trusted issues.labeled path with a missing get_issue_guidance export
