### PR TITLE
Refactor reviewer-bot lock and state interfaces

### DIFF
--- a/.github/reviewer-bot-tests/test_main.py
+++ b/.github/reviewer-bot-tests/test_main.py
@@ -1,7 +1,12 @@
 import pytest
 
 from scripts import reviewer_bot
-from scripts.reviewer_bot_lib.context import ReviewerBotContext
+from scripts.reviewer_bot_lib.context import (
+    GitHubTransportContext,
+    LeaseLockContext,
+    ReviewerBotContext,
+    StateStoreContext,
+)
 
 
 def make_state():
@@ -30,6 +35,12 @@ def test_reviewer_bot_exports_runtime_modules():
 
 def test_reviewer_bot_satisfies_runtime_context_protocol():
     assert isinstance(reviewer_bot, ReviewerBotContext)
+
+
+def test_reviewer_bot_satisfies_narrower_lock_and_state_protocols():
+    assert isinstance(reviewer_bot, GitHubTransportContext)
+    assert isinstance(reviewer_bot, StateStoreContext)
+    assert isinstance(reviewer_bot, LeaseLockContext)
 
 
 def test_render_lock_commit_message_uses_direct_json_import():

--- a/scripts/reviewer_bot_lib/context.py
+++ b/scripts/reviewer_bot_lib/context.py
@@ -10,37 +10,14 @@ from .config import AssignmentAttempt, GitHubApiResult, LeaseContext, StateIssue
 
 
 @runtime_checkable
-class ReviewerBotContext(Protocol):
-    """Minimal runtime surface expected by the core extracted modules.
+class GitHubTransportContext(Protocol):
+    """GitHub API transport and mutation surface used by low-level helpers."""
 
-    This protocol intentionally captures true runtime services and shared state,
-    not pure helper modules or formatting helpers that should be imported
-    directly where used.
-    """
-
-    ACTIVE_LEASE_CONTEXT: LeaseContext | None
     LOCK_API_RETRY_LIMIT: int
     LOCK_RETRY_BASE_SECONDS: float
-    LOCK_LEASE_TTL_SECONDS: int
-    LOCK_MAX_WAIT_SECONDS: int
-    LOCK_RENEWAL_WINDOW_SECONDS: int
-    LOCK_REF_NAME: str
-    LOCK_REF_BOOTSTRAP_BRANCH: str
-    LOCK_COMMIT_MARKER: str
-    LOCK_SCHEMA_VERSION: int
-    STATE_ISSUE_NUMBER: int
-    STATE_READ_RETRY_LIMIT: int
-    STATE_READ_RETRY_BASE_SECONDS: float
-    EVENT_INTENT_MUTATING: str
-    EVENT_INTENT_NON_MUTATING_DEFER: str
-    EVENT_INTENT_NON_MUTATING_READONLY: str
     REVIEWER_REQUEST_422_TEMPLATE: str
     AssignmentAttempt: type[AssignmentAttempt]
     GitHubApiResult: type[GitHubApiResult]
-    LeaseContext: type[LeaseContext]
-    sys: Any
-    datetime: type[datetime]
-    timezone: Any
 
     def get_github_token(self) -> str: ...
     def github_api_request(
@@ -56,6 +33,30 @@ class ReviewerBotContext(Protocol):
     def request_reviewer_assignment(self, issue_number: int, username: str) -> AssignmentAttempt: ...
     def remove_assignee(self, issue_number: int, username: str) -> bool: ...
     def remove_pr_reviewer(self, issue_number: int, username: str) -> bool: ...
+
+
+@runtime_checkable
+class StateStoreContext(Protocol):
+    """State issue and serialization surface used by state-store helpers."""
+
+    ACTIVE_LEASE_CONTEXT: LeaseContext | None
+    STATE_ISSUE_NUMBER: int
+    STATE_READ_RETRY_LIMIT: int
+    STATE_READ_RETRY_BASE_SECONDS: float
+    LOCK_API_RETRY_LIMIT: int
+    LOCK_RETRY_BASE_SECONDS: float
+    GitHubApiResult: type[GitHubApiResult]
+    sys: Any
+
+    def github_api_request(
+        self,
+        method: str,
+        endpoint: str,
+        data: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
+        *,
+        suppress_error_log: bool = False,
+    ) -> GitHubApiResult: ...
     def get_state_issue(self) -> dict | None: ...
     def get_state_issue_snapshot(self) -> StateIssueSnapshot | None: ...
     def conditional_patch_state_issue(self, body: str, etag: str | None = None) -> GitHubApiResult: ...
@@ -69,11 +70,41 @@ class ReviewerBotContext(Protocol):
         preserve_state_block: bool = False,
     ) -> str: ...
     def assert_lock_held(self, operation: str) -> None: ...
-    def load_state(self, *, fail_on_unavailable: bool = False) -> dict: ...
-    def save_state(self, state: dict) -> bool: ...
+    def parse_iso8601_timestamp(self, value: Any) -> datetime | None: ...
+    def normalize_lock_metadata(self, lock_meta: dict | None) -> dict: ...
+    def ensure_state_issue_lease_lock_fresh(self) -> bool: ...
+
+
+@runtime_checkable
+class LeaseLockContext(Protocol):
+    """Lock-specific runtime surface used by lease-lock helpers."""
+
+    ACTIVE_LEASE_CONTEXT: LeaseContext | None
+    LOCK_API_RETRY_LIMIT: int
+    LOCK_RETRY_BASE_SECONDS: float
+    LOCK_LEASE_TTL_SECONDS: int
+    LOCK_MAX_WAIT_SECONDS: int
+    LOCK_RENEWAL_WINDOW_SECONDS: int
+    LOCK_REF_NAME: str
+    LOCK_REF_BOOTSTRAP_BRANCH: str
+    LOCK_COMMIT_MARKER: str
+    LOCK_SCHEMA_VERSION: int
+    LeaseContext: type[LeaseContext]
+    sys: Any
+
     def parse_iso8601_timestamp(self, value: Any) -> datetime | None: ...
     def normalize_lock_metadata(self, lock_meta: dict | None) -> dict: ...
     def clear_lock_metadata(self) -> dict: ...
+    def get_state_issue_snapshot(self) -> StateIssueSnapshot | None: ...
+    def github_api_request(
+        self,
+        method: str,
+        endpoint: str,
+        data: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
+        *,
+        suppress_error_log: bool = False,
+    ) -> GitHubApiResult: ...
     def get_lock_ref_display(self) -> str: ...
     def get_state_issue_html_url(self) -> str: ...
     def get_lock_ref_snapshot(self) -> tuple[str, str, dict]: ...
@@ -88,6 +119,24 @@ class ReviewerBotContext(Protocol):
     def cas_update_lock_ref(self, new_sha: str) -> GitHubApiResult: ...
     def lock_is_currently_valid(self, lock_meta: dict, now: datetime | None = None) -> bool: ...
     def renew_state_issue_lease_lock(self, context: LeaseContext) -> bool: ...
+
+
+@runtime_checkable
+class ReviewerBotContext(GitHubTransportContext, StateStoreContext, LeaseLockContext, Protocol):
+    """Broader runtime surface expected by orchestration-heavy extracted modules.
+
+    This protocol intentionally captures true runtime services and shared state,
+    not pure helper modules or formatting helpers that should be imported
+    directly where used.
+    """
+
+    EVENT_INTENT_MUTATING: str
+    EVENT_INTENT_NON_MUTATING_DEFER: str
+    EVENT_INTENT_NON_MUTATING_READONLY: str
+    datetime: type[datetime]
+    timezone: Any
+    def load_state(self, *, fail_on_unavailable: bool = False) -> dict: ...
+    def save_state(self, state: dict) -> bool: ...
     def ensure_state_issue_lease_lock_fresh(self) -> bool: ...
     def acquire_state_issue_lease_lock(self) -> LeaseContext: ...
     def release_state_issue_lease_lock(self) -> bool: ...

--- a/scripts/reviewer_bot_lib/github_api.py
+++ b/scripts/reviewer_bot_lib/github_api.py
@@ -9,7 +9,7 @@ from urllib.parse import quote
 import requests
 
 from .config import LOCK_API_RETRY_LIMIT, LOCK_RETRY_BASE_SECONDS, STATUS_LABEL_CONFIG
-from .context import ReviewerBotContext
+from .context import GitHubTransportContext
 
 
 def get_github_token() -> str:
@@ -21,7 +21,7 @@ def get_github_token() -> str:
 
 
 def github_api_request(
-    bot: ReviewerBotContext,
+    bot: GitHubTransportContext,
     method: str,
     endpoint: str,
     data: dict | None = None,
@@ -64,7 +64,7 @@ def github_api_request(
     )
 
 
-def github_api(bot: ReviewerBotContext, method: str, endpoint: str, data: dict | None = None):
+def github_api(bot: GitHubTransportContext, method: str, endpoint: str, data: dict | None = None):
     response = bot.github_api_request(method, endpoint, data)
     if not response.ok:
         return None
@@ -73,27 +73,27 @@ def github_api(bot: ReviewerBotContext, method: str, endpoint: str, data: dict |
     return response.payload
 
 
-def post_comment(bot: ReviewerBotContext, issue_number: int, body: str) -> bool:
+def post_comment(bot: GitHubTransportContext, issue_number: int, body: str) -> bool:
     return bot.github_api("POST", f"issues/{issue_number}/comments", {"body": body}) is not None
 
 
-def get_repo_labels(bot: ReviewerBotContext) -> set[str]:
+def get_repo_labels(bot: GitHubTransportContext) -> set[str]:
     result = bot.github_api("GET", "labels?per_page=100")
     if result and isinstance(result, list):
         return {label["name"] for label in result}
     return set()
 
 
-def add_label(bot: ReviewerBotContext, issue_number: int, label: str) -> bool:
+def add_label(bot: GitHubTransportContext, issue_number: int, label: str) -> bool:
     return bot.github_api("POST", f"issues/{issue_number}/labels", {"labels": [label]}) is not None
 
 
-def remove_label(bot: ReviewerBotContext, issue_number: int, label: str) -> bool:
+def remove_label(bot: GitHubTransportContext, issue_number: int, label: str) -> bool:
     bot.github_api("DELETE", f"issues/{issue_number}/labels/{quote(label, safe='')}")
     return True
 
 
-def add_label_with_status(bot: ReviewerBotContext, issue_number: int, label: str) -> bool:
+def add_label_with_status(bot: GitHubTransportContext, issue_number: int, label: str) -> bool:
     response = bot.github_api_request(
         "POST",
         f"issues/{issue_number}/labels",
@@ -114,7 +114,7 @@ def add_label_with_status(bot: ReviewerBotContext, issue_number: int, label: str
     return False
 
 
-def remove_label_with_status(bot: ReviewerBotContext, issue_number: int, label: str) -> bool:
+def remove_label_with_status(bot: GitHubTransportContext, issue_number: int, label: str) -> bool:
     response = bot.github_api_request(
         "DELETE",
         f"issues/{issue_number}/labels/{quote(label, safe='')}",
@@ -135,7 +135,7 @@ def remove_label_with_status(bot: ReviewerBotContext, issue_number: int, label: 
 
 
 def ensure_label_exists(
-    bot: ReviewerBotContext,
+    bot: GitHubTransportContext,
     label: str,
     *,
     color: str | None = None,
@@ -164,7 +164,7 @@ def ensure_label_exists(
     return False
 
 
-def request_reviewer_assignment(bot: ReviewerBotContext, issue_number: int, username: str):
+def request_reviewer_assignment(bot: GitHubTransportContext, issue_number: int, username: str):
     is_pr = os.environ.get("IS_PULL_REQUEST", "false").lower() == "true"
     if is_pr:
         endpoint = f"pulls/{issue_number}/requested_reviewers"
@@ -214,11 +214,11 @@ def request_reviewer_assignment(bot: ReviewerBotContext, issue_number: int, user
     return bot.AssignmentAttempt(success=False, status_code=None, exhausted_retryable_failure=True)
 
 
-def assign_reviewer(bot: ReviewerBotContext, issue_number: int, username: str) -> bool:
+def assign_reviewer(bot: GitHubTransportContext, issue_number: int, username: str) -> bool:
     return bot.request_reviewer_assignment(issue_number, username).success
 
 
-def get_assignment_failure_comment(bot: ReviewerBotContext, reviewer: str, attempt) -> str | None:
+def get_assignment_failure_comment(bot: GitHubTransportContext, reviewer: str, attempt) -> str | None:
     is_pr = os.environ.get("IS_PULL_REQUEST", "false").lower() == "true"
     if attempt.status_code == 422:
         if is_pr:
@@ -237,7 +237,7 @@ def get_assignment_failure_comment(bot: ReviewerBotContext, reviewer: str, attem
     return None
 
 
-def get_issue_assignees(bot: ReviewerBotContext, issue_number: int) -> list[str]:
+def get_issue_assignees(bot: GitHubTransportContext, issue_number: int) -> list[str]:
     is_pr = os.environ.get("IS_PULL_REQUEST", "false").lower() == "true"
     if is_pr:
         result = bot.github_api("GET", f"pulls/{issue_number}")
@@ -250,21 +250,21 @@ def get_issue_assignees(bot: ReviewerBotContext, issue_number: int) -> list[str]
     return []
 
 
-def add_reaction(bot: ReviewerBotContext, comment_id: int, reaction: str) -> bool:
+def add_reaction(bot: GitHubTransportContext, comment_id: int, reaction: str) -> bool:
     return (
         bot.github_api("POST", f"issues/comments/{comment_id}/reactions", {"content": reaction})
         is not None
     )
 
 
-def remove_assignee(bot: ReviewerBotContext, issue_number: int, username: str) -> bool:
+def remove_assignee(bot: GitHubTransportContext, issue_number: int, username: str) -> bool:
     return (
         bot.github_api("DELETE", f"issues/{issue_number}/assignees", {"assignees": [username]})
         is not None
     )
 
 
-def remove_pr_reviewer(bot: ReviewerBotContext, issue_number: int, username: str) -> bool:
+def remove_pr_reviewer(bot: GitHubTransportContext, issue_number: int, username: str) -> bool:
     return (
         bot.github_api(
             "DELETE",
@@ -275,14 +275,14 @@ def remove_pr_reviewer(bot: ReviewerBotContext, issue_number: int, username: str
     )
 
 
-def unassign_reviewer(bot: ReviewerBotContext, issue_number: int, username: str) -> bool:
+def unassign_reviewer(bot: GitHubTransportContext, issue_number: int, username: str) -> bool:
     is_pr = os.environ.get("IS_PULL_REQUEST", "false").lower() == "true"
     if is_pr:
         bot.remove_pr_reviewer(issue_number, username)
     return bot.remove_assignee(issue_number, username)
 
 
-def check_user_permission(bot: ReviewerBotContext, username: str, required_permission: str = "triage") -> bool:
+def check_user_permission(bot: GitHubTransportContext, username: str, required_permission: str = "triage") -> bool:
     result = bot.github_api("GET", f"collaborators/{username}/permission")
     if not result:
         return False

--- a/scripts/reviewer_bot_lib/lease_lock.py
+++ b/scripts/reviewer_bot_lib/lease_lock.py
@@ -19,10 +19,10 @@ from .config import (
     LOCK_RETRY_BASE_SECONDS,
     LeaseContext,
 )
-from .context import ReviewerBotContext
+from .context import LeaseLockContext
 
 
-def lock_is_currently_valid(bot: ReviewerBotContext, lock_meta: dict, now: datetime | None = None) -> bool:
+def lock_is_currently_valid(bot: LeaseLockContext, lock_meta: dict, now: datetime | None = None) -> bool:
     if not isinstance(lock_meta, dict):
         return False
     if lock_meta.get("lock_state") != "locked":
@@ -56,7 +56,7 @@ def get_lock_owner_context() -> tuple[str, str, str]:
     return run_id, workflow, job
 
 
-def build_lock_metadata(bot: ReviewerBotContext, lock_token: str, lock_owner_run_id: str, lock_owner_workflow: str, lock_owner_job: str) -> dict:
+def build_lock_metadata(bot: LeaseLockContext, lock_token: str, lock_owner_run_id: str, lock_owner_workflow: str, lock_owner_job: str) -> dict:
     acquired_at = datetime.now(timezone.utc)
     expires_at = acquired_at.timestamp() + getattr(bot, "LOCK_LEASE_TTL_SECONDS", LOCK_LEASE_TTL_SECONDS)
     return bot.normalize_lock_metadata(
@@ -73,7 +73,7 @@ def build_lock_metadata(bot: ReviewerBotContext, lock_token: str, lock_owner_run
     )
 
 
-def clear_lock_metadata(bot: ReviewerBotContext) -> dict:
+def clear_lock_metadata(bot: LeaseLockContext) -> dict:
     return bot.normalize_lock_metadata({"lock_state": "unlocked"})
 
 
@@ -86,15 +86,15 @@ def normalize_lock_ref_name(ref_name: str) -> str:
     return normalized
 
 
-def get_lock_ref_name(bot: ReviewerBotContext) -> str:
+def get_lock_ref_name(bot: LeaseLockContext) -> str:
     return normalize_lock_ref_name(getattr(bot, "LOCK_REF_NAME", LOCK_REF_NAME))
 
 
-def get_lock_ref_display(bot: ReviewerBotContext) -> str:
+def get_lock_ref_display(bot: LeaseLockContext) -> str:
     return f"refs/{get_lock_ref_name(bot)}"
 
 
-def get_state_issue_html_url(bot: ReviewerBotContext) -> str:
+def get_state_issue_html_url(bot: LeaseLockContext) -> str:
     context = bot.ACTIVE_LEASE_CONTEXT
     if context and context.state_issue_url:
         return context.state_issue_url
@@ -129,12 +129,12 @@ def extract_commit_sha(payload: Any) -> str | None:
     return sha if isinstance(sha, str) and sha else None
 
 
-def render_lock_commit_message(bot: ReviewerBotContext, lock_meta: dict) -> str:
+def render_lock_commit_message(bot: LeaseLockContext, lock_meta: dict) -> str:
     lock_json = json.dumps(bot.normalize_lock_metadata(lock_meta), sort_keys=False)
     return f"{LOCK_COMMIT_MARKER}\n{lock_json}"
 
 
-def parse_lock_metadata_from_lock_commit_message(bot: ReviewerBotContext, message: str) -> dict:
+def parse_lock_metadata_from_lock_commit_message(bot: LeaseLockContext, message: str) -> dict:
     if not message.startswith(f"{LOCK_COMMIT_MARKER}\n"):
         return bot.clear_lock_metadata()
     lock_json = message.split("\n", 1)[1]
@@ -145,7 +145,7 @@ def parse_lock_metadata_from_lock_commit_message(bot: ReviewerBotContext, messag
     return bot.normalize_lock_metadata(parsed if isinstance(parsed, dict) else None)
 
 
-def ensure_lock_ref_exists(bot: ReviewerBotContext) -> str:
+def ensure_lock_ref_exists(bot: LeaseLockContext) -> str:
     lock_ref = get_lock_ref_name(bot)
     response = bot.github_api_request("GET", f"git/ref/{lock_ref}", suppress_error_log=True)
     if response.status_code == 200:
@@ -200,7 +200,7 @@ def ensure_lock_ref_exists(bot: ReviewerBotContext) -> str:
     return ref_sha
 
 
-def get_lock_ref_snapshot(bot: ReviewerBotContext) -> tuple[str, str, dict]:
+def get_lock_ref_snapshot(bot: LeaseLockContext) -> tuple[str, str, dict]:
     ref_sha = ensure_lock_ref_exists(bot)
     commit_response = bot.github_api_request("GET", f"git/commits/{ref_sha}", suppress_error_log=True)
     if commit_response.status_code != 200:
@@ -219,7 +219,7 @@ def get_lock_ref_snapshot(bot: ReviewerBotContext) -> tuple[str, str, dict]:
     return ref_sha, tree_sha, lock_meta
 
 
-def create_lock_commit(bot: ReviewerBotContext, parent_sha: str, tree_sha: str, lock_meta: dict):
+def create_lock_commit(bot: LeaseLockContext, parent_sha: str, tree_sha: str, lock_meta: dict):
     return bot.github_api_request(
         "POST",
         "git/commits",
@@ -228,7 +228,7 @@ def create_lock_commit(bot: ReviewerBotContext, parent_sha: str, tree_sha: str, 
     )
 
 
-def cas_update_lock_ref(bot: ReviewerBotContext, new_sha: str):
+def cas_update_lock_ref(bot: LeaseLockContext, new_sha: str):
     return bot.github_api_request(
         "PATCH",
         f"git/refs/{get_lock_ref_name(bot)}",
@@ -237,7 +237,7 @@ def cas_update_lock_ref(bot: ReviewerBotContext, new_sha: str):
     )
 
 
-def ensure_state_issue_lease_lock_fresh(bot: ReviewerBotContext) -> bool:
+def ensure_state_issue_lease_lock_fresh(bot: LeaseLockContext) -> bool:
     context = bot.ACTIVE_LEASE_CONTEXT
     if context is None:
         return False
@@ -257,7 +257,7 @@ def ensure_state_issue_lease_lock_fresh(bot: ReviewerBotContext) -> bool:
     return bot.renew_state_issue_lease_lock(context)
 
 
-def renew_state_issue_lease_lock(bot: ReviewerBotContext, context: LeaseContext) -> bool:
+def renew_state_issue_lease_lock(bot: LeaseLockContext, context: LeaseContext) -> bool:
     retry_limit = getattr(bot, "LOCK_API_RETRY_LIMIT", LOCK_API_RETRY_LIMIT)
     retry_base = getattr(bot, "LOCK_RETRY_BASE_SECONDS", LOCK_RETRY_BASE_SECONDS)
     for attempt in range(1, retry_limit + 1):
@@ -326,7 +326,7 @@ def renew_state_issue_lease_lock(bot: ReviewerBotContext, context: LeaseContext)
     return False
 
 
-def acquire_state_issue_lease_lock(bot: ReviewerBotContext) -> LeaseContext:
+def acquire_state_issue_lease_lock(bot: LeaseLockContext) -> LeaseContext:
     if bot.ACTIVE_LEASE_CONTEXT is not None:
         return bot.ACTIVE_LEASE_CONTEXT
     lock_token = uuid.uuid4().hex
@@ -422,7 +422,7 @@ def acquire_state_issue_lease_lock(bot: ReviewerBotContext) -> LeaseContext:
         time.sleep(delay)
 
 
-def release_state_issue_lease_lock(bot: ReviewerBotContext) -> bool:
+def release_state_issue_lease_lock(bot: LeaseLockContext) -> bool:
     context = bot.ACTIVE_LEASE_CONTEXT
     if context is None:
         return True

--- a/scripts/reviewer_bot_lib/state_store.py
+++ b/scripts/reviewer_bot_lib/state_store.py
@@ -27,10 +27,10 @@ from .config import (
     StateIssueBodyParts,
     StateIssueSnapshot,
 )
-from .context import ReviewerBotContext
+from .context import StateStoreContext
 
 
-def get_state_issue(bot: ReviewerBotContext) -> dict | None:
+def get_state_issue(bot: StateStoreContext) -> dict | None:
     """Fetch the state issue from GitHub with retry for transient failures."""
     state_issue_number = getattr(bot, "STATE_ISSUE_NUMBER", STATE_ISSUE_NUMBER)
     state_read_retry_limit = getattr(bot, "STATE_READ_RETRY_LIMIT", STATE_READ_RETRY_LIMIT)
@@ -270,7 +270,7 @@ def parse_state_from_issue(issue: dict) -> dict:
     return parse_state_yaml_from_issue_body(body)
 
 
-def get_state_issue_snapshot(bot: ReviewerBotContext) -> StateIssueSnapshot | None:
+def get_state_issue_snapshot(bot: StateStoreContext) -> StateIssueSnapshot | None:
     state_issue_number = getattr(bot, "STATE_ISSUE_NUMBER", STATE_ISSUE_NUMBER)
     if not state_issue_number:
         print("ERROR: STATE_ISSUE_NUMBER not set", file=sys.stderr)
@@ -305,7 +305,7 @@ def get_state_issue_snapshot(bot: ReviewerBotContext) -> StateIssueSnapshot | No
     return StateIssueSnapshot(body=body, etag=response.headers.get("etag"), html_url=html_url)
 
 
-def conditional_patch_state_issue(bot: ReviewerBotContext, body: str, etag: str | None = None):
+def conditional_patch_state_issue(bot: StateStoreContext, body: str, etag: str | None = None):
     state_issue_number = getattr(bot, "STATE_ISSUE_NUMBER", STATE_ISSUE_NUMBER)
     return bot.github_api_request(
         "PATCH",
@@ -315,12 +315,12 @@ def conditional_patch_state_issue(bot: ReviewerBotContext, body: str, etag: str 
     )
 
 
-def assert_lock_held(bot: ReviewerBotContext, operation: str) -> None:
+def assert_lock_held(bot: StateStoreContext, operation: str) -> None:
     if bot.ACTIVE_LEASE_CONTEXT is None:
         raise RuntimeError(f"Mutating path reached without lease lock: {operation}")
 
 
-def load_state(bot: ReviewerBotContext, *, fail_on_unavailable: bool = False) -> dict:
+def load_state(bot: StateStoreContext, *, fail_on_unavailable: bool = False) -> dict:
     default_state = {
         "schema_version": STATE_SCHEMA_VERSION,
         "freshness_runtime_epoch": FRESHNESS_RUNTIME_EPOCH_LEGACY,
@@ -362,7 +362,7 @@ def load_state(bot: ReviewerBotContext, *, fail_on_unavailable: bool = False) ->
     return state
 
 
-def save_state(bot: ReviewerBotContext, state: dict) -> bool:
+def save_state(bot: StateStoreContext, state: dict) -> bool:
     assert_lock_held(bot, "save_state")
 
     state_issue_number = getattr(bot, "STATE_ISSUE_NUMBER", STATE_ISSUE_NUMBER)


### PR DESCRIPTION
## Summary
- split the broad reviewer-bot runtime context into smaller transport, state-store, and lease-lock protocols
- type the lock/state infrastructure modules against those narrower interfaces
- keep reviewer-bot behavior unchanged while reducing the effective facade surface

## What Changed
- extend scripts/reviewer_bot_lib/context.py with smaller protocols:
  - GitHubTransportContext
  - StateStoreContext
  - LeaseLockContext
- redefine ReviewerBotContext in terms of those narrower protocols plus the higher-level orchestration surface
- update the core infrastructure modules to type against the smaller protocols where appropriate:
  - scripts/reviewer_bot_lib/github_api.py
  - scripts/reviewer_bot_lib/state_store.py
  - scripts/reviewer_bot_lib/lease_lock.py
- remove the dead dynamic queue wrapper from scripts/reviewer_bot_lib/queue.py
- add a structural regression test asserting that the main reviewer-bot module satisfies the narrower lock/state protocols

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Notes
- this PR is structural only; it is intended to reduce the effective runtime facade surface without changing reviewer-bot semantics
- follow-up cleanup can now continue by narrowing event/command usage and further shrinking scripts/reviewer_bot.py
