### PR TITLE
Refactor reviewer-bot module imports

### DIFF
--- a/.github/reviewer-bot-tests/test_main.py
+++ b/.github/reviewer-bot-tests/test_main.py
@@ -20,17 +20,14 @@ def make_state():
     }
 
 
-def test_reviewer_bot_exports_compatibility_modules():
-    assert reviewer_bot.json is not None
-    assert reviewer_bot.os is not None
-    assert reviewer_bot.yaml is not None
+def test_reviewer_bot_exports_runtime_modules():
     assert reviewer_bot.requests is not None
     assert reviewer_bot.sys is not None
     assert reviewer_bot.datetime is not None
     assert reviewer_bot.timezone is not None
 
 
-def test_render_lock_commit_message_uses_json_compatibility_surface():
+def test_render_lock_commit_message_uses_direct_json_import():
     rendered = reviewer_bot.render_lock_commit_message({"lock_state": "unlocked"})
     assert reviewer_bot.LOCK_COMMIT_MARKER in rendered
 
@@ -41,7 +38,7 @@ def test_reviewer_bot_exports_guidance_helpers():
     assert reviewer_bot.get_fls_audit_guidance is not None
 
 
-def test_main_show_state_uses_yaml_compatibility_surface(monkeypatch, capsys):
+def test_main_show_state_uses_direct_yaml_import(monkeypatch, capsys):
     monkeypatch.setenv("EVENT_NAME", "workflow_dispatch")
     monkeypatch.setenv("EVENT_ACTION", "")
     monkeypatch.setenv("MANUAL_ACTION", "show-state")

--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -54,8 +54,6 @@ All commands must be prefixed with @guidelines-bot /<command>:
     - Show all available commands
 """
 
-import json  # noqa: F401
-import os  # noqa: F401
 import sys
 from collections.abc import Iterable
 from datetime import datetime, timezone
@@ -63,7 +61,6 @@ from pathlib import Path
 from typing import Any
 
 # GitHub API interaction
-import yaml  # noqa: F401
 
 try:
     import scripts.reviewer_bot_lib.automation as automation_module

--- a/scripts/reviewer_bot_lib/automation.py
+++ b/scripts/reviewer_bot_lib/automation.py
@@ -1,5 +1,6 @@
 """Automation-heavy reviewer-bot helpers."""
 
+import os
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -41,7 +42,7 @@ def get_default_branch(bot) -> str:
 
 
 def find_open_pr_for_branch(bot, branch: str) -> dict | None:
-    owner = bot.os.environ.get("REPO_OWNER", "").strip()
+    owner = os.environ.get("REPO_OWNER", "").strip()
     branch = branch.strip()
     if not owner or not branch:
         return None
@@ -73,7 +74,7 @@ def create_pull_request(bot, branch: str, base: str, issue_number: int) -> dict 
 
 
 def handle_accept_no_fls_changes_command(bot, issue_number: int, comment_author: str) -> tuple[str, bool]:
-    if bot.os.environ.get("IS_PULL_REQUEST", "false").lower() == "true":
+    if os.environ.get("IS_PULL_REQUEST", "false").lower() == "true":
         return "❌ This command can only be used on issues, not PRs.", False
     labels = bot.parse_issue_labels()
     if bot.FLS_AUDIT_LABEL not in labels:

--- a/scripts/reviewer_bot_lib/events.py
+++ b/scripts/reviewer_bot_lib/events.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import quote
 
+import yaml
+
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
@@ -1343,7 +1345,7 @@ def handle_closed_event(bot, state: dict) -> bool:
 def handle_manual_dispatch(bot, state: dict) -> bool:
     action = os.environ.get("MANUAL_ACTION", "")
     if action == "show-state":
-        print(f"Current state:\n{bot.yaml.dump(state, default_flow_style=False)}")
+        print(f"Current state:\n{yaml.dump(state, default_flow_style=False)}")
         return False
     bot.assert_lock_held("handle_manual_dispatch")
     if action == "sync-members":

--- a/scripts/reviewer_bot_lib/lease_lock.py
+++ b/scripts/reviewer_bot_lib/lease_lock.py
@@ -1,5 +1,6 @@
 """Reviewer-bot lease lock helpers."""
 
+import json
 import os
 import random
 import time
@@ -128,7 +129,7 @@ def extract_commit_sha(payload: Any) -> str | None:
 
 
 def render_lock_commit_message(bot, lock_meta: dict) -> str:
-    lock_json = bot.json.dumps(bot.normalize_lock_metadata(lock_meta), sort_keys=False)
+    lock_json = json.dumps(bot.normalize_lock_metadata(lock_meta), sort_keys=False)
     return f"{LOCK_COMMIT_MARKER}\n{lock_json}"
 
 
@@ -137,8 +138,8 @@ def parse_lock_metadata_from_lock_commit_message(bot, message: str) -> dict:
         return bot.clear_lock_metadata()
     lock_json = message.split("\n", 1)[1]
     try:
-        parsed = bot.json.loads(lock_json)
-    except bot.json.JSONDecodeError:
+        parsed = json.loads(lock_json)
+    except json.JSONDecodeError:
         return bot.clear_lock_metadata()
     return bot.normalize_lock_metadata(parsed if isinstance(parsed, dict) else None)
 


### PR DESCRIPTION
## Summary
- stop routing json, os, and yaml through the reviewer-bot module namespace
- import those modules directly where they are used in extracted reviewer-bot helpers
- keep the change narrow and validate the affected runtime paths with focused tests

## What Changed
- update lease-lock helpers to use direct json imports instead of bot.json
- update automation helpers to use direct os imports instead of bot.os
- update the show-state maintenance path to use a direct yaml import instead of bot.yaml
- remove the corresponding compatibility-only imports from scripts/reviewer_bot.py
- adjust focused reviewer-bot regression tests to reflect the reduced runtime facade

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Stacking
- first PR in the reviewer-bot facade reduction series
