### PR TITLE
Refactor reviewer-bot guidance imports

### DIFF
--- a/.github/reviewer-bot-tests/test_main.py
+++ b/.github/reviewer-bot-tests/test_main.py
@@ -32,12 +32,6 @@ def test_render_lock_commit_message_uses_direct_json_import():
     assert reviewer_bot.LOCK_COMMIT_MARKER in rendered
 
 
-def test_reviewer_bot_exports_guidance_helpers():
-    assert reviewer_bot.get_issue_guidance is not None
-    assert reviewer_bot.get_pr_guidance is not None
-    assert reviewer_bot.get_fls_audit_guidance is not None
-
-
 def test_main_show_state_uses_direct_yaml_import(monkeypatch, capsys):
     monkeypatch.setenv("EVENT_NAME", "workflow_dispatch")
     monkeypatch.setenv("EVENT_ACTION", "")

--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -67,7 +67,6 @@ try:
     import scripts.reviewer_bot_lib.commands as commands_module
     import scripts.reviewer_bot_lib.events as events_module
     import scripts.reviewer_bot_lib.github_api as github_api_module
-    import scripts.reviewer_bot_lib.guidance as guidance_module
     import scripts.reviewer_bot_lib.lease_lock as lease_lock_module
     import scripts.reviewer_bot_lib.reviews as reviews_module
     import scripts.reviewer_bot_lib.state_store as state_store_module
@@ -154,7 +153,6 @@ except ImportError:
     import reviewer_bot_lib.commands as commands_module
     import reviewer_bot_lib.events as events_module
     import reviewer_bot_lib.github_api as github_api_module
-    import reviewer_bot_lib.guidance as guidance_module
     import reviewer_bot_lib.lease_lock as lease_lock_module
     import reviewer_bot_lib.reviews as reviews_module
     import reviewer_bot_lib.state_store as state_store_module
@@ -622,18 +620,6 @@ def handle_label_command(issue_number: int, label_string: str) -> tuple[str, boo
 
 def parse_issue_labels() -> list[str]:
     return commands_module.parse_issue_labels()
-
-
-def get_issue_guidance(reviewer: str, issue_author: str) -> str:
-    return guidance_module.get_issue_guidance(reviewer, issue_author)
-
-
-def get_pr_guidance(reviewer: str, pr_author: str) -> str:
-    return guidance_module.get_pr_guidance(reviewer, pr_author)
-
-
-def get_fls_audit_guidance(reviewer: str, issue_author: str) -> str:
-    return guidance_module.get_fls_audit_guidance(reviewer, issue_author)
 
 
 def run_command(command: list[str], cwd: Path, check: bool = True) -> Any:

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -7,6 +7,8 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .guidance import get_issue_guidance, get_pr_guidance
+
 
 def strip_code_blocks(comment_body: str) -> str:
     sanitized = comment_body
@@ -535,10 +537,10 @@ def handle_assign_from_queue_command(bot, state: dict, issue_number: int) -> tup
         bot.post_comment(issue_number, failure_comment)
     if is_pr:
         if assignment_attempt.success:
-            guidance = bot.get_pr_guidance(next_reviewer, issue_author)
+            guidance = get_pr_guidance(next_reviewer, issue_author)
             bot.post_comment(issue_number, guidance)
     else:
-        guidance = bot.get_issue_guidance(next_reviewer, issue_author)
+        guidance = get_issue_guidance(next_reviewer, issue_author)
         bot.post_comment(issue_number, guidance)
     if assignment_attempt.success:
         return f"✅ @{next_reviewer} (next in queue) has been assigned as reviewer{prev_text}.", True

--- a/scripts/reviewer_bot_lib/events.py
+++ b/scripts/reviewer_bot_lib/events.py
@@ -14,6 +14,8 @@ from urllib.parse import quote
 
 import yaml
 
+from .guidance import get_fls_audit_guidance, get_issue_guidance, get_pr_guidance
+
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
@@ -328,9 +330,9 @@ def handle_issue_or_pr_opened(bot, state: dict) -> bool:
     if failure_comment:
         bot.post_comment(issue_number, failure_comment)
     if is_pr and assignment_attempt.success:
-        bot.post_comment(issue_number, bot.get_pr_guidance(reviewer, issue_author))
+        bot.post_comment(issue_number, get_pr_guidance(reviewer, issue_author))
     if not is_pr:
-        guidance = bot.get_fls_audit_guidance(reviewer, issue_author) if bot.FLS_AUDIT_LABEL in labels else bot.get_issue_guidance(reviewer, issue_author)
+        guidance = get_fls_audit_guidance(reviewer, issue_author) if bot.FLS_AUDIT_LABEL in labels else get_issue_guidance(reviewer, issue_author)
         bot.post_comment(issue_number, guidance)
     return True
 


### PR DESCRIPTION
## Summary
- stop routing issue and PR guidance helpers through the reviewer-bot module namespace
- import guidance helpers directly where the extracted event and command handlers use them
- reduce the reviewer-bot facade surface further after #439

## What Changed
- update reviewer-bot event handlers to import guidance helpers directly from reviewer_bot_lib.guidance
- update reviewer-bot command handlers to import guidance helpers directly from reviewer_bot_lib.guidance
- remove the corresponding guidance wrapper exports from scripts/reviewer_bot.py
- trim focused tests to match the reduced runtime facade surface

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Stacking
- logically stacked on top of #439
- this PR includes the #439 delta until #439 merges, after which it should be rebased or will naturally shrink against main
