### PR TITLE
Refactor reviewer-bot comment routing

### DIFF
--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -65,6 +65,7 @@ from typing import Any
 try:
     import scripts.reviewer_bot_lib.automation as automation_module
     import scripts.reviewer_bot_lib.commands as commands_module
+    import scripts.reviewer_bot_lib.comment_routing as comment_routing_module
     import scripts.reviewer_bot_lib.events as events_module
     import scripts.reviewer_bot_lib.github_api as github_api_module
     import scripts.reviewer_bot_lib.lease_lock as lease_lock_module
@@ -152,6 +153,7 @@ except ImportError:
     import reviewer_bot_lib.app as app_module
     import reviewer_bot_lib.automation as automation_module
     import reviewer_bot_lib.commands as commands_module
+    import reviewer_bot_lib.comment_routing as comment_routing_module
     import reviewer_bot_lib.events as events_module
     import reviewer_bot_lib.github_api as github_api_module
     import reviewer_bot_lib.lease_lock as lease_lock_module
@@ -844,15 +846,15 @@ def find_triage_approval_after(
 
 
 def classify_comment_payload(comment_body: str) -> dict:
-    return events_module.classify_comment_payload(_runtime_bot(), comment_body)
+    return comment_routing_module.classify_comment_payload(_runtime_bot(), comment_body)
 
 
 def classify_issue_comment_actor() -> str:
-    return events_module.classify_issue_comment_actor()
+    return comment_routing_module.classify_issue_comment_actor()
 
 
 def route_issue_comment_trust(issue_number: int) -> str:
-    return events_module.route_issue_comment_trust(_runtime_bot(), issue_number)
+    return comment_routing_module.route_issue_comment_trust(_runtime_bot(), issue_number)
 
 
 def observer_run_reason_from_details(run_details: dict, runbook_signature: dict | None) -> str:
@@ -1125,7 +1127,7 @@ def handle_closed_event(state: dict) -> bool:
 
 
 def handle_comment_event(state: dict) -> bool:
-    return events_module.handle_comment_event(_runtime_bot(), state)
+    return comment_routing_module.handle_comment_event(_runtime_bot(), state)
 
 
 def handle_manual_dispatch(state: dict) -> bool:

--- a/scripts/reviewer_bot_lib/comment_routing.py
+++ b/scripts/reviewer_bot_lib/comment_routing.py
@@ -1,0 +1,328 @@
+"""Comment payload parsing, trust routing, and direct comment handling."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from datetime import datetime, timezone
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _runtime_epoch(state: dict) -> str:
+    return str(state.get("freshness_runtime_epoch", "")).strip() or "legacy_v14"
+
+
+def _is_pr_event() -> bool:
+    return os.environ.get("IS_PULL_REQUEST", "false").lower() == "true"
+
+
+def _require_v18_for_pr(state: dict, context: str) -> bool:
+    if not _is_pr_event():
+        return True
+    epoch = _runtime_epoch(state)
+    if epoch != "freshness_v15":
+        print(f"V18 PR freshness path safe-noop for {context}; epoch is {epoch}")
+        return False
+    return True
+
+
+def _normalize_comment_body(body: str) -> str:
+    return "\n".join(line.rstrip() for line in body.replace("\r\n", "\n").split("\n")).strip()
+
+
+def _semantic_digest(value: str) -> str:
+    return hashlib.sha256(_normalize_comment_body(value).encode("utf-8")).hexdigest()
+
+
+def _digest_body(body: str) -> str:
+    return hashlib.sha256(_normalize_comment_body(body).encode("utf-8")).hexdigest()
+
+
+def _comment_line_is_command(bot, line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    pattern = rf"^{re.escape(bot.BOT_MENTION)}\s+/[A-Za-z0-9?_-]+(?:\s+.*)?$"
+    return re.match(pattern, stripped) is not None
+
+
+def classify_comment_payload(bot, body: str) -> dict:
+    normalized = _normalize_comment_body(bot.strip_code_blocks(body))
+    if not normalized:
+        return {
+            "comment_class": "empty_or_whitespace",
+            "has_non_command_text": False,
+            "command_count": 0,
+            "command": None,
+            "args": [],
+            "normalized_body": normalized,
+        }
+    lines = [line for line in normalized.splitlines() if line.strip()]
+    command_lines = [line for line in lines if _comment_line_is_command(bot, line)]
+    non_command_lines = [line for line in lines if not _comment_line_is_command(bot, line)]
+    parsed = bot.parse_command(normalized)
+    command = None
+    args: list[str] = []
+    if parsed:
+        command, args = parsed
+    if command_lines and not non_command_lines:
+        comment_class = "command_only"
+    elif command_lines and non_command_lines:
+        comment_class = "command_plus_text"
+    else:
+        comment_class = "plain_text"
+    return {
+        "comment_class": comment_class,
+        "has_non_command_text": bool(non_command_lines),
+        "command_count": len(command_lines),
+        "command": command,
+        "args": args,
+        "normalized_body": normalized,
+    }
+
+
+def classify_issue_comment_actor() -> str:
+    comment_user_type = os.environ.get("COMMENT_USER_TYPE", "").strip()
+    comment_author = os.environ.get("COMMENT_AUTHOR", "").strip()
+    sender_type = os.environ.get("COMMENT_SENDER_TYPE", "").strip()
+    installation_id = os.environ.get("COMMENT_INSTALLATION_ID", "").strip()
+    via_github_app = os.environ.get("COMMENT_PERFORMED_VIA_GITHUB_APP", "").strip().lower()
+    if comment_user_type == "Bot" or comment_author.endswith("[bot]"):
+        return "bot_account"
+    if installation_id or via_github_app == "true" or (sender_type and sender_type not in {"User", "Bot"}):
+        return "github_app_or_other_automation"
+    if comment_user_type == "User" and comment_author and not comment_author.endswith("[bot]") and not installation_id and via_github_app != "true":
+        return "repo_user_principal"
+    return "unknown_actor"
+
+
+def _is_self_comment(bot, author: str) -> bool:
+    return author.strip().lower() == bot.BOT_NAME.lower() or author.strip().lower() == bot.BOT_MENTION.lstrip("@").lower()
+
+
+def _fetch_pr_metadata(bot, issue_number: int) -> dict:
+    pull_request = bot.github_api("GET", f"pulls/{issue_number}")
+    if not isinstance(pull_request, dict):
+        raise RuntimeError(f"Failed to fetch live PR metadata for #{issue_number}")
+    if not isinstance(pull_request.get("head"), dict) or not isinstance(pull_request.get("user"), dict):
+        raise RuntimeError(f"Unusable PR metadata for #{issue_number}")
+    return pull_request
+
+
+def route_issue_comment_trust(bot, issue_number: int) -> str:
+    actor_class = classify_issue_comment_actor()
+    if actor_class in {"bot_account", "github_app_or_other_automation"} or _is_self_comment(bot, os.environ.get("COMMENT_AUTHOR", "")):
+        return "safe_noop"
+    if not _is_pr_event():
+        return "issue_direct"
+    pull_request = _fetch_pr_metadata(bot, issue_number)
+    head_repo = pull_request.get("head", {}).get("repo", {})
+    head_full_name = head_repo.get("full_name") if isinstance(head_repo, dict) else None
+    if not isinstance(head_full_name, str) or not head_full_name:
+        raise RuntimeError("Missing PR head repository metadata for trust routing")
+    is_cross_repo = head_full_name != os.environ.get("GITHUB_REPOSITORY", "")
+    pr_author = pull_request.get("user", {}).get("login")
+    is_dependabot_restricted = pr_author == "dependabot[bot]"
+    author_association = os.environ.get("COMMENT_AUTHOR_ASSOCIATION", "").strip()
+    workflow_file = os.environ.get("CURRENT_WORKFLOW_FILE", "").strip()
+    workflow_ref = os.environ.get("GITHUB_REF", "").strip()
+    direct_match = (
+        not is_cross_repo
+        and not is_dependabot_restricted
+        and actor_class == "repo_user_principal"
+        and author_association in bot.AUTHOR_ASSOCIATION_TRUST_ALLOWLIST
+        and workflow_file == ".github/workflows/reviewer-bot-pr-comment-trusted.yml"
+        and workflow_ref == "refs/heads/main"
+    )
+    if is_cross_repo or is_dependabot_restricted:
+        return "pr_deferred_reconcile"
+    if direct_match:
+        return "pr_trusted_direct"
+    raise RuntimeError("Ambiguous same-repo PR comment trust posture; failing closed")
+
+
+def _record_conversation_freshness(bot, state: dict, issue_number: int, comment_author: str, comment_id: int, created_at: str) -> bool:
+    review_data = bot.ensure_review_entry(state, issue_number, create=True)
+    if review_data is None:
+        return False
+    issue_author = os.environ.get("ISSUE_AUTHOR", "")
+    semantic_key = f"issue_comment:{comment_id}"
+    if issue_author and issue_author.lower() == comment_author.lower():
+        return bot.reviews_module.accept_channel_event(
+            review_data,
+            "contributor_comment",
+            semantic_key=semantic_key,
+            timestamp=created_at,
+            actor=comment_author,
+        )
+    current_reviewer = review_data.get("current_reviewer")
+    if isinstance(current_reviewer, str) and current_reviewer.lower() == comment_author.lower():
+        changed = bot.reviews_module.accept_channel_event(
+            review_data,
+            "reviewer_comment",
+            semantic_key=semantic_key,
+            timestamp=created_at,
+            actor=comment_author,
+        )
+        review_data["last_reviewer_activity"] = created_at
+        review_data["transition_warning_sent"] = None
+        return changed
+    return False
+
+
+def _store_pending_privileged_command(review_data: dict, issue_number: int, source_event_key: str, command_name: str, actor: str, args: list[str]) -> bool:
+    pending = review_data.setdefault("pending_privileged_commands", {})
+    pending[source_event_key] = {
+        "source_event_key": source_event_key,
+        "command_name": command_name,
+        "issue_number": issue_number,
+        "actor": actor,
+        "args": args,
+        "status": "pending",
+        "created_at": _now_iso(),
+    }
+    return True
+
+
+def _validate_accept_no_fls_changes_handoff(bot, issue_number: int, comment_author: str) -> tuple[bool, dict]:
+    if _is_pr_event():
+        return False, {"reason": "pull_request_target_not_allowed"}
+    labels = bot.parse_issue_labels()
+    if bot.FLS_AUDIT_LABEL not in labels:
+        return False, {"reason": "missing_fls_audit_label"}
+    if not bot.check_user_permission(comment_author, "triage"):
+        return False, {"reason": "authorization_failed"}
+    return True, {
+        "command_name": "accept-no-fls-changes",
+        "issue_number": issue_number,
+        "actor": comment_author,
+        "authorization": {"required_permission": "triage", "authorized": True},
+        "target": {"kind": "issue", "number": issue_number, "labels": sorted(labels)},
+    }
+
+
+def _handle_command(bot, state: dict, issue_number: int, comment_author: str, classified: dict) -> bool:
+    command = classified.get("command")
+    args = classified.get("args") or []
+    if not isinstance(command, str):
+        return False
+    actor_class = classify_issue_comment_actor()
+    if actor_class in {"unknown_actor", "bot_account", "github_app_or_other_automation"}:
+        return False
+    review_data = bot.ensure_review_entry(state, issue_number, create=True)
+    if review_data is None:
+        return False
+    source_event_key = f"issue_comment:{os.environ.get('COMMENT_ID', '')}"
+    if command == "accept-no-fls-changes":
+        is_valid, metadata = _validate_accept_no_fls_changes_handoff(bot, issue_number, comment_author)
+        if not is_valid:
+            bot.post_comment(
+                issue_number,
+                "❌ This command is not eligible for privileged handoff from the current trusted live state.",
+            )
+            return False
+        stored = _store_pending_privileged_command(review_data, issue_number, source_event_key, command, comment_author, list(args))
+        if stored:
+            review_data["pending_privileged_commands"][source_event_key].update(metadata)
+            bot.post_comment(
+                issue_number,
+                "✅ Recorded pending privileged command `accept-no-fls-changes` from trusted live validation. Use the isolated privileged workflow to execute it from issue `#314` state.",
+            )
+        return stored
+    if command == "_multiple_commands":
+        bot.post_comment(issue_number, f"⚠️ Multiple bot commands in one comment are ignored. Please post a single command per comment. For a list of commands, use `{bot.BOT_MENTION} /commands`.")
+        return False
+    response = ""
+    success = False
+    state_changed = False
+    if command == "pass":
+        response, success = bot.handle_pass_command(state, issue_number, comment_author, " ".join(args) if args else None)
+        state_changed = success
+    elif command == "away":
+        if args:
+            response, success = bot.handle_pass_until_command(state, issue_number, comment_author, args[0], " ".join(args[1:]) if len(args) > 1 else None)
+            state_changed = success
+        else:
+            response = f"❌ Missing date. Usage: `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]`"
+    elif command == "label":
+        response, success = bot.handle_label_command(issue_number, " ".join(args))
+    elif command == "sync-members":
+        response, success = bot.handle_sync_members_command(state)
+        state_changed = success
+    elif command == "queue":
+        response, success = bot.handle_queue_command(state)
+    elif command == "commands":
+        response, success = bot.handle_commands_command()
+    elif command == "claim":
+        response, success = bot.handle_claim_command(state, issue_number, comment_author)
+        state_changed = success
+    elif command == "release":
+        response, success = bot.handle_release_command(state, issue_number, comment_author, list(args))
+        state_changed = success
+    elif command == "rectify":
+        response, success, state_changed = bot.handle_rectify_command(state, issue_number, comment_author)
+    elif command == "r?-user":
+        response, success = bot.handle_assign_command(state, issue_number, args[0] if args else "")
+        state_changed = success
+    elif command == "assign-from-queue":
+        response, success = bot.handle_assign_from_queue_command(state, issue_number)
+        state_changed = success
+    elif command == "r?":
+        response = f"❌ Missing target. Usage:\n- `{bot.BOT_MENTION} /r? @username` - Assign a specific reviewer\n- `{bot.BOT_MENTION} /r? producers` - Assign next reviewer from queue"
+    elif command == "_malformed_known":
+        attempted = args[0] if args else "command"
+        response = f"⚠️ Did you mean `{bot.BOT_MENTION} /{attempted}`?\n\nCommands require a `/` prefix."
+    elif command == "_malformed_unknown":
+        attempted = args[0] if args else ""
+        response = f"⚠️ Unknown command `{attempted}`. Commands require a `/` prefix.\n\nTry `{bot.BOT_MENTION} /commands` to see available commands."
+    else:
+        response = f"❌ Unknown command: `/{command}`\n\nAvailable commands:\n{bot.get_commands_help()}"
+    comment_id = int(os.environ.get("COMMENT_ID", "0") or 0)
+    if comment_id > 0 and command != "_multiple_commands":
+        bot.add_reaction(comment_id, "eyes")
+        if success:
+            bot.add_reaction(comment_id, "+1")
+    if response:
+        bot.post_comment(issue_number, response)
+    return state_changed
+
+
+def _process_comment_event(bot, state: dict, issue_number: int) -> bool:
+    comment_body = os.environ.get("COMMENT_BODY", "")
+    comment_author = os.environ.get("COMMENT_AUTHOR", "")
+    comment_id = int(os.environ.get("COMMENT_ID", "0") or 0)
+    comment_created_at = os.environ.get("COMMENT_CREATED_AT", "") or _now_iso()
+    classified = classify_comment_payload(bot, comment_body)
+    comment_class = classified["comment_class"]
+    state_changed = False
+    if comment_class in {"plain_text", "command_plus_text"} and comment_id > 0:
+        state_changed = _record_conversation_freshness(bot, state, issue_number, comment_author, comment_id, comment_created_at) or state_changed
+    if comment_class in {"command_only", "command_plus_text"} and int(classified.get("command_count", 0)) == 1:
+        state_changed = _handle_command(bot, state, issue_number, comment_author, classified) or state_changed
+    return state_changed
+
+
+def handle_comment_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_comment_event")
+    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
+    if not issue_number:
+        return False
+    bot.collect_touched_item(issue_number)
+    route = route_issue_comment_trust(bot, issue_number)
+    if route == "safe_noop":
+        return False
+    if route == "issue_direct":
+        return _process_comment_event(bot, state, issue_number)
+    if route == "pr_trusted_direct":
+        if not _require_v18_for_pr(state, "pr_trusted_direct_comment"):
+            return False
+        return _process_comment_event(bot, state, issue_number)
+    raise RuntimeError("Deferred PR comment events must not mutate directly in trusted workflows")

--- a/scripts/reviewer_bot_lib/events.py
+++ b/scripts/reviewer_bot_lib/events.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import hashlib
 import io
 import json
 import os
-import re
 import zipfile
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -14,6 +12,12 @@ from urllib.parse import quote
 
 import yaml
 
+from .comment_routing import (
+    _digest_body,
+    _handle_command,
+    _record_conversation_freshness,
+    classify_comment_payload,
+)
 from .lifecycle import (
     maybe_record_head_observation_repair,
 )
@@ -54,75 +58,6 @@ def _require_legacy_for_legacy_pr(state: dict, context: str) -> bool:
         return False
     return True
 
-
-def _normalize_comment_body(body: str) -> str:
-    return "\n".join(line.rstrip() for line in body.replace("\r\n", "\n").split("\n")).strip()
-
-
-def _semantic_digest(value: str) -> str:
-    return hashlib.sha256(_normalize_comment_body(value).encode("utf-8")).hexdigest()
-
-
-def _digest_body(body: str) -> str:
-    return hashlib.sha256(_normalize_comment_body(body).encode("utf-8")).hexdigest()
-
-
-def _comment_line_is_command(bot, line: str) -> bool:
-    stripped = line.strip()
-    if not stripped:
-        return False
-    pattern = rf"^{re.escape(bot.BOT_MENTION)}\s+/[A-Za-z0-9?_-]+(?:\s+.*)?$"
-    return re.match(pattern, stripped) is not None
-
-
-def classify_comment_payload(bot, body: str) -> dict:
-    normalized = _normalize_comment_body(bot.strip_code_blocks(body))
-    if not normalized:
-        return {
-            "comment_class": "empty_or_whitespace",
-            "has_non_command_text": False,
-            "command_count": 0,
-            "command": None,
-            "args": [],
-            "normalized_body": normalized,
-        }
-    lines = [line for line in normalized.splitlines() if line.strip()]
-    command_lines = [line for line in lines if _comment_line_is_command(bot, line)]
-    non_command_lines = [line for line in lines if not _comment_line_is_command(bot, line)]
-    parsed = bot.parse_command(normalized)
-    command = None
-    args: list[str] = []
-    if parsed:
-        command, args = parsed
-    if command_lines and not non_command_lines:
-        comment_class = "command_only"
-    elif command_lines and non_command_lines:
-        comment_class = "command_plus_text"
-    else:
-        comment_class = "plain_text"
-    return {
-        "comment_class": comment_class,
-        "has_non_command_text": bool(non_command_lines),
-        "command_count": len(command_lines),
-        "command": command,
-        "args": args,
-        "normalized_body": normalized,
-    }
-
-
-def classify_issue_comment_actor() -> str:
-    comment_user_type = os.environ.get("COMMENT_USER_TYPE", "").strip()
-    comment_author = os.environ.get("COMMENT_AUTHOR", "").strip()
-    sender_type = os.environ.get("COMMENT_SENDER_TYPE", "").strip()
-    installation_id = os.environ.get("COMMENT_INSTALLATION_ID", "").strip()
-    via_github_app = os.environ.get("COMMENT_PERFORMED_VIA_GITHUB_APP", "").strip().lower()
-    if comment_user_type == "Bot" or comment_author.endswith("[bot]"):
-        return "bot_account"
-    if installation_id or via_github_app == "true" or (sender_type and sender_type not in {"User", "Bot"}):
-        return "github_app_or_other_automation"
-    if comment_user_type == "User" and comment_author and not comment_author.endswith("[bot]") and not installation_id and via_github_app != "true":
-        return "repo_user_principal"
-    return "unknown_actor"
 
 
 def get_latest_review_by_reviewer(bot, reviews: list[dict], reviewer: str) -> dict | None:
@@ -276,230 +211,6 @@ def reconcile_active_review_entry(
     return f"ℹ️ Rectify checked PR #{issue_number}: {'; '.join(messages) or 'no reconciliation transitions applied'}.", True, False
 
 
-
-
-def _is_self_comment(bot, author: str) -> bool:
-    return author.strip().lower() == bot.BOT_NAME.lower() or author.strip().lower() == bot.BOT_MENTION.lstrip("@").lower()
-
-
-def _fetch_pr_metadata(bot, issue_number: int) -> dict:
-    pull_request = bot.github_api("GET", f"pulls/{issue_number}")
-    if not isinstance(pull_request, dict):
-        raise RuntimeError(f"Failed to fetch live PR metadata for #{issue_number}")
-    if not isinstance(pull_request.get("head"), dict) or not isinstance(pull_request.get("user"), dict):
-        raise RuntimeError(f"Unusable PR metadata for #{issue_number}")
-    return pull_request
-
-
-def route_issue_comment_trust(bot, issue_number: int) -> str:
-    actor_class = classify_issue_comment_actor()
-    if actor_class in {"bot_account", "github_app_or_other_automation"} or _is_self_comment(bot, os.environ.get("COMMENT_AUTHOR", "")):
-        return "safe_noop"
-    if not _is_pr_event():
-        return "issue_direct"
-    pull_request = _fetch_pr_metadata(bot, issue_number)
-    head_repo = pull_request.get("head", {}).get("repo", {})
-    head_full_name = head_repo.get("full_name") if isinstance(head_repo, dict) else None
-    if not isinstance(head_full_name, str) or not head_full_name:
-        raise RuntimeError("Missing PR head repository metadata for trust routing")
-    is_cross_repo = head_full_name != os.environ.get("GITHUB_REPOSITORY", "")
-    pr_author = pull_request.get("user", {}).get("login")
-    is_dependabot_restricted = pr_author == "dependabot[bot]"
-    author_association = os.environ.get("COMMENT_AUTHOR_ASSOCIATION", "").strip()
-    workflow_file = os.environ.get("CURRENT_WORKFLOW_FILE", "").strip()
-    workflow_ref = os.environ.get("GITHUB_REF", "").strip()
-    direct_match = (
-        not is_cross_repo
-        and not is_dependabot_restricted
-        and actor_class == "repo_user_principal"
-        and author_association in bot.AUTHOR_ASSOCIATION_TRUST_ALLOWLIST
-        and workflow_file == ".github/workflows/reviewer-bot-pr-comment-trusted.yml"
-        and workflow_ref == "refs/heads/main"
-    )
-    if is_cross_repo or is_dependabot_restricted:
-        return "pr_deferred_reconcile"
-    if direct_match:
-        return "pr_trusted_direct"
-    raise RuntimeError("Ambiguous same-repo PR comment trust posture; failing closed")
-
-
-def _record_conversation_freshness(bot, state: dict, issue_number: int, comment_author: str, comment_id: int, created_at: str) -> bool:
-    review_data = bot.ensure_review_entry(state, issue_number, create=True)
-    if review_data is None:
-        return False
-    issue_author = os.environ.get("ISSUE_AUTHOR", "")
-    semantic_key = f"issue_comment:{comment_id}"
-    if issue_author and issue_author.lower() == comment_author.lower():
-        return bot.reviews_module.accept_channel_event(
-            review_data,
-            "contributor_comment",
-            semantic_key=semantic_key,
-            timestamp=created_at,
-            actor=comment_author,
-        )
-    current_reviewer = review_data.get("current_reviewer")
-    if isinstance(current_reviewer, str) and current_reviewer.lower() == comment_author.lower():
-        changed = bot.reviews_module.accept_channel_event(
-            review_data,
-            "reviewer_comment",
-            semantic_key=semantic_key,
-            timestamp=created_at,
-            actor=comment_author,
-        )
-        review_data["last_reviewer_activity"] = created_at
-        review_data["transition_warning_sent"] = None
-        return changed
-    return False
-
-
-def _store_pending_privileged_command(review_data: dict, issue_number: int, source_event_key: str, command_name: str, actor: str, args: list[str]) -> bool:
-    pending = review_data.setdefault("pending_privileged_commands", {})
-    pending[source_event_key] = {
-        "source_event_key": source_event_key,
-        "command_name": command_name,
-        "issue_number": issue_number,
-        "actor": actor,
-        "args": args,
-        "status": "pending",
-        "created_at": _now_iso(),
-    }
-    return True
-
-
-def _validate_accept_no_fls_changes_handoff(bot, issue_number: int, comment_author: str) -> tuple[bool, dict]:
-    if _is_pr_event():
-        return False, {"reason": "pull_request_target_not_allowed"}
-    labels = bot.parse_issue_labels()
-    if bot.FLS_AUDIT_LABEL not in labels:
-        return False, {"reason": "missing_fls_audit_label"}
-    if not bot.check_user_permission(comment_author, "triage"):
-        return False, {"reason": "authorization_failed"}
-    return True, {
-        "command_name": "accept-no-fls-changes",
-        "issue_number": issue_number,
-        "actor": comment_author,
-        "authorization": {"required_permission": "triage", "authorized": True},
-        "target": {"kind": "issue", "number": issue_number, "labels": sorted(labels)},
-    }
-
-
-def _handle_command(bot, state: dict, issue_number: int, comment_author: str, classified: dict) -> bool:
-    command = classified.get("command")
-    args = classified.get("args") or []
-    if not isinstance(command, str):
-        return False
-    actor_class = classify_issue_comment_actor()
-    if actor_class in {"unknown_actor", "bot_account", "github_app_or_other_automation"}:
-        return False
-    review_data = bot.ensure_review_entry(state, issue_number, create=True)
-    if review_data is None:
-        return False
-    source_event_key = f"issue_comment:{os.environ.get('COMMENT_ID', '')}"
-    if command == "accept-no-fls-changes":
-        is_valid, metadata = _validate_accept_no_fls_changes_handoff(bot, issue_number, comment_author)
-        if not is_valid:
-            bot.post_comment(
-                issue_number,
-                "❌ This command is not eligible for privileged handoff from the current trusted live state.",
-            )
-            return False
-        stored = _store_pending_privileged_command(review_data, issue_number, source_event_key, command, comment_author, list(args))
-        if stored:
-            review_data["pending_privileged_commands"][source_event_key].update(metadata)
-            bot.post_comment(
-                issue_number,
-                "✅ Recorded pending privileged command `accept-no-fls-changes` from trusted live validation. Use the isolated privileged workflow to execute it from issue `#314` state.",
-            )
-        return stored
-    if command == "_multiple_commands":
-        bot.post_comment(issue_number, f"⚠️ Multiple bot commands in one comment are ignored. Please post a single command per comment. For a list of commands, use `{bot.BOT_MENTION} /commands`.")
-        return False
-    response = ""
-    success = False
-    state_changed = False
-    if command == "pass":
-        response, success = bot.handle_pass_command(state, issue_number, comment_author, " ".join(args) if args else None)
-        state_changed = success
-    elif command == "away":
-        if args:
-            response, success = bot.handle_pass_until_command(state, issue_number, comment_author, args[0], " ".join(args[1:]) if len(args) > 1 else None)
-            state_changed = success
-        else:
-            response = f"❌ Missing date. Usage: `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]`"
-    elif command == "label":
-        response, success = bot.handle_label_command(issue_number, " ".join(args))
-    elif command == "sync-members":
-        response, success = bot.handle_sync_members_command(state)
-        state_changed = success
-    elif command == "queue":
-        response, success = bot.handle_queue_command(state)
-    elif command == "commands":
-        response, success = bot.handle_commands_command()
-    elif command == "claim":
-        response, success = bot.handle_claim_command(state, issue_number, comment_author)
-        state_changed = success
-    elif command == "release":
-        response, success = bot.handle_release_command(state, issue_number, comment_author, list(args))
-        state_changed = success
-    elif command == "rectify":
-        response, success, state_changed = bot.handle_rectify_command(state, issue_number, comment_author)
-    elif command == "r?-user":
-        response, success = bot.handle_assign_command(state, issue_number, args[0] if args else "")
-        state_changed = success
-    elif command == "assign-from-queue":
-        response, success = bot.handle_assign_from_queue_command(state, issue_number)
-        state_changed = success
-    elif command == "r?":
-        response = f"❌ Missing target. Usage:\n- `{bot.BOT_MENTION} /r? @username` - Assign a specific reviewer\n- `{bot.BOT_MENTION} /r? producers` - Assign next reviewer from queue"
-    elif command == "_malformed_known":
-        attempted = args[0] if args else "command"
-        response = f"⚠️ Did you mean `{bot.BOT_MENTION} /{attempted}`?\n\nCommands require a `/` prefix."
-    elif command == "_malformed_unknown":
-        attempted = args[0] if args else ""
-        response = f"⚠️ Unknown command `{attempted}`. Commands require a `/` prefix.\n\nTry `{bot.BOT_MENTION} /commands` to see available commands."
-    else:
-        response = f"❌ Unknown command: `/{command}`\n\nAvailable commands:\n{bot.get_commands_help()}"
-    comment_id = int(os.environ.get("COMMENT_ID", "0") or 0)
-    if comment_id > 0 and command != "_multiple_commands":
-        bot.add_reaction(comment_id, "eyes")
-        if success:
-            bot.add_reaction(comment_id, "+1")
-    if response:
-        bot.post_comment(issue_number, response)
-    return state_changed
-
-
-def _process_comment_event(bot, state: dict, issue_number: int) -> bool:
-    comment_body = os.environ.get("COMMENT_BODY", "")
-    comment_author = os.environ.get("COMMENT_AUTHOR", "")
-    comment_id = int(os.environ.get("COMMENT_ID", "0") or 0)
-    comment_created_at = os.environ.get("COMMENT_CREATED_AT", "") or _now_iso()
-    classified = classify_comment_payload(bot, comment_body)
-    comment_class = classified["comment_class"]
-    state_changed = False
-    if comment_class in {"plain_text", "command_plus_text"} and comment_id > 0:
-        state_changed = _record_conversation_freshness(bot, state, issue_number, comment_author, comment_id, comment_created_at) or state_changed
-    if comment_class in {"command_only", "command_plus_text"} and int(classified.get("command_count", 0)) == 1:
-        state_changed = _handle_command(bot, state, issue_number, comment_author, classified) or state_changed
-    return state_changed
-
-
-def handle_comment_event(bot, state: dict) -> bool:
-    bot.assert_lock_held("handle_comment_event")
-    issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
-    if not issue_number:
-        return False
-    bot.collect_touched_item(issue_number)
-    route = route_issue_comment_trust(bot, issue_number)
-    if route == "safe_noop":
-        return False
-    if route == "issue_direct":
-        return _process_comment_event(bot, state, issue_number)
-    if route == "pr_trusted_direct":
-        if not _require_v18_for_pr(state, "pr_trusted_direct_comment"):
-            return False
-        return _process_comment_event(bot, state, issue_number)
-    raise RuntimeError("Deferred PR comment events must not mutate directly in trusted workflows")
 
 
 def handle_pull_request_review_event(bot, state: dict) -> bool:


### PR DESCRIPTION
## Summary
- extract the comment parsing, actor classification, trust routing, and direct comment handling cluster out of events.py
- keep behavior unchanged while reducing the size and coupling of the events module
- route the existing comment-related entrypoints through the new module explicitly

## What Changed
- add scripts/reviewer_bot_lib/comment_routing.py and move the comment/trust-routing cluster there:
  - comment payload parsing helpers
  - actor classification
  - issue comment trust routing
  - direct comment freshness updates
  - direct command routing and privileged handoff setup
  - handle_comment_event
- remove those implementations from scripts/reviewer_bot_lib/events.py and import the needed helpers instead
- update scripts/reviewer_bot.py wrappers to call the new comment routing module directly

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Notes
- this is a structural extraction only; deferred reconcile and sweeper logic remain in events.py for later slices
- follow-up slices can target trusted workflow_run reconcile and sweeper/run/artifact correlation separately
