### PR TITLE
Refactor reviewer-bot lifecycle handlers

### DIFF
--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -68,6 +68,7 @@ try:
     import scripts.reviewer_bot_lib.events as events_module
     import scripts.reviewer_bot_lib.github_api as github_api_module
     import scripts.reviewer_bot_lib.lease_lock as lease_lock_module
+    import scripts.reviewer_bot_lib.lifecycle as lifecycle_module
     import scripts.reviewer_bot_lib.reviews as reviews_module
     import scripts.reviewer_bot_lib.state_store as state_store_module
     from scripts.reviewer_bot_lib import app as app_module
@@ -154,6 +155,7 @@ except ImportError:
     import reviewer_bot_lib.events as events_module
     import reviewer_bot_lib.github_api as github_api_module
     import reviewer_bot_lib.lease_lock as lease_lock_module
+    import reviewer_bot_lib.lifecycle as lifecycle_module
     import reviewer_bot_lib.reviews as reviews_module
     import reviewer_bot_lib.state_store as state_store_module
     from reviewer_bot_lib.config import (  # noqa: F401
@@ -241,6 +243,10 @@ ACTIVE_LEASE_CONTEXT: LeaseContext | None = None
 TOUCHED_ISSUE_NUMBERS: set[int] = set()
 
 
+def _runtime_bot() -> Any:
+    return sys.modules[__name__]
+
+
 def get_github_token() -> str:
     return github_api_module.get_github_token()
 
@@ -254,7 +260,7 @@ def github_api_request(
     suppress_error_log: bool = False,
 ) -> GitHubApiResult:
     return github_api_module.github_api_request(
-        sys.modules[__name__],
+        _runtime_bot(),
         method,
         endpoint,
         data,
@@ -264,31 +270,31 @@ def github_api_request(
 
 
 def github_api(method: str, endpoint: str, data: dict | None = None) -> Any | None:
-    return github_api_module.github_api(sys.modules[__name__], method, endpoint, data)
+    return github_api_module.github_api(_runtime_bot(), method, endpoint, data)
 
 
 def post_comment(issue_number: int, body: str) -> bool:
-    return github_api_module.post_comment(sys.modules[__name__], issue_number, body)
+    return github_api_module.post_comment(_runtime_bot(), issue_number, body)
 
 
 def get_repo_labels() -> set[str]:
-    return github_api_module.get_repo_labels(sys.modules[__name__])
+    return github_api_module.get_repo_labels(_runtime_bot())
 
 
 def add_label(issue_number: int, label: str) -> bool:
-    return github_api_module.add_label(sys.modules[__name__], issue_number, label)
+    return github_api_module.add_label(_runtime_bot(), issue_number, label)
 
 
 def remove_label(issue_number: int, label: str) -> bool:
-    return github_api_module.remove_label(sys.modules[__name__], issue_number, label)
+    return github_api_module.remove_label(_runtime_bot(), issue_number, label)
 
 
 def add_label_with_status(issue_number: int, label: str) -> bool:
-    return github_api_module.add_label_with_status(sys.modules[__name__], issue_number, label)
+    return github_api_module.add_label_with_status(_runtime_bot(), issue_number, label)
 
 
 def remove_label_with_status(issue_number: int, label: str) -> bool:
-    return github_api_module.remove_label_with_status(sys.modules[__name__], issue_number, label)
+    return github_api_module.remove_label_with_status(_runtime_bot(), issue_number, label)
 
 
 def ensure_label_exists(
@@ -298,7 +304,7 @@ def ensure_label_exists(
     description: str | None = None,
 ) -> bool:
     return github_api_module.ensure_label_exists(
-        sys.modules[__name__],
+        _runtime_bot(),
         label,
         color=color,
         description=description,
@@ -348,39 +354,39 @@ def get_issue_or_pr_labels(issue_number: int) -> set[str] | None:
 
 
 def request_reviewer_assignment(issue_number: int, username: str) -> AssignmentAttempt:
-    return github_api_module.request_reviewer_assignment(sys.modules[__name__], issue_number, username)
+    return github_api_module.request_reviewer_assignment(_runtime_bot(), issue_number, username)
 
 
 def assign_reviewer(issue_number: int, username: str) -> bool:
-    return github_api_module.assign_reviewer(sys.modules[__name__], issue_number, username)
+    return github_api_module.assign_reviewer(_runtime_bot(), issue_number, username)
 
 
 def get_assignment_failure_comment(reviewer: str, attempt: AssignmentAttempt) -> str | None:
-    return github_api_module.get_assignment_failure_comment(sys.modules[__name__], reviewer, attempt)
+    return github_api_module.get_assignment_failure_comment(_runtime_bot(), reviewer, attempt)
 
 
 def get_issue_assignees(issue_number: int) -> list[str]:
-    return github_api_module.get_issue_assignees(sys.modules[__name__], issue_number)
+    return github_api_module.get_issue_assignees(_runtime_bot(), issue_number)
 
 
 def add_reaction(comment_id: int, reaction: str) -> bool:
-    return github_api_module.add_reaction(sys.modules[__name__], comment_id, reaction)
+    return github_api_module.add_reaction(_runtime_bot(), comment_id, reaction)
 
 
 def remove_assignee(issue_number: int, username: str) -> bool:
-    return github_api_module.remove_assignee(sys.modules[__name__], issue_number, username)
+    return github_api_module.remove_assignee(_runtime_bot(), issue_number, username)
 
 
 def remove_pr_reviewer(issue_number: int, username: str) -> bool:
-    return github_api_module.remove_pr_reviewer(sys.modules[__name__], issue_number, username)
+    return github_api_module.remove_pr_reviewer(_runtime_bot(), issue_number, username)
 
 
 def unassign_reviewer(issue_number: int, username: str) -> bool:
-    return github_api_module.unassign_reviewer(sys.modules[__name__], issue_number, username)
+    return github_api_module.unassign_reviewer(_runtime_bot(), issue_number, username)
 
 
 def check_user_permission(username: str, required_permission: str = "triage") -> bool:
-    return github_api_module.check_user_permission(sys.modules[__name__], username, required_permission)
+    return github_api_module.check_user_permission(_runtime_bot(), username, required_permission)
 
 
 # ==============================================================================
@@ -389,7 +395,7 @@ def check_user_permission(username: str, required_permission: str = "triage") ->
 
 
 def get_state_issue() -> dict | None:
-    return state_store_module.get_state_issue(sys.modules[__name__])
+    return state_store_module.get_state_issue(_runtime_bot())
 
 
 def default_state_issue_prefix() -> str:
@@ -445,23 +451,23 @@ def parse_state_from_issue(issue: dict) -> dict:
 
 
 def get_state_issue_snapshot() -> StateIssueSnapshot | None:
-    return state_store_module.get_state_issue_snapshot(sys.modules[__name__])
+    return state_store_module.get_state_issue_snapshot(_runtime_bot())
 
 
 def conditional_patch_state_issue(body: str, etag: str | None = None) -> GitHubApiResult:
-    return state_store_module.conditional_patch_state_issue(sys.modules[__name__], body, etag)
+    return state_store_module.conditional_patch_state_issue(_runtime_bot(), body, etag)
 
 
 def assert_lock_held(operation: str) -> None:
-    state_store_module.assert_lock_held(sys.modules[__name__], operation)
+    state_store_module.assert_lock_held(_runtime_bot(), operation)
 
 
 def load_state(*, fail_on_unavailable: bool = False) -> dict:
-    return state_store_module.load_state(sys.modules[__name__], fail_on_unavailable=fail_on_unavailable)
+    return state_store_module.load_state(_runtime_bot(), fail_on_unavailable=fail_on_unavailable)
 
 
 def save_state(state: dict) -> bool:
-    return state_store_module.save_state(sys.modules[__name__], state)
+    return state_store_module.save_state(_runtime_bot(), state)
 
 
 def parse_iso8601_timestamp(value: Any) -> datetime | None:
@@ -469,7 +475,7 @@ def parse_iso8601_timestamp(value: Any) -> datetime | None:
 
 
 def lock_is_currently_valid(lock_meta: dict, now: datetime | None = None) -> bool:
-    return lease_lock_module.lock_is_currently_valid(sys.modules[__name__], lock_meta, now)
+    return lease_lock_module.lock_is_currently_valid(_runtime_bot(), lock_meta, now)
 
 
 def get_lock_owner_context() -> tuple[str, str, str]:
@@ -483,12 +489,12 @@ def build_lock_metadata(
     lock_owner_job: str,
 ) -> dict:
     return lease_lock_module.build_lock_metadata(
-        sys.modules[__name__], lock_token, lock_owner_run_id, lock_owner_workflow, lock_owner_job
+        _runtime_bot(), lock_token, lock_owner_run_id, lock_owner_workflow, lock_owner_job
     )
 
 
 def clear_lock_metadata() -> dict:
-    return lease_lock_module.clear_lock_metadata(sys.modules[__name__])
+    return lease_lock_module.clear_lock_metadata(_runtime_bot())
 
 
 def normalize_lock_ref_name(ref_name: str) -> str:
@@ -496,15 +502,15 @@ def normalize_lock_ref_name(ref_name: str) -> str:
 
 
 def get_lock_ref_name() -> str:
-    return lease_lock_module.get_lock_ref_name(sys.modules[__name__])
+    return lease_lock_module.get_lock_ref_name(_runtime_bot())
 
 
 def get_lock_ref_display() -> str:
-    return lease_lock_module.get_lock_ref_display(sys.modules[__name__])
+    return lease_lock_module.get_lock_ref_display(_runtime_bot())
 
 
 def get_state_issue_html_url() -> str:
-    return lease_lock_module.get_state_issue_html_url(sys.modules[__name__])
+    return lease_lock_module.get_state_issue_html_url(_runtime_bot())
 
 
 def extract_ref_sha(payload: Any) -> str | None:
@@ -520,47 +526,47 @@ def extract_commit_sha(payload: Any) -> str | None:
 
 
 def render_lock_commit_message(lock_meta: dict) -> str:
-    return lease_lock_module.render_lock_commit_message(sys.modules[__name__], lock_meta)
+    return lease_lock_module.render_lock_commit_message(_runtime_bot(), lock_meta)
 
 
 def parse_lock_metadata_from_lock_commit_message(message: str) -> dict:
-    return lease_lock_module.parse_lock_metadata_from_lock_commit_message(sys.modules[__name__], message)
+    return lease_lock_module.parse_lock_metadata_from_lock_commit_message(_runtime_bot(), message)
 
 
 def ensure_lock_ref_exists() -> str:
-    return lease_lock_module.ensure_lock_ref_exists(sys.modules[__name__])
+    return lease_lock_module.ensure_lock_ref_exists(_runtime_bot())
 
 
 def get_lock_ref_snapshot() -> tuple[str, str, dict]:
-    return lease_lock_module.get_lock_ref_snapshot(sys.modules[__name__])
+    return lease_lock_module.get_lock_ref_snapshot(_runtime_bot())
 
 
 def create_lock_commit(parent_sha: str, tree_sha: str, lock_meta: dict) -> GitHubApiResult:
-    return lease_lock_module.create_lock_commit(sys.modules[__name__], parent_sha, tree_sha, lock_meta)
+    return lease_lock_module.create_lock_commit(_runtime_bot(), parent_sha, tree_sha, lock_meta)
 
 
 def cas_update_lock_ref(new_sha: str) -> GitHubApiResult:
-    return lease_lock_module.cas_update_lock_ref(sys.modules[__name__], new_sha)
+    return lease_lock_module.cas_update_lock_ref(_runtime_bot(), new_sha)
 
 
 def ensure_state_issue_lease_lock_fresh() -> bool:
-    return lease_lock_module.ensure_state_issue_lease_lock_fresh(sys.modules[__name__])
+    return lease_lock_module.ensure_state_issue_lease_lock_fresh(_runtime_bot())
 
 
 def renew_state_issue_lease_lock(context: LeaseContext) -> bool:
-    return lease_lock_module.renew_state_issue_lease_lock(sys.modules[__name__], context)
+    return lease_lock_module.renew_state_issue_lease_lock(_runtime_bot(), context)
 
 
 def acquire_state_issue_lease_lock() -> LeaseContext:
-    return lease_lock_module.acquire_state_issue_lease_lock(sys.modules[__name__])
+    return lease_lock_module.acquire_state_issue_lease_lock(_runtime_bot())
 
 
 def release_state_issue_lease_lock() -> bool:
-    return lease_lock_module.release_state_issue_lease_lock(sys.modules[__name__])
+    return lease_lock_module.release_state_issue_lease_lock(_runtime_bot())
 
 
 def sync_members_with_queue(state: dict) -> tuple[dict, list[str]]:
-    return queue_sync_members_with_queue(sys.modules[__name__], state)
+    return queue_sync_members_with_queue(_runtime_bot(), state)
 
 
 def reposition_member_as_next(state: dict, username: str) -> bool:
@@ -601,21 +607,21 @@ def strip_code_blocks(comment_body: str) -> str:
 
 
 def parse_command(comment_body: str) -> tuple[str, list[str]] | None:
-    return commands_module.parse_command(sys.modules[__name__], comment_body)
+    return commands_module.parse_command(_runtime_bot(), comment_body)
 
 
 def handle_pass_command(state: dict, issue_number: int, comment_author: str,
                        reason: str | None) -> tuple[str, bool]:
-    return commands_module.handle_pass_command(sys.modules[__name__], state, issue_number, comment_author, reason)
+    return commands_module.handle_pass_command(_runtime_bot(), state, issue_number, comment_author, reason)
 
 
 def handle_pass_until_command(state: dict, issue_number: int, comment_author: str,
                               return_date: str, reason: str | None) -> tuple[str, bool]:
-    return commands_module.handle_pass_until_command(sys.modules[__name__], state, issue_number, comment_author, return_date, reason)
+    return commands_module.handle_pass_until_command(_runtime_bot(), state, issue_number, comment_author, return_date, reason)
 
 
 def handle_label_command(issue_number: int, label_string: str) -> tuple[str, bool]:
-    return commands_module.handle_label_command(sys.modules[__name__], issue_number, label_string)
+    return commands_module.handle_label_command(_runtime_bot(), issue_number, label_string)
 
 
 def parse_issue_labels() -> list[str]:
@@ -635,54 +641,54 @@ def list_changed_files(repo_root: Path) -> list[str]:
 
 
 def get_default_branch() -> str:
-    return automation_module.get_default_branch(sys.modules[__name__])
+    return automation_module.get_default_branch(_runtime_bot())
 
 
 def find_open_pr_for_branch(branch: str) -> dict | None:
-    return automation_module.find_open_pr_for_branch(sys.modules[__name__], branch)
+    return automation_module.find_open_pr_for_branch(_runtime_bot(), branch)
 
 
 def resolve_workflow_run_pr_number() -> int:
-    return commands_module.resolve_workflow_run_pr_number(sys.modules[__name__])
+    return commands_module.resolve_workflow_run_pr_number(_runtime_bot())
 
 
 def create_pull_request(branch: str, base: str, issue_number: int) -> dict | None:
-    return automation_module.create_pull_request(sys.modules[__name__], branch, base, issue_number)
+    return automation_module.create_pull_request(_runtime_bot(), branch, base, issue_number)
 
 
 def handle_accept_no_fls_changes_command(issue_number: int, comment_author: str) -> tuple[str, bool]:
-    return automation_module.handle_accept_no_fls_changes_command(sys.modules[__name__], issue_number, comment_author)
+    return automation_module.handle_accept_no_fls_changes_command(_runtime_bot(), issue_number, comment_author)
 
 
 def handle_sync_members_command(state: dict) -> tuple[str, bool]:
-    return commands_module.handle_sync_members_command(sys.modules[__name__], state)
+    return commands_module.handle_sync_members_command(_runtime_bot(), state)
 
 
 def handle_queue_command(state: dict) -> tuple[str, bool]:
-    return commands_module.handle_queue_command(sys.modules[__name__], state)
+    return commands_module.handle_queue_command(_runtime_bot(), state)
 
 
 def handle_commands_command() -> tuple[str, bool]:
-    return commands_module.handle_commands_command(sys.modules[__name__])
+    return commands_module.handle_commands_command(_runtime_bot())
 
 
 def handle_claim_command(state: dict, issue_number: int,
                         comment_author: str) -> tuple[str, bool]:
-    return commands_module.handle_claim_command(sys.modules[__name__], state, issue_number, comment_author)
+    return commands_module.handle_claim_command(_runtime_bot(), state, issue_number, comment_author)
 
 
 def handle_release_command(state: dict, issue_number: int,
                           comment_author: str, args: list | None = None) -> tuple[str, bool]:
-    return commands_module.handle_release_command(sys.modules[__name__], state, issue_number, comment_author, args)
+    return commands_module.handle_release_command(_runtime_bot(), state, issue_number, comment_author, args)
 
 
 def handle_assign_command(state: dict, issue_number: int,
                          username: str) -> tuple[str, bool]:
-    return commands_module.handle_assign_command(sys.modules[__name__], state, issue_number, username)
+    return commands_module.handle_assign_command(_runtime_bot(), state, issue_number, username)
 
 
 def handle_assign_from_queue_command(state: dict, issue_number: int) -> tuple[str, bool]:
-    return commands_module.handle_assign_from_queue_command(sys.modules[__name__], state, issue_number)
+    return commands_module.handle_assign_from_queue_command(_runtime_bot(), state, issue_number)
 
 
 # ==============================================================================
@@ -713,11 +719,11 @@ def mark_review_complete(
 
 
 def is_triage_or_higher(username: str) -> bool:
-    return reviews_module.is_triage_or_higher(sys.modules[__name__], username)
+    return reviews_module.is_triage_or_higher(_runtime_bot(), username)
 
 
 def trigger_mandatory_approver_escalation(state: dict, issue_number: int) -> bool:
-    return reviews_module.trigger_mandatory_approver_escalation(sys.modules[__name__], state, issue_number)
+    return reviews_module.trigger_mandatory_approver_escalation(_runtime_bot(), state, issue_number)
 
 
 def satisfy_mandatory_approver_requirement(
@@ -726,7 +732,7 @@ def satisfy_mandatory_approver_requirement(
     approver: str,
 ) -> bool:
     return reviews_module.satisfy_mandatory_approver_requirement(
-        sys.modules[__name__], state, issue_number, approver
+        _runtime_bot(), state, issue_number, approver
     )
 
 
@@ -737,7 +743,7 @@ def handle_pr_approved_review(
     completion_source: str,
 ) -> bool:
     return reviews_module.handle_pr_approved_review(
-        sys.modules[__name__], state, issue_number, review_author, completion_source
+        _runtime_bot(), state, issue_number, review_author, completion_source
     )
 
 
@@ -746,7 +752,7 @@ def parse_github_timestamp(value: str | None) -> datetime | None:
 
 
 def get_pull_request_reviews(issue_number: int) -> list[dict] | None:
-    return reviews_module.get_pull_request_reviews(sys.modules[__name__], issue_number)
+    return reviews_module.get_pull_request_reviews(_runtime_bot(), issue_number)
 
 
 def collapse_latest_reviews_by_login(reviews: list[dict]) -> dict[str, dict]:
@@ -754,7 +760,7 @@ def collapse_latest_reviews_by_login(reviews: list[dict]) -> dict[str, dict]:
 
 
 def get_current_cycle_boundary(review_data: dict) -> datetime | None:
-    return reviews_module.get_current_cycle_boundary(sys.modules[__name__], review_data)
+    return reviews_module.get_current_cycle_boundary(_runtime_bot(), review_data)
 
 
 def pr_has_current_write_approval(
@@ -764,7 +770,7 @@ def pr_has_current_write_approval(
     reviews: list[dict] | None = None,
 ) -> bool | None:
     return reviews_module.pr_has_current_write_approval(
-        sys.modules[__name__],
+        _runtime_bot(),
         issue_number,
         review_data,
         permission_cache=permission_cache,
@@ -779,24 +785,24 @@ def project_status_labels_for_item(
     issue_snapshot: dict | None = None,
 ) -> tuple[set[str] | None, dict[str, str | None]]:
     return reviews_module.project_status_labels_for_item(
-        sys.modules[__name__], issue_number, state, issue_snapshot=issue_snapshot
+        _runtime_bot(), issue_number, state, issue_snapshot=issue_snapshot
     )
 
 
 def sync_status_labels(issue_number: int, desired_labels: set[str], actual_labels: Iterable[str]) -> bool:
-    return reviews_module.sync_status_labels(sys.modules[__name__], issue_number, desired_labels, actual_labels)
+    return reviews_module.sync_status_labels(_runtime_bot(), issue_number, desired_labels, actual_labels)
 
 
 def sync_status_labels_for_items(state: dict, issue_numbers: Iterable[int]) -> bool:
-    return reviews_module.sync_status_labels_for_items(sys.modules[__name__], state, issue_numbers)
+    return reviews_module.sync_status_labels_for_items(_runtime_bot(), state, issue_numbers)
 
 
 def list_open_items_with_status_labels() -> list[int]:
-    return reviews_module.list_open_items_with_status_labels(sys.modules[__name__])
+    return reviews_module.list_open_items_with_status_labels(_runtime_bot())
 
 
 def get_latest_review_by_reviewer(reviews: list[dict], reviewer: str) -> dict | None:
-    return events_module.get_latest_review_by_reviewer(sys.modules[__name__], reviews, reviewer)
+    return events_module.get_latest_review_by_reviewer(_runtime_bot(), reviews, reviewer)
 
 
 def find_triage_approval_after(
@@ -838,7 +844,7 @@ def find_triage_approval_after(
 
 
 def classify_comment_payload(comment_body: str) -> dict:
-    return events_module.classify_comment_payload(sys.modules[__name__], comment_body)
+    return events_module.classify_comment_payload(_runtime_bot(), comment_body)
 
 
 def classify_issue_comment_actor() -> str:
@@ -846,7 +852,7 @@ def classify_issue_comment_actor() -> str:
 
 
 def route_issue_comment_trust(issue_number: int) -> str:
-    return events_module.route_issue_comment_trust(sys.modules[__name__], issue_number)
+    return events_module.route_issue_comment_trust(_runtime_bot(), issue_number)
 
 
 def observer_run_reason_from_details(run_details: dict, runbook_signature: dict | None) -> str:
@@ -862,7 +868,7 @@ def classify_artifact_gap_reason(gap: dict, now: datetime | None = None) -> str:
 
 
 def sweep_deferred_gaps(state: dict) -> bool:
-    return events_module.sweep_deferred_gaps(sys.modules[__name__], state)
+    return events_module.sweep_deferred_gaps(_runtime_bot(), state)
 
 
 def correlate_candidate_observer_runs(
@@ -914,7 +920,7 @@ def reconcile_active_review_entry(
     completion_source: str = "rectify:reconcile-pr-review",
 ) -> tuple[str, bool, bool]:
     return events_module.reconcile_active_review_entry(
-        sys.modules[__name__],
+        _runtime_bot(),
         state,
         issue_number,
         require_pull_request_context=require_pull_request_context,
@@ -1087,47 +1093,47 @@ _Life happens! If you're dealing with something, just let us know._"""
 
 
 def handle_transition_notice(state: dict, issue_number: int, reviewer: str) -> bool:
-    return events_module.handle_transition_notice(sys.modules[__name__], state, issue_number, reviewer)
+    return lifecycle_module.handle_transition_notice(_runtime_bot(), state, issue_number, reviewer)
 
 
 def handle_issue_or_pr_opened(state: dict) -> bool:
-    return events_module.handle_issue_or_pr_opened(sys.modules[__name__], state)
+    return lifecycle_module.handle_issue_or_pr_opened(_runtime_bot(), state)
 
 
 def handle_labeled_event(state: dict) -> bool:
-    return events_module.handle_labeled_event(sys.modules[__name__], state)
+    return lifecycle_module.handle_labeled_event(_runtime_bot(), state)
 
 
 def handle_issue_edited_event(state: dict) -> bool:
-    return events_module.handle_issue_edited_event(sys.modules[__name__], state)
+    return lifecycle_module.handle_issue_edited_event(_runtime_bot(), state)
 
 
 def handle_pull_request_target_synchronize(state: dict) -> bool:
-    return events_module.handle_pull_request_target_synchronize(sys.modules[__name__], state)
+    return lifecycle_module.handle_pull_request_target_synchronize(_runtime_bot(), state)
 
 
 def handle_pull_request_review_event(state: dict) -> bool:
-    return events_module.handle_pull_request_review_event(sys.modules[__name__], state)
+    return events_module.handle_pull_request_review_event(_runtime_bot(), state)
 
 
 def handle_workflow_run_event(state: dict) -> bool:
-    return events_module.handle_workflow_run_event(sys.modules[__name__], state)
+    return events_module.handle_workflow_run_event(_runtime_bot(), state)
 
 
 def handle_closed_event(state: dict) -> bool:
-    return events_module.handle_closed_event(sys.modules[__name__], state)
+    return lifecycle_module.handle_closed_event(_runtime_bot(), state)
 
 
 def handle_comment_event(state: dict) -> bool:
-    return events_module.handle_comment_event(sys.modules[__name__], state)
+    return events_module.handle_comment_event(_runtime_bot(), state)
 
 
 def handle_manual_dispatch(state: dict) -> bool:
-    return events_module.handle_manual_dispatch(sys.modules[__name__], state)
+    return events_module.handle_manual_dispatch(_runtime_bot(), state)
 
 
 def handle_scheduled_check(state: dict) -> bool:
-    return events_module.handle_scheduled_check(sys.modules[__name__], state)
+    return events_module.handle_scheduled_check(_runtime_bot(), state)
 
 
 # ==============================================================================
@@ -1136,16 +1142,16 @@ def handle_scheduled_check(state: dict) -> bool:
 
 
 def classify_event_intent(event_name: str, event_action: str) -> str:
-    return app_module.classify_event_intent(sys.modules[__name__], event_name, event_action)
+    return app_module.classify_event_intent(_runtime_bot(), event_name, event_action)
 
 
 def event_requires_lease_lock(event_name: str, event_action: str) -> bool:
     """Backwards-compatible helper for tests and call sites."""
-    return app_module.event_requires_lease_lock(sys.modules[__name__], event_name, event_action)
+    return app_module.event_requires_lease_lock(_runtime_bot(), event_name, event_action)
 
 
 def main():
-    app_module.main(sys.modules[__name__])
+    app_module.main(_runtime_bot())
 
 
 if __name__ == "__main__":

--- a/scripts/reviewer_bot_lib/events.py
+++ b/scripts/reviewer_bot_lib/events.py
@@ -14,7 +14,9 @@ from urllib.parse import quote
 
 import yaml
 
-from .guidance import get_fls_audit_guidance, get_issue_guidance, get_pr_guidance
+from .lifecycle import (
+    maybe_record_head_observation_repair,
+)
 
 
 def _now() -> datetime:
@@ -274,190 +276,6 @@ def reconcile_active_review_entry(
     return f"ℹ️ Rectify checked PR #{issue_number}: {'; '.join(messages) or 'no reconciliation transitions applied'}.", True, False
 
 
-def handle_transition_notice(bot, state: dict, issue_number: int, reviewer: str) -> bool:
-    notice_message = f"""🔔 **Transition Period Ended**
-
-@{reviewer}, the {bot.TRANSITION_PERIOD_DAYS}-day transition period has passed without activity on this review.
-
-Per our [contribution guidelines](CONTRIBUTING.md#review-deadlines), this may result in a transition from Producer to Observer status.
-
-**The review will now be reassigned to the next person in the queue.**
-
-_If you believe this is in error or have extenuating circumstances, please reach out to the subcommittee._"""
-    bot.post_comment(issue_number, notice_message)
-    return True
-
-
-def handle_issue_or_pr_opened(bot, state: dict) -> bool:
-    bot.assert_lock_held("handle_issue_or_pr_opened")
-    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
-    if not issue_number:
-        return False
-    bot.collect_touched_item(issue_number)
-    issue_key = str(issue_number)
-    tracked_reviewer = None
-    if isinstance(state.get("active_reviews"), dict) and issue_key in state["active_reviews"]:
-        review_data = state["active_reviews"][issue_key]
-        if isinstance(review_data, dict):
-            tracked_reviewer = review_data.get("current_reviewer")
-    if tracked_reviewer:
-        return False
-    current_assignees = bot.get_issue_assignees(issue_number)
-    if current_assignees:
-        return False
-    labels_json = os.environ.get("ISSUE_LABELS", "[]")
-    try:
-        labels = json.loads(labels_json)
-    except json.JSONDecodeError:
-        labels = []
-    if not any(label in bot.REVIEW_LABELS for label in labels):
-        return False
-    issue_author = os.environ.get("ISSUE_AUTHOR", "")
-    reviewer = bot.get_next_reviewer(state, skip_usernames={issue_author} if issue_author else set())
-    if not reviewer:
-        bot.post_comment(issue_number, f"⚠️ No reviewers available in the queue. Please use `{bot.BOT_MENTION} /sync-members` to update the queue.")
-        return False
-    is_pr = _is_pr_event()
-    assignment_attempt = bot.request_reviewer_assignment(issue_number, reviewer)
-    bot.set_current_reviewer(state, issue_number, reviewer)
-    review_data = bot.ensure_review_entry(state, issue_number, create=True)
-    if is_pr and isinstance(review_data, dict):
-        head_sha = os.environ.get("PR_HEAD_SHA", "").strip()
-        if head_sha:
-            review_data["active_head_sha"] = head_sha
-    bot.record_assignment(state, reviewer, issue_number, "pr" if is_pr else "issue")
-    failure_comment = bot.get_assignment_failure_comment(reviewer, assignment_attempt)
-    if failure_comment:
-        bot.post_comment(issue_number, failure_comment)
-    if is_pr and assignment_attempt.success:
-        bot.post_comment(issue_number, get_pr_guidance(reviewer, issue_author))
-    if not is_pr:
-        guidance = get_fls_audit_guidance(reviewer, issue_author) if bot.FLS_AUDIT_LABEL in labels else get_issue_guidance(reviewer, issue_author)
-        bot.post_comment(issue_number, guidance)
-    return True
-
-
-def handle_issue_edited_event(bot, state: dict) -> bool:
-    bot.assert_lock_held("handle_issue_edited_event")
-    if _is_pr_event():
-        return False
-    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
-    if not issue_number:
-        return False
-    bot.collect_touched_item(issue_number)
-    issue_author = os.environ.get("ISSUE_AUTHOR", "").strip()
-    editor = os.environ.get("SENDER_LOGIN", "").strip() or issue_author
-    if not issue_author or editor.lower() != issue_author.lower():
-        return False
-    review_data = bot.ensure_review_entry(state, issue_number)
-    if review_data is None:
-        return False
-    updated_at = os.environ.get("ISSUE_UPDATED_AT", "").strip() or _now_iso()
-    current_title = os.environ.get("ISSUE_TITLE", "")
-    current_body = os.environ.get("ISSUE_BODY", "")
-    previous_title = os.environ.get("ISSUE_CHANGES_TITLE_FROM", "")
-    previous_body = os.environ.get("ISSUE_CHANGES_BODY_FROM", "")
-    title_changed = _normalize_comment_body(current_title) != _normalize_comment_body(previous_title)
-    body_changed = _normalize_comment_body(current_body) != _normalize_comment_body(previous_body)
-    if not title_changed and not body_changed:
-        return False
-    if title_changed and body_changed:
-        semantic_key = f"issues_edit_title_body:{issue_number}:{_semantic_digest(current_title)}:{_semantic_digest(current_body)}"
-    elif title_changed:
-        semantic_key = f"issues_edit_title:{issue_number}:{_semantic_digest(current_title)}"
-    else:
-        semantic_key = f"issues_edit_body:{issue_number}:{_semantic_digest(current_body)}"
-    return bot.reviews_module.accept_channel_event(
-        review_data,
-        "contributor_comment",
-        semantic_key=semantic_key,
-        timestamp=updated_at,
-        actor=issue_author,
-        source_precedence=0,
-    )
-
-
-def handle_labeled_event(bot, state: dict) -> bool:
-    bot.assert_lock_held("handle_labeled_event")
-    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
-    if not issue_number:
-        return False
-    label_name = os.environ.get("LABEL_NAME", "")
-    is_pr = _is_pr_event()
-    bot.collect_touched_item(issue_number)
-    if label_name == "sign-off: create pr":
-        if is_pr:
-            return False
-        review_data = bot.ensure_review_entry(state, issue_number)
-        reviewer = review_data.get("current_reviewer") if review_data else None
-        return bot.mark_review_complete(state, issue_number, reviewer, "issue_label: sign-off: create pr")
-    if label_name not in bot.REVIEW_LABELS:
-        return False
-    return handle_issue_or_pr_opened(bot, state)
-
-
-def handle_pull_request_target_synchronize(bot, state: dict) -> bool:
-    bot.assert_lock_held("handle_pull_request_target_synchronize")
-    if _runtime_epoch(state) != "freshness_v15":
-        print("V18 synchronize repair safe-noop before epoch flip")
-        return False
-    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
-    if not issue_number:
-        return False
-    review_data = bot.ensure_review_entry(state, issue_number)
-    if review_data is None or not review_data.get("current_reviewer"):
-        return False
-    head_sha = os.environ.get("PR_HEAD_SHA", "").strip()
-    if not head_sha:
-        raise RuntimeError("Missing PR_HEAD_SHA for synchronize event")
-    bot.collect_touched_item(issue_number)
-    review_data["active_head_sha"] = head_sha
-    timestamp = os.environ.get("EVENT_CREATED_AT", "") or _now_iso()
-    changed = bot.reviews_module.accept_channel_event(
-        review_data,
-        "contributor_revision",
-        semantic_key=f"pull_request_sync:{issue_number}:{head_sha}",
-        timestamp=timestamp,
-        reviewed_head_sha=head_sha,
-        source_precedence=1,
-    )
-    bot.reviews_module.rebuild_pr_approval_state(bot, issue_number, review_data)
-    return changed
-
-
-def maybe_record_head_observation_repair(bot, issue_number: int, review_data: dict) -> bool:
-    pull_request = bot.github_api("GET", f"pulls/{issue_number}")
-    if not isinstance(pull_request, dict):
-        raise RuntimeError(f"Failed to fetch live PR #{issue_number} for head observation repair")
-    if str(pull_request.get("state", "")).lower() != "open":
-        return False
-    head = pull_request.get("head")
-    head_sha = head.get("sha") if isinstance(head, dict) else None
-    if not isinstance(head_sha, str) or not head_sha.strip():
-        raise RuntimeError(f"Pull request #{issue_number} is missing a usable head SHA")
-    head_sha = head_sha.strip()
-    current_head = review_data.get("active_head_sha")
-    if current_head == head_sha:
-        return False
-    contributor_revision = review_data.get("contributor_revision", {}).get("accepted")
-    if isinstance(contributor_revision, dict) and contributor_revision.get("reviewed_head_sha") == head_sha:
-        review_data["active_head_sha"] = head_sha
-        return False
-    changed = bot.reviews_module.accept_channel_event(
-        review_data,
-        "contributor_revision",
-        semantic_key=f"pull_request_head_observed:{issue_number}:{head_sha}",
-        timestamp=_now_iso(),
-        reviewed_head_sha=head_sha,
-        source_precedence=0,
-    )
-    review_data["active_head_sha"] = head_sha
-    review_data["current_cycle_completion"] = {}
-    review_data["current_cycle_write_approval"] = {}
-    review_data["review_completed_at"] = None
-    review_data["review_completed_by"] = None
-    review_data["review_completion_source"] = None
-    return changed
 
 
 def _is_self_comment(bot, author: str) -> bool:
@@ -1329,19 +1147,6 @@ def handle_workflow_run_event(bot, state: dict) -> bool:
         _update_deferred_gap(review_data, payload, "reconcile_failed_closed", f"{exc} See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
         raise
     raise RuntimeError("Unsupported deferred workflow_run payload")
-
-
-def handle_closed_event(bot, state: dict) -> bool:
-    bot.assert_lock_held("handle_closed_event")
-    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
-    if not issue_number:
-        return False
-    bot.collect_touched_item(issue_number)
-    issue_key = str(issue_number)
-    if isinstance(state.get("active_reviews"), dict) and issue_key in state["active_reviews"]:
-        del state["active_reviews"][issue_key]
-        return True
-    return False
 
 
 def handle_manual_dispatch(bot, state: dict) -> bool:

--- a/scripts/reviewer_bot_lib/lifecycle.py
+++ b/scripts/reviewer_bot_lib/lifecycle.py
@@ -1,0 +1,230 @@
+"""Issue and PR lifecycle handlers for reviewer-bot."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+
+from .guidance import get_fls_audit_guidance, get_issue_guidance, get_pr_guidance
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _runtime_epoch(state: dict) -> str:
+    return str(state.get("freshness_runtime_epoch", "")).strip() or "legacy_v14"
+
+
+def _is_pr_event() -> bool:
+    return os.environ.get("IS_PULL_REQUEST", "false").lower() == "true"
+
+
+def _normalize_comment_body(body: str) -> str:
+    return "\n".join(line.rstrip() for line in body.replace("\r\n", "\n").split("\n")).strip()
+
+
+def _semantic_digest(value: str) -> str:
+    return hashlib.sha256(_normalize_comment_body(value).encode("utf-8")).hexdigest()
+
+
+def handle_transition_notice(bot, state: dict, issue_number: int, reviewer: str) -> bool:
+    del state
+    notice_message = f"""🔔 **Transition Period Ended**
+
+@{reviewer}, the {bot.TRANSITION_PERIOD_DAYS}-day transition period has passed without activity on this review.
+
+Per our [contribution guidelines](CONTRIBUTING.md#review-deadlines), this may result in a transition from Producer to Observer status.
+
+**The review will now be reassigned to the next person in the queue.**
+
+_If you believe this is in error or have extenuating circumstances, please reach out to the subcommittee._"""
+    bot.post_comment(issue_number, notice_message)
+    return True
+
+
+def handle_issue_or_pr_opened(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_issue_or_pr_opened")
+    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
+    if not issue_number:
+        return False
+    bot.collect_touched_item(issue_number)
+    issue_key = str(issue_number)
+    tracked_reviewer = None
+    if isinstance(state.get("active_reviews"), dict) and issue_key in state["active_reviews"]:
+        review_data = state["active_reviews"][issue_key]
+        if isinstance(review_data, dict):
+            tracked_reviewer = review_data.get("current_reviewer")
+    if tracked_reviewer:
+        return False
+    current_assignees = bot.get_issue_assignees(issue_number)
+    if current_assignees:
+        return False
+    labels_json = os.environ.get("ISSUE_LABELS", "[]")
+    try:
+        labels = json.loads(labels_json)
+    except json.JSONDecodeError:
+        labels = []
+    if not any(label in bot.REVIEW_LABELS for label in labels):
+        return False
+    issue_author = os.environ.get("ISSUE_AUTHOR", "")
+    reviewer = bot.get_next_reviewer(state, skip_usernames={issue_author} if issue_author else set())
+    if not reviewer:
+        bot.post_comment(issue_number, f"⚠️ No reviewers available in the queue. Please use `{bot.BOT_MENTION} /sync-members` to update the queue.")
+        return False
+    is_pr = _is_pr_event()
+    assignment_attempt = bot.request_reviewer_assignment(issue_number, reviewer)
+    bot.set_current_reviewer(state, issue_number, reviewer)
+    review_data = bot.ensure_review_entry(state, issue_number, create=True)
+    if is_pr and isinstance(review_data, dict):
+        head_sha = os.environ.get("PR_HEAD_SHA", "").strip()
+        if head_sha:
+            review_data["active_head_sha"] = head_sha
+    bot.record_assignment(state, reviewer, issue_number, "pr" if is_pr else "issue")
+    failure_comment = bot.get_assignment_failure_comment(reviewer, assignment_attempt)
+    if failure_comment:
+        bot.post_comment(issue_number, failure_comment)
+    if is_pr and assignment_attempt.success:
+        bot.post_comment(issue_number, get_pr_guidance(reviewer, issue_author))
+    if not is_pr:
+        guidance = get_fls_audit_guidance(reviewer, issue_author) if bot.FLS_AUDIT_LABEL in labels else get_issue_guidance(reviewer, issue_author)
+        bot.post_comment(issue_number, guidance)
+    return True
+
+
+def handle_issue_edited_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_issue_edited_event")
+    if _is_pr_event():
+        return False
+    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
+    if not issue_number:
+        return False
+    bot.collect_touched_item(issue_number)
+    issue_author = os.environ.get("ISSUE_AUTHOR", "").strip()
+    editor = os.environ.get("SENDER_LOGIN", "").strip() or issue_author
+    if not issue_author or editor.lower() != issue_author.lower():
+        return False
+    review_data = bot.ensure_review_entry(state, issue_number)
+    if review_data is None:
+        return False
+    updated_at = os.environ.get("ISSUE_UPDATED_AT", "").strip() or _now_iso()
+    current_title = os.environ.get("ISSUE_TITLE", "")
+    current_body = os.environ.get("ISSUE_BODY", "")
+    previous_title = os.environ.get("ISSUE_CHANGES_TITLE_FROM", "")
+    previous_body = os.environ.get("ISSUE_CHANGES_BODY_FROM", "")
+    title_changed = _normalize_comment_body(current_title) != _normalize_comment_body(previous_title)
+    body_changed = _normalize_comment_body(current_body) != _normalize_comment_body(previous_body)
+    if not title_changed and not body_changed:
+        return False
+    if title_changed and body_changed:
+        semantic_key = f"issues_edit_title_body:{issue_number}:{_semantic_digest(current_title)}:{_semantic_digest(current_body)}"
+    elif title_changed:
+        semantic_key = f"issues_edit_title:{issue_number}:{_semantic_digest(current_title)}"
+    else:
+        semantic_key = f"issues_edit_body:{issue_number}:{_semantic_digest(current_body)}"
+    return bot.reviews_module.accept_channel_event(
+        review_data,
+        "contributor_comment",
+        semantic_key=semantic_key,
+        timestamp=updated_at,
+        actor=issue_author,
+        source_precedence=0,
+    )
+
+
+def handle_labeled_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_labeled_event")
+    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
+    if not issue_number:
+        return False
+    label_name = os.environ.get("LABEL_NAME", "")
+    is_pr = _is_pr_event()
+    bot.collect_touched_item(issue_number)
+    if label_name == "sign-off: create pr":
+        if is_pr:
+            return False
+        review_data = bot.ensure_review_entry(state, issue_number)
+        reviewer = review_data.get("current_reviewer") if review_data else None
+        return bot.mark_review_complete(state, issue_number, reviewer, "issue_label: sign-off: create pr")
+    if label_name not in bot.REVIEW_LABELS:
+        return False
+    return handle_issue_or_pr_opened(bot, state)
+
+
+def handle_pull_request_target_synchronize(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_pull_request_target_synchronize")
+    if _runtime_epoch(state) != "freshness_v15":
+        print("V18 synchronize repair safe-noop before epoch flip")
+        return False
+    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
+    if not issue_number:
+        return False
+    review_data = bot.ensure_review_entry(state, issue_number)
+    if review_data is None or not review_data.get("current_reviewer"):
+        return False
+    head_sha = os.environ.get("PR_HEAD_SHA", "").strip()
+    if not head_sha:
+        raise RuntimeError("Missing PR_HEAD_SHA for synchronize event")
+    bot.collect_touched_item(issue_number)
+    review_data["active_head_sha"] = head_sha
+    timestamp = os.environ.get("EVENT_CREATED_AT", "") or _now_iso()
+    changed = bot.reviews_module.accept_channel_event(
+        review_data,
+        "contributor_revision",
+        semantic_key=f"pull_request_sync:{issue_number}:{head_sha}",
+        timestamp=timestamp,
+        reviewed_head_sha=head_sha,
+        source_precedence=1,
+    )
+    bot.reviews_module.rebuild_pr_approval_state(bot, issue_number, review_data)
+    return changed
+
+
+def maybe_record_head_observation_repair(bot, issue_number: int, review_data: dict) -> bool:
+    pull_request = bot.github_api("GET", f"pulls/{issue_number}")
+    if not isinstance(pull_request, dict):
+        raise RuntimeError(f"Failed to fetch live PR #{issue_number} for head observation repair")
+    if str(pull_request.get("state", "")).lower() != "open":
+        return False
+    head = pull_request.get("head")
+    head_sha = head.get("sha") if isinstance(head, dict) else None
+    if not isinstance(head_sha, str) or not head_sha.strip():
+        raise RuntimeError(f"Pull request #{issue_number} is missing a usable head SHA")
+    head_sha = head_sha.strip()
+    current_head = review_data.get("active_head_sha")
+    if current_head == head_sha:
+        return False
+    contributor_revision = review_data.get("contributor_revision", {}).get("accepted")
+    if isinstance(contributor_revision, dict) and contributor_revision.get("reviewed_head_sha") == head_sha:
+        review_data["active_head_sha"] = head_sha
+        return False
+    changed = bot.reviews_module.accept_channel_event(
+        review_data,
+        "contributor_revision",
+        semantic_key=f"pull_request_head_observed:{issue_number}:{head_sha}",
+        timestamp=_now_iso(),
+        reviewed_head_sha=head_sha,
+        source_precedence=0,
+    )
+    review_data["active_head_sha"] = head_sha
+    review_data["current_cycle_completion"] = {}
+    review_data["current_cycle_write_approval"] = {}
+    review_data["review_completed_at"] = None
+    review_data["review_completed_by"] = None
+    review_data["review_completion_source"] = None
+    return changed
+
+
+def handle_closed_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_closed_event")
+    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
+    if not issue_number:
+        return False
+    bot.collect_touched_item(issue_number)
+    issue_key = str(issue_number)
+    if isinstance(state.get("active_reviews"), dict) and issue_key in state["active_reviews"]:
+        del state["active_reviews"][issue_key]
+        return True
+    return False


### PR DESCRIPTION
## Summary
- extract the issue and PR lifecycle handler cluster out of events.py into a dedicated lifecycle module
- keep behavior unchanged while reducing the size and coupling of the events module
- route the existing lifecycle entrypoints through the new lifecycle module explicitly

## What Changed
- add scripts/reviewer_bot_lib/lifecycle.py and move the lifecycle-related handlers there:
  - handle_transition_notice
  - handle_issue_or_pr_opened
  - handle_issue_edited_event
  - handle_labeled_event
  - handle_pull_request_target_synchronize
  - maybe_record_head_observation_repair
  - handle_closed_event
- remove those implementations from scripts/reviewer_bot_lib/events.py and import them instead
- update scripts/reviewer_bot.py lifecycle wrappers to call the new lifecycle module directly
- replace direct sys.modules[__name__] pass-throughs in the entrypoint adapter with a small Any-typed runtime helper so the protocol typing remains workable

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Notes
- this is the first extraction slice from events.py and is intended to be structural only
- follow-up slices can target comment routing, deferred reconcile, and sweeper logic separately
