### PR TITLE
Refactor reviewer-bot reconcile handlers

### DIFF
--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -70,6 +70,7 @@ try:
     import scripts.reviewer_bot_lib.github_api as github_api_module
     import scripts.reviewer_bot_lib.lease_lock as lease_lock_module
     import scripts.reviewer_bot_lib.lifecycle as lifecycle_module
+    import scripts.reviewer_bot_lib.reconcile as reconcile_module
     import scripts.reviewer_bot_lib.reviews as reviews_module
     import scripts.reviewer_bot_lib.state_store as state_store_module
     from scripts.reviewer_bot_lib import app as app_module
@@ -158,6 +159,7 @@ except ImportError:
     import reviewer_bot_lib.github_api as github_api_module
     import reviewer_bot_lib.lease_lock as lease_lock_module
     import reviewer_bot_lib.lifecycle as lifecycle_module
+    import reviewer_bot_lib.reconcile as reconcile_module
     import reviewer_bot_lib.reviews as reviews_module
     import reviewer_bot_lib.state_store as state_store_module
     from reviewer_bot_lib.config import (  # noqa: F401
@@ -849,12 +851,39 @@ def classify_comment_payload(comment_body: str) -> dict:
     return comment_routing_module.classify_comment_payload(_runtime_bot(), comment_body)
 
 
+def _digest_body(body: str) -> str:
+    return comment_routing_module._digest_body(body)
+
+
 def classify_issue_comment_actor() -> str:
     return comment_routing_module.classify_issue_comment_actor()
 
 
 def route_issue_comment_trust(issue_number: int) -> str:
     return comment_routing_module.route_issue_comment_trust(_runtime_bot(), issue_number)
+
+
+def _record_conversation_freshness(
+    state: dict,
+    issue_number: int,
+    comment_author: str,
+    comment_id: int,
+    created_at: str,
+) -> bool:
+    return comment_routing_module._record_conversation_freshness(
+        _runtime_bot(), state, issue_number, comment_author, comment_id, created_at
+    )
+
+
+def _handle_comment_command(
+    state: dict,
+    issue_number: int,
+    comment_author: str,
+    classified: dict,
+) -> bool:
+    return comment_routing_module._handle_command(
+        _runtime_bot(), state, issue_number, comment_author, classified
+    )
 
 
 def observer_run_reason_from_details(run_details: dict, runbook_signature: dict | None) -> str:
@@ -921,7 +950,7 @@ def reconcile_active_review_entry(
     require_pull_request_context: bool = True,
     completion_source: str = "rectify:reconcile-pr-review",
 ) -> tuple[str, bool, bool]:
-    return events_module.reconcile_active_review_entry(
+    return reconcile_module.reconcile_active_review_entry(
         _runtime_bot(),
         state,
         issue_number,
@@ -1114,12 +1143,16 @@ def handle_pull_request_target_synchronize(state: dict) -> bool:
     return lifecycle_module.handle_pull_request_target_synchronize(_runtime_bot(), state)
 
 
+def maybe_record_head_observation_repair(issue_number: int, review_data: dict) -> bool:
+    return lifecycle_module.maybe_record_head_observation_repair(_runtime_bot(), issue_number, review_data)
+
+
 def handle_pull_request_review_event(state: dict) -> bool:
     return events_module.handle_pull_request_review_event(_runtime_bot(), state)
 
 
 def handle_workflow_run_event(state: dict) -> bool:
-    return events_module.handle_workflow_run_event(_runtime_bot(), state)
+    return reconcile_module.handle_workflow_run_event(_runtime_bot(), state)
 
 
 def handle_closed_event(state: dict) -> bool:

--- a/scripts/reviewer_bot_lib/events.py
+++ b/scripts/reviewer_bot_lib/events.py
@@ -12,14 +12,14 @@ from urllib.parse import quote
 
 import yaml
 
-from .comment_routing import (
-    _digest_body,
-    _handle_command,
-    _record_conversation_freshness,
-    classify_comment_payload,
-)
 from .lifecycle import (
     maybe_record_head_observation_repair,
+)
+from .reconcile import (
+    _artifact_expected_name,
+    _artifact_expected_payload_name,
+    _update_deferred_gap,
+    _was_reconciled_source_event,
 )
 
 
@@ -104,115 +104,6 @@ def find_triage_approval_after(bot, reviews: list[dict], since: datetime | None)
     return None
 
 
-def _ensure_source_event_key(review_data: dict, source_event_key: str, payload: dict | None = None) -> None:
-    review_data.setdefault("deferred_gaps", {})
-    if payload is None:
-        payload = {}
-    payload["source_event_key"] = source_event_key
-    review_data["deferred_gaps"][source_event_key] = payload
-
-
-def _clear_source_event_key(review_data: dict, source_event_key: str) -> None:
-    deferred_gaps = review_data.get("deferred_gaps")
-    if isinstance(deferred_gaps, dict):
-        deferred_gaps.pop(source_event_key, None)
-
-
-def _mark_reconciled_source_event(review_data: dict, source_event_key: str) -> None:
-    reconciled = review_data.setdefault("reconciled_source_events", [])
-    if source_event_key not in reconciled:
-        reconciled.append(source_event_key)
-
-
-def _was_reconciled_source_event(review_data: dict, source_event_key: str) -> bool:
-    reconciled = review_data.get("reconciled_source_events")
-    return isinstance(reconciled, list) and source_event_key in reconciled
-
-
-def _record_review_rebuild(bot, state: dict, issue_number: int, review_data: dict) -> bool:
-    pull_request = bot.github_api("GET", f"pulls/{issue_number}")
-    if not isinstance(pull_request, dict):
-        raise RuntimeError(f"Failed to fetch pull request #{issue_number}")
-    reviews = bot.get_pull_request_reviews(issue_number)
-    if reviews is None:
-        raise RuntimeError(f"Failed to fetch live reviews for PR #{issue_number}")
-    completion, _ = bot.reviews_module.rebuild_pr_approval_state(bot, issue_number, review_data, pull_request=pull_request, reviews=reviews)
-    if completion is None:
-        raise RuntimeError(f"Unable to rebuild approval state for PR #{issue_number}")
-    latest = bot.get_latest_review_by_reviewer(reviews, str(review_data.get("current_reviewer", "")))
-    if latest is not None:
-        commit_id = latest.get("commit_id")
-        submitted_at = latest.get("submitted_at")
-        if isinstance(commit_id, str) and isinstance(submitted_at, str):
-            bot.reviews_module.accept_channel_event(
-                review_data,
-                "reviewer_review",
-                semantic_key=f"pull_request_review:{latest.get('id')}",
-                timestamp=submitted_at,
-                actor=review_data.get("current_reviewer"),
-                reviewed_head_sha=commit_id,
-                source_precedence=1,
-            )
-    return bool(completion.get("completed"))
-
-
-def reconcile_active_review_entry(
-    bot,
-    state: dict,
-    issue_number: int,
-    *,
-    require_pull_request_context: bool = True,
-    completion_source: str = "rectify:reconcile-pr-review",
-) -> tuple[str, bool, bool]:
-    review_data = bot.ensure_review_entry(state, issue_number)
-    if review_data is None:
-        return f"ℹ️ No active review entry exists for #{issue_number}; nothing to rectify.", True, False
-    assigned_reviewer = review_data.get("current_reviewer")
-    if not assigned_reviewer:
-        return f"ℹ️ #{issue_number} has no tracked assigned reviewer; nothing to rectify.", True, False
-    if require_pull_request_context and not _is_pr_event():
-        return f"ℹ️ #{issue_number} is not a pull request in this event context; `/rectify` only reconciles PR reviews.", True, False
-    if not _require_v18_for_pr(state, "rectify"):
-        return "ℹ️ PR review freshness rectify is epoch-gated and currently inactive.", True, False
-    state_changed = maybe_record_head_observation_repair(bot, issue_number, review_data)
-    reviews = bot.get_pull_request_reviews(issue_number)
-    if reviews is None:
-        return f"❌ Failed to fetch reviews for PR #{issue_number}; cannot run `/rectify`.", False, False
-    latest_review = bot.get_latest_review_by_reviewer(reviews, assigned_reviewer)
-    messages: list[str] = []
-    if latest_review is not None:
-        latest_state = str(latest_review.get("state", "")).upper()
-        commit_id = latest_review.get("commit_id")
-        submitted_at = latest_review.get("submitted_at")
-        if latest_state in {"APPROVED", "COMMENTED", "CHANGES_REQUESTED"} and isinstance(commit_id, str) and isinstance(submitted_at, str):
-            state_changed = bot.reviews_module.accept_channel_event(
-                review_data,
-                "reviewer_review",
-                semantic_key=f"pull_request_review:{latest_review.get('id')}",
-                timestamp=submitted_at,
-                actor=assigned_reviewer,
-                reviewed_head_sha=commit_id,
-                source_precedence=1,
-            ) or state_changed
-            messages.append(f"latest review by @{assigned_reviewer} is `{latest_state}`")
-    if _record_review_rebuild(bot, state, issue_number, review_data):
-        state_changed = True
-        review_data["review_completion_source"] = completion_source
-    if review_data.get("mandatory_approver_required"):
-        escalation_opened_at = bot.parse_iso8601_timestamp(review_data.get("mandatory_approver_pinged_at")) or bot.parse_iso8601_timestamp(review_data.get("mandatory_approver_label_applied_at"))
-        triage_approval = find_triage_approval_after(bot, reviews, escalation_opened_at)
-        if triage_approval is not None:
-            approver, _ = triage_approval
-            if bot.satisfy_mandatory_approver_requirement(state, issue_number, approver):
-                state_changed = True
-                messages.append(f"mandatory triage approval satisfied by @{approver}")
-    if state_changed:
-        return f"✅ Rectified PR #{issue_number}: {'; '.join(messages) or 'reconciled live review state'}.", True, True
-    return f"ℹ️ Rectify checked PR #{issue_number}: {'; '.join(messages) or 'no reconciliation transitions applied'}.", True, False
-
-
-
-
 def handle_pull_request_review_event(bot, state: dict) -> bool:
     issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
     if not issue_number:
@@ -226,135 +117,6 @@ def handle_pull_request_review_event(bot, state: dict) -> bool:
         return False
     print(f"Deferring pull_request_review {review_action} for #{issue_number}")
     return False
-
-
-def _validate_deferred_comment_artifact(payload: dict) -> None:
-    required = {
-        "schema_version",
-        "source_workflow_name",
-        "source_workflow_file",
-        "source_run_id",
-        "source_run_attempt",
-        "source_event_name",
-        "source_event_action",
-        "source_event_key",
-        "pr_number",
-        "comment_id",
-        "comment_class",
-        "has_non_command_text",
-        "source_body_digest",
-        "source_created_at",
-    }
-    missing = sorted(required - set(payload))
-    if missing:
-        raise RuntimeError("Deferred comment artifact missing required fields: " + ", ".join(missing))
-    if payload.get("schema_version") != 2:
-        raise RuntimeError("Deferred comment artifact schema_version is not accepted by V18 reconcile")
-    if not isinstance(payload.get("comment_id"), int) or not isinstance(payload.get("pr_number"), int):
-        raise RuntimeError("Deferred comment artifact comment_id and pr_number must be integers")
-    if not isinstance(payload.get("comment_class"), str) or not isinstance(payload.get("has_non_command_text"), bool):
-        raise RuntimeError("Deferred comment artifact parse fields are malformed")
-    if not isinstance(payload.get("source_body_digest"), str) or not isinstance(payload.get("source_created_at"), str):
-        raise RuntimeError("Deferred comment artifact source digest or timestamp is malformed")
-
-
-def _validate_deferred_review_artifact(payload: dict) -> None:
-    required = {
-        "schema_version",
-        "source_workflow_name",
-        "source_workflow_file",
-        "source_run_id",
-        "source_run_attempt",
-        "source_event_name",
-        "source_event_action",
-        "source_event_key",
-        "pr_number",
-        "review_id",
-    }
-    missing = sorted(required - set(payload))
-    if missing:
-        raise RuntimeError("Deferred review artifact missing required fields: " + ", ".join(missing))
-    if payload.get("schema_version") != 2:
-        raise RuntimeError("Deferred review artifact schema_version is not accepted by V18 reconcile")
-    if not isinstance(payload.get("review_id"), int) or not isinstance(payload.get("pr_number"), int):
-        raise RuntimeError("Deferred review artifact review_id and pr_number must be integers")
-
-
-def _load_deferred_context() -> dict:
-    path = os.environ.get("DEFERRED_CONTEXT_PATH", "").strip()
-    if not path:
-        raise RuntimeError("Missing DEFERRED_CONTEXT_PATH for workflow_run reconcile")
-    with open(path, encoding="utf-8") as handle:
-        payload = json.load(handle)
-    if not isinstance(payload, dict):
-        raise RuntimeError("Deferred context payload must be a JSON object")
-    return payload
-
-
-def _expected_observer_identity(payload: dict) -> tuple[str, str]:
-    event_name = payload.get("source_event_name")
-    event_action = payload.get("source_event_action")
-    if event_name == "issue_comment" and event_action == "created":
-        return (
-            "Reviewer Bot PR Comment Observer",
-            ".github/workflows/reviewer-bot-pr-comment-observer.yml",
-        )
-    if event_name == "pull_request_review" and event_action == "submitted":
-        return (
-            "Reviewer Bot PR Review Submitted Observer",
-            ".github/workflows/reviewer-bot-pr-review-submitted-observer.yml",
-        )
-    if event_name == "pull_request_review" and event_action == "dismissed":
-        return (
-            "Reviewer Bot PR Review Dismissed Observer",
-            ".github/workflows/reviewer-bot-pr-review-dismissed-observer.yml",
-        )
-    raise RuntimeError("Unsupported deferred workflow identity")
-
-
-def _validate_workflow_run_artifact_identity(payload: dict) -> None:
-    expected_name, expected_file = _expected_observer_identity(payload)
-    if payload.get("source_workflow_name") != expected_name:
-        raise RuntimeError("Deferred artifact workflow name mismatch")
-    if payload.get("source_workflow_file") != expected_file:
-        raise RuntimeError("Deferred artifact workflow file mismatch")
-    triggering_name = os.environ.get("WORKFLOW_RUN_TRIGGERING_NAME", "").strip()
-    if triggering_name and triggering_name != expected_name:
-        raise RuntimeError("Triggering workflow name mismatch")
-    triggering_id = os.environ.get("WORKFLOW_RUN_TRIGGERING_ID", "").strip()
-    if triggering_id and str(payload.get("source_run_id")) != triggering_id:
-        raise RuntimeError("Deferred artifact run_id mismatch")
-    triggering_attempt = os.environ.get("WORKFLOW_RUN_TRIGGERING_ATTEMPT", "").strip()
-    if triggering_attempt and str(payload.get("source_run_attempt")) != triggering_attempt:
-        raise RuntimeError("Deferred artifact run_attempt mismatch")
-    if os.environ.get("WORKFLOW_RUN_TRIGGERING_CONCLUSION", "").strip() != "success":
-        raise RuntimeError("Triggering observer workflow did not conclude successfully")
-
-
-def _artifact_expected_name(payload: dict) -> str:
-    event_name = payload.get("source_event_name")
-    event_action = payload.get("source_event_action")
-    run_id = payload.get("source_run_id")
-    run_attempt = payload.get("source_run_attempt")
-    if event_name == "issue_comment" and event_action == "created":
-        return f"reviewer-bot-comment-context-{run_id}-attempt-{run_attempt}"
-    if event_name == "pull_request_review" and event_action == "submitted":
-        return f"reviewer-bot-review-submitted-context-{run_id}-attempt-{run_attempt}"
-    if event_name == "pull_request_review" and event_action == "dismissed":
-        return f"reviewer-bot-review-dismissed-context-{run_id}-attempt-{run_attempt}"
-    raise RuntimeError("Unsupported deferred artifact naming")
-
-
-def _artifact_expected_payload_name(payload: dict) -> str:
-    event_name = payload.get("source_event_name")
-    event_action = payload.get("source_event_action")
-    if event_name == "issue_comment" and event_action == "created":
-        return "deferred-comment.json"
-    if event_name == "pull_request_review" and event_action == "submitted":
-        return "deferred-review-submitted.json"
-    if event_name == "pull_request_review" and event_action == "dismissed":
-        return "deferred-review-dismissed.json"
-    raise RuntimeError("Unsupported deferred payload path")
 
 
 def correlate_candidate_observer_runs(
@@ -662,34 +424,6 @@ def evaluate_deferred_gap_state(
     return "artifact_invalid", str(artifact_correlation.get("reason") or "artifact_invalid")
 
 
-def _update_deferred_gap(review_data: dict, payload: dict, reason: str, diagnostic_summary: str) -> None:
-    source_event_key = str(payload.get("source_event_key", ""))
-    if not source_event_key:
-        return
-    review_data.setdefault("deferred_gaps", {})
-    existing = review_data["deferred_gaps"].get(source_event_key, {})
-    if not isinstance(existing, dict):
-        existing = {}
-    existing.update(
-        {
-            "source_event_key": source_event_key,
-            "source_event_kind": f"{payload.get('source_event_name')}:{payload.get('source_event_action')}",
-            "pr_number": payload.get("pr_number"),
-            "reason": reason,
-            "source_event_created_at": payload.get("source_created_at") or payload.get("source_submitted_at"),
-            "source_run_id": payload.get("source_run_id"),
-            "source_run_attempt": payload.get("source_run_attempt"),
-            "source_workflow_file": payload.get("source_workflow_file"),
-            "source_artifact_name": payload.get("source_artifact_name"),
-            "first_noted_at": existing.get("first_noted_at") or _now_iso(),
-            "last_checked_at": _now_iso(),
-            "operator_action_required": True,
-            "diagnostic_summary": diagnostic_summary,
-        }
-    )
-    review_data["deferred_gaps"][source_event_key] = existing
-
-
 def observer_run_reason_from_details(run_details: dict, runbook_signature: dict | None) -> str:
     status = str(run_details.get("status", "")).strip()
     conclusion = run_details.get("conclusion")
@@ -736,128 +470,6 @@ def parse_timestamp(value: Any) -> datetime | None:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
-
-
-def handle_workflow_run_event(bot, state: dict) -> bool:
-    bot.assert_lock_held("handle_workflow_run_event")
-    if _runtime_epoch(state) != "freshness_v15":
-        print("V18 workflow_run reconcile safe-noop before epoch flip")
-        return False
-    payload = _load_deferred_context()
-    pr_number = int(payload.get("pr_number", 0) or 0)
-    if pr_number <= 0:
-        raise RuntimeError("Deferred context is missing a valid PR number")
-    bot.collect_touched_item(pr_number)
-    review_data = bot.ensure_review_entry(state, pr_number, create=True)
-    if review_data is None:
-        raise RuntimeError(f"No review entry available for PR #{pr_number}")
-    event_name = payload.get("source_event_name")
-    event_action = payload.get("source_event_action")
-    source_event_key = str(payload.get("source_event_key", ""))
-    try:
-        if event_name == "issue_comment":
-            _validate_deferred_comment_artifact(payload)
-            _validate_workflow_run_artifact_identity(payload)
-            if source_event_key != f"issue_comment:{payload['comment_id']}":
-                raise RuntimeError("Deferred comment artifact source_event_key mismatch")
-            comment_author = str(payload.get("actor_login", ""))
-            comment_created_at = str(payload.get("source_created_at"))
-            comment_id_value = payload.get("comment_id")
-            if not isinstance(comment_id_value, int):
-                raise RuntimeError("Deferred comment artifact comment_id must be an integer")
-            comment_id = comment_id_value
-            classified = payload.get("comment_class")
-            source_freshness_eligible = classified in {"plain_text", "command_plus_text"} and bool(payload.get("has_non_command_text"))
-            live_comment = bot.github_api("GET", f"issues/comments/{payload['comment_id']}")
-            if not isinstance(live_comment, dict):
-                changed = False
-                if source_freshness_eligible:
-                    changed = _record_conversation_freshness(bot, state, pr_number, comment_author, comment_id, comment_created_at)
-                _update_deferred_gap(review_data, payload, "reconcile_failed_closed", f"Deferred comment {payload['comment_id']} is no longer visible; source-time freshness only may be preserved. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
-                return changed
-            live_body = live_comment.get("body")
-            if not isinstance(live_body, str):
-                raise RuntimeError("Live deferred comment body is unavailable")
-            if _digest_body(live_body) != payload.get("source_body_digest"):
-                changed = False
-                if source_freshness_eligible:
-                    changed = _record_conversation_freshness(bot, state, pr_number, comment_author, comment_id, comment_created_at)
-                _update_deferred_gap(review_data, payload, "reconcile_failed_closed", f"Deferred comment {payload['comment_id']} body digest changed; command execution suppressed. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
-                return changed
-            changed = False
-            if source_freshness_eligible:
-                changed = _record_conversation_freshness(bot, state, pr_number, comment_author, comment_id, comment_created_at) or changed
-            if classified in {"command_only", "command_plus_text"}:
-                live_classified = classify_comment_payload(bot, live_body)
-                if int(live_classified.get("command_count", 0)) == 1:
-                    changed = _handle_command(bot, state, pr_number, comment_author, live_classified) or changed
-            _mark_reconciled_source_event(review_data, source_event_key)
-            _clear_source_event_key(review_data, source_event_key)
-            return changed
-
-        if event_name == "pull_request_review" and event_action == "submitted":
-            _validate_deferred_review_artifact(payload)
-            _validate_workflow_run_artifact_identity(payload)
-            review_id_value = payload.get("review_id")
-            if not isinstance(review_id_value, int):
-                raise RuntimeError("Deferred review artifact review_id must be an integer")
-            review_id = review_id_value
-            if source_event_key != f"pull_request_review:{review_id}":
-                raise RuntimeError("Deferred review-submitted artifact source_event_key mismatch")
-            live_review = bot.github_api("GET", f"pulls/{pr_number}/reviews/{review_id}")
-            live_pr = bot.github_api("GET", f"pulls/{pr_number}")
-            if not isinstance(live_pr, dict):
-                raise RuntimeError(f"Failed to fetch live PR #{pr_number}")
-            live_commit_id = None
-            live_submitted_at = payload.get("source_submitted_at")
-            live_state = payload.get("source_review_state")
-            if isinstance(live_review, dict):
-                live_commit_id = live_review.get("commit_id")
-                live_submitted_at = live_review.get("submitted_at") or live_submitted_at
-                live_state = live_review.get("state") or live_state
-            else:
-                live_commit_id = payload.get("source_commit_id")
-            actor = str(payload.get("actor_login", ""))
-            changed = maybe_record_head_observation_repair(bot, pr_number, review_data)
-            if isinstance(review_data.get("current_reviewer"), str) and review_data.get("current_reviewer", "").lower() == actor.lower() and isinstance(live_commit_id, str) and isinstance(live_submitted_at, str):
-                bot.reviews_module.accept_channel_event(
-                    review_data,
-                    "reviewer_review",
-                    semantic_key=source_event_key,
-                    timestamp=live_submitted_at,
-                    actor=actor,
-                    reviewed_head_sha=live_commit_id,
-                    source_precedence=1,
-                )
-            _record_review_rebuild(bot, state, pr_number, review_data)
-            _mark_reconciled_source_event(review_data, source_event_key)
-            _clear_source_event_key(review_data, source_event_key)
-            return changed or True
-
-        if event_name == "pull_request_review" and event_action == "dismissed":
-            _validate_deferred_review_artifact(payload)
-            _validate_workflow_run_artifact_identity(payload)
-            review_id_value = payload.get("review_id")
-            if not isinstance(review_id_value, int):
-                raise RuntimeError("Deferred review artifact review_id must be an integer")
-            if source_event_key != f"pull_request_review_dismissed:{review_id_value}":
-                raise RuntimeError("Deferred review-dismissed artifact source_event_key mismatch")
-            bot.reviews_module.accept_channel_event(
-                review_data,
-                "review_dismissal",
-                semantic_key=source_event_key,
-                timestamp=_now_iso(),
-                dismissal_only=True,
-            )
-            maybe_record_head_observation_repair(bot, pr_number, review_data)
-            _record_review_rebuild(bot, state, pr_number, review_data)
-            _mark_reconciled_source_event(review_data, source_event_key)
-            _clear_source_event_key(review_data, source_event_key)
-            return True
-    except RuntimeError as exc:
-        _update_deferred_gap(review_data, payload, "reconcile_failed_closed", f"{exc} See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
-        raise
-    raise RuntimeError("Unsupported deferred workflow_run payload")
 
 
 def handle_manual_dispatch(bot, state: dict) -> bool:
@@ -1050,6 +662,7 @@ def _record_gap_diagnostics(
     diagnostic_reason: str,
 ) -> None:
     _update_deferred_gap(
+        bot,
         review_data,
         {
             "source_event_key": source_event_key,

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -1,0 +1,396 @@
+"""Trusted deferred reconcile helpers for reviewer-bot workflow_run processing."""
+
+from __future__ import annotations
+
+import json
+import os
+
+
+def _now_iso(bot) -> str:
+    return bot.datetime.now(bot.timezone.utc).isoformat()
+
+
+def _ensure_source_event_key(review_data: dict, source_event_key: str, payload: dict | None = None) -> None:
+    review_data.setdefault("deferred_gaps", {})
+    if payload is None:
+        payload = {}
+    payload["source_event_key"] = source_event_key
+    review_data["deferred_gaps"][source_event_key] = payload
+
+
+def _clear_source_event_key(review_data: dict, source_event_key: str) -> None:
+    deferred_gaps = review_data.get("deferred_gaps")
+    if isinstance(deferred_gaps, dict):
+        deferred_gaps.pop(source_event_key, None)
+
+
+def _mark_reconciled_source_event(review_data: dict, source_event_key: str) -> None:
+    reconciled = review_data.setdefault("reconciled_source_events", [])
+    if source_event_key not in reconciled:
+        reconciled.append(source_event_key)
+
+
+def _was_reconciled_source_event(review_data: dict, source_event_key: str) -> bool:
+    reconciled = review_data.get("reconciled_source_events")
+    return isinstance(reconciled, list) and source_event_key in reconciled
+
+
+def _record_review_rebuild(bot, state: dict, issue_number: int, review_data: dict) -> bool:
+    pull_request = bot.github_api("GET", f"pulls/{issue_number}")
+    if not isinstance(pull_request, dict):
+        raise RuntimeError(f"Failed to fetch pull request #{issue_number}")
+    reviews = bot.get_pull_request_reviews(issue_number)
+    if reviews is None:
+        raise RuntimeError(f"Failed to fetch live reviews for PR #{issue_number}")
+    completion, _ = bot.reviews_module.rebuild_pr_approval_state(bot, issue_number, review_data, pull_request=pull_request, reviews=reviews)
+    if completion is None:
+        raise RuntimeError(f"Unable to rebuild approval state for PR #{issue_number}")
+    latest = bot.get_latest_review_by_reviewer(reviews, str(review_data.get("current_reviewer", "")))
+    if latest is not None:
+        commit_id = latest.get("commit_id")
+        submitted_at = latest.get("submitted_at")
+        if isinstance(commit_id, str) and isinstance(submitted_at, str):
+            bot.reviews_module.accept_channel_event(
+                review_data,
+                "reviewer_review",
+                semantic_key=f"pull_request_review:{latest.get('id')}",
+                timestamp=submitted_at,
+                actor=review_data.get("current_reviewer"),
+                reviewed_head_sha=commit_id,
+                source_precedence=1,
+            )
+    return bool(completion.get("completed"))
+
+
+def reconcile_active_review_entry(
+    bot,
+    state: dict,
+    issue_number: int,
+    *,
+    require_pull_request_context: bool = True,
+    completion_source: str = "rectify:reconcile-pr-review",
+) -> tuple[str, bool, bool]:
+    review_data = bot.ensure_review_entry(state, issue_number)
+    if review_data is None:
+        return f"ℹ️ No active review entry exists for #{issue_number}; nothing to rectify.", True, False
+    assigned_reviewer = review_data.get("current_reviewer")
+    if not assigned_reviewer:
+        return f"ℹ️ #{issue_number} has no tracked assigned reviewer; nothing to rectify.", True, False
+    if require_pull_request_context and os.environ.get("IS_PULL_REQUEST", "false").lower() != "true":
+        return f"ℹ️ #{issue_number} is not a pull request in this event context; `/rectify` only reconciles PR reviews.", True, False
+    if str(state.get("freshness_runtime_epoch", "")).strip() != "freshness_v15" and os.environ.get("IS_PULL_REQUEST", "false").lower() == "true":
+        return "ℹ️ PR review freshness rectify is epoch-gated and currently inactive.", True, False
+    state_changed = bot.maybe_record_head_observation_repair(issue_number, review_data)
+    reviews = bot.get_pull_request_reviews(issue_number)
+    if reviews is None:
+        return f"❌ Failed to fetch reviews for PR #{issue_number}; cannot run `/rectify`.", False, False
+    latest_review = bot.get_latest_review_by_reviewer(reviews, assigned_reviewer)
+    messages: list[str] = []
+    if latest_review is not None:
+        latest_state = str(latest_review.get("state", "")).upper()
+        commit_id = latest_review.get("commit_id")
+        submitted_at = latest_review.get("submitted_at")
+        if latest_state in {"APPROVED", "COMMENTED", "CHANGES_REQUESTED"} and isinstance(commit_id, str) and isinstance(submitted_at, str):
+            state_changed = bot.reviews_module.accept_channel_event(
+                review_data,
+                "reviewer_review",
+                semantic_key=f"pull_request_review:{latest_review.get('id')}",
+                timestamp=submitted_at,
+                actor=assigned_reviewer,
+                reviewed_head_sha=commit_id,
+                source_precedence=1,
+            ) or state_changed
+            messages.append(f"latest review by @{assigned_reviewer} is `{latest_state}`")
+    if _record_review_rebuild(bot, state, issue_number, review_data):
+        state_changed = True
+        review_data["review_completion_source"] = completion_source
+    if review_data.get("mandatory_approver_required"):
+        escalation_opened_at = bot.parse_iso8601_timestamp(review_data.get("mandatory_approver_pinged_at")) or bot.parse_iso8601_timestamp(review_data.get("mandatory_approver_label_applied_at"))
+        triage_approval = bot.find_triage_approval_after(reviews, escalation_opened_at)
+        if triage_approval is not None:
+            approver, _ = triage_approval
+            if bot.satisfy_mandatory_approver_requirement(state, issue_number, approver):
+                state_changed = True
+                messages.append(f"mandatory triage approval satisfied by @{approver}")
+    if state_changed:
+        return f"✅ Rectified PR #{issue_number}: {'; '.join(messages) or 'reconciled live review state'}.", True, True
+    return f"ℹ️ Rectify checked PR #{issue_number}: {'; '.join(messages) or 'no reconciliation transitions applied'}.", True, False
+
+
+def _validate_deferred_comment_artifact(payload: dict) -> None:
+    required = {
+        "schema_version",
+        "source_workflow_name",
+        "source_workflow_file",
+        "source_run_id",
+        "source_run_attempt",
+        "source_event_name",
+        "source_event_action",
+        "source_event_key",
+        "pr_number",
+        "comment_id",
+        "comment_class",
+        "has_non_command_text",
+        "source_body_digest",
+        "source_created_at",
+    }
+    missing = sorted(required - set(payload))
+    if missing:
+        raise RuntimeError("Deferred comment artifact missing required fields: " + ", ".join(missing))
+    if payload.get("schema_version") != 2:
+        raise RuntimeError("Deferred comment artifact schema_version is not accepted by V18 reconcile")
+    if not isinstance(payload.get("comment_id"), int) or not isinstance(payload.get("pr_number"), int):
+        raise RuntimeError("Deferred comment artifact comment_id and pr_number must be integers")
+    if not isinstance(payload.get("comment_class"), str) or not isinstance(payload.get("has_non_command_text"), bool):
+        raise RuntimeError("Deferred comment artifact parse fields are malformed")
+    if not isinstance(payload.get("source_body_digest"), str) or not isinstance(payload.get("source_created_at"), str):
+        raise RuntimeError("Deferred comment artifact source digest or timestamp is malformed")
+
+
+def _validate_deferred_review_artifact(payload: dict) -> None:
+    required = {
+        "schema_version",
+        "source_workflow_name",
+        "source_workflow_file",
+        "source_run_id",
+        "source_run_attempt",
+        "source_event_name",
+        "source_event_action",
+        "source_event_key",
+        "pr_number",
+        "review_id",
+    }
+    missing = sorted(required - set(payload))
+    if missing:
+        raise RuntimeError("Deferred review artifact missing required fields: " + ", ".join(missing))
+    if payload.get("schema_version") != 2:
+        raise RuntimeError("Deferred review artifact schema_version is not accepted by V18 reconcile")
+    if not isinstance(payload.get("review_id"), int) or not isinstance(payload.get("pr_number"), int):
+        raise RuntimeError("Deferred review artifact review_id and pr_number must be integers")
+
+
+def _load_deferred_context() -> dict:
+    path = os.environ.get("DEFERRED_CONTEXT_PATH", "").strip()
+    if not path:
+        raise RuntimeError("Missing DEFERRED_CONTEXT_PATH for workflow_run reconcile")
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise RuntimeError("Deferred context payload must be a JSON object")
+    return payload
+
+
+def _expected_observer_identity(payload: dict) -> tuple[str, str]:
+    event_name = payload.get("source_event_name")
+    event_action = payload.get("source_event_action")
+    if event_name == "issue_comment" and event_action == "created":
+        return (
+            "Reviewer Bot PR Comment Observer",
+            ".github/workflows/reviewer-bot-pr-comment-observer.yml",
+        )
+    if event_name == "pull_request_review" and event_action == "submitted":
+        return (
+            "Reviewer Bot PR Review Submitted Observer",
+            ".github/workflows/reviewer-bot-pr-review-submitted-observer.yml",
+        )
+    if event_name == "pull_request_review" and event_action == "dismissed":
+        return (
+            "Reviewer Bot PR Review Dismissed Observer",
+            ".github/workflows/reviewer-bot-pr-review-dismissed-observer.yml",
+        )
+    raise RuntimeError("Unsupported deferred workflow identity")
+
+
+def _validate_workflow_run_artifact_identity(payload: dict) -> None:
+    expected_name, expected_file = _expected_observer_identity(payload)
+    if payload.get("source_workflow_name") != expected_name:
+        raise RuntimeError("Deferred artifact workflow name mismatch")
+    if payload.get("source_workflow_file") != expected_file:
+        raise RuntimeError("Deferred artifact workflow file mismatch")
+    triggering_name = os.environ.get("WORKFLOW_RUN_TRIGGERING_NAME", "").strip()
+    if triggering_name and triggering_name != expected_name:
+        raise RuntimeError("Triggering workflow name mismatch")
+    triggering_id = os.environ.get("WORKFLOW_RUN_TRIGGERING_ID", "").strip()
+    if triggering_id and str(payload.get("source_run_id")) != triggering_id:
+        raise RuntimeError("Deferred artifact run_id mismatch")
+    triggering_attempt = os.environ.get("WORKFLOW_RUN_TRIGGERING_ATTEMPT", "").strip()
+    if triggering_attempt and str(payload.get("source_run_attempt")) != triggering_attempt:
+        raise RuntimeError("Deferred artifact run_attempt mismatch")
+    if os.environ.get("WORKFLOW_RUN_TRIGGERING_CONCLUSION", "").strip() != "success":
+        raise RuntimeError("Triggering observer workflow did not conclude successfully")
+
+
+def _artifact_expected_name(payload: dict) -> str:
+    event_name = payload.get("source_event_name")
+    event_action = payload.get("source_event_action")
+    run_id = payload.get("source_run_id")
+    run_attempt = payload.get("source_run_attempt")
+    if event_name == "issue_comment" and event_action == "created":
+        return f"reviewer-bot-comment-context-{run_id}-attempt-{run_attempt}"
+    if event_name == "pull_request_review" and event_action == "submitted":
+        return f"reviewer-bot-review-submitted-context-{run_id}-attempt-{run_attempt}"
+    if event_name == "pull_request_review" and event_action == "dismissed":
+        return f"reviewer-bot-review-dismissed-context-{run_id}-attempt-{run_attempt}"
+    raise RuntimeError("Unsupported deferred artifact naming")
+
+
+def _artifact_expected_payload_name(payload: dict) -> str:
+    event_name = payload.get("source_event_name")
+    event_action = payload.get("source_event_action")
+    if event_name == "issue_comment" and event_action == "created":
+        return "deferred-comment.json"
+    if event_name == "pull_request_review" and event_action == "submitted":
+        return "deferred-review-submitted.json"
+    if event_name == "pull_request_review" and event_action == "dismissed":
+        return "deferred-review-dismissed.json"
+    raise RuntimeError("Unsupported deferred payload path")
+
+
+def _update_deferred_gap(bot, review_data: dict, payload: dict, reason: str, diagnostic_summary: str) -> None:
+    source_event_key = str(payload.get("source_event_key", ""))
+    if not source_event_key:
+        return
+    review_data.setdefault("deferred_gaps", {})
+    existing = review_data["deferred_gaps"].get(source_event_key, {})
+    if not isinstance(existing, dict):
+        existing = {}
+    existing.update(
+        {
+            "source_event_key": source_event_key,
+            "source_event_kind": f"{payload.get('source_event_name')}:{payload.get('source_event_action')}",
+            "pr_number": payload.get("pr_number"),
+            "reason": reason,
+            "source_event_created_at": payload.get("source_created_at") or payload.get("source_submitted_at"),
+            "source_run_id": payload.get("source_run_id"),
+            "source_run_attempt": payload.get("source_run_attempt"),
+            "source_workflow_file": payload.get("source_workflow_file"),
+            "source_artifact_name": payload.get("source_artifact_name"),
+            "first_noted_at": existing.get("first_noted_at") or _now_iso(bot),
+            "last_checked_at": _now_iso(bot),
+            "operator_action_required": True,
+            "diagnostic_summary": diagnostic_summary,
+        }
+    )
+    review_data["deferred_gaps"][source_event_key] = existing
+
+
+def handle_workflow_run_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_workflow_run_event")
+    if str(state.get("freshness_runtime_epoch", "")).strip() != "freshness_v15":
+        print("V18 workflow_run reconcile safe-noop before epoch flip")
+        return False
+    payload = _load_deferred_context()
+    pr_number = int(payload.get("pr_number", 0) or 0)
+    if pr_number <= 0:
+        raise RuntimeError("Deferred context is missing a valid PR number")
+    bot.collect_touched_item(pr_number)
+    review_data = bot.ensure_review_entry(state, pr_number, create=True)
+    if review_data is None:
+        raise RuntimeError(f"No review entry available for PR #{pr_number}")
+    event_name = payload.get("source_event_name")
+    event_action = payload.get("source_event_action")
+    source_event_key = str(payload.get("source_event_key", ""))
+    try:
+        if event_name == "issue_comment":
+            _validate_deferred_comment_artifact(payload)
+            _validate_workflow_run_artifact_identity(payload)
+            if source_event_key != f"issue_comment:{payload['comment_id']}":
+                raise RuntimeError("Deferred comment artifact source_event_key mismatch")
+            comment_author = str(payload.get("actor_login", ""))
+            comment_created_at = str(payload.get("source_created_at"))
+            comment_id_value = payload.get("comment_id")
+            if not isinstance(comment_id_value, int):
+                raise RuntimeError("Deferred comment artifact comment_id must be an integer")
+            comment_id = comment_id_value
+            classified = payload.get("comment_class")
+            source_freshness_eligible = classified in {"plain_text", "command_plus_text"} and bool(payload.get("has_non_command_text"))
+            live_comment = bot.github_api("GET", f"issues/comments/{payload['comment_id']}")
+            if not isinstance(live_comment, dict):
+                changed = False
+                if source_freshness_eligible:
+                    changed = bot._record_conversation_freshness(state, pr_number, comment_author, comment_id, comment_created_at)
+                _update_deferred_gap(bot, review_data, payload, "reconcile_failed_closed", f"Deferred comment {payload['comment_id']} is no longer visible; source-time freshness only may be preserved. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
+                return changed
+            live_body = live_comment.get("body")
+            if not isinstance(live_body, str):
+                raise RuntimeError("Live deferred comment body is unavailable")
+            if bot._digest_body(live_body) != payload.get("source_body_digest"):
+                changed = False
+                if source_freshness_eligible:
+                    changed = bot._record_conversation_freshness(state, pr_number, comment_author, comment_id, comment_created_at)
+                _update_deferred_gap(bot, review_data, payload, "reconcile_failed_closed", f"Deferred comment {payload['comment_id']} body digest changed; command execution suppressed. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
+                return changed
+            changed = False
+            if source_freshness_eligible:
+                changed = bot._record_conversation_freshness(state, pr_number, comment_author, comment_id, comment_created_at) or changed
+            if classified in {"command_only", "command_plus_text"}:
+                live_classified = bot.classify_comment_payload(live_body)
+                if int(live_classified.get("command_count", 0)) == 1:
+                    changed = bot._handle_comment_command(state, pr_number, comment_author, live_classified) or changed
+            _mark_reconciled_source_event(review_data, source_event_key)
+            _clear_source_event_key(review_data, source_event_key)
+            return changed
+
+        if event_name == "pull_request_review" and event_action == "submitted":
+            _validate_deferred_review_artifact(payload)
+            _validate_workflow_run_artifact_identity(payload)
+            review_id_value = payload.get("review_id")
+            if not isinstance(review_id_value, int):
+                raise RuntimeError("Deferred review artifact review_id must be an integer")
+            review_id = review_id_value
+            if source_event_key != f"pull_request_review:{review_id}":
+                raise RuntimeError("Deferred review-submitted artifact source_event_key mismatch")
+            live_review = bot.github_api("GET", f"pulls/{pr_number}/reviews/{review_id}")
+            live_pr = bot.github_api("GET", f"pulls/{pr_number}")
+            if not isinstance(live_pr, dict):
+                raise RuntimeError(f"Failed to fetch live PR #{pr_number}")
+            live_commit_id = None
+            live_submitted_at = payload.get("source_submitted_at")
+            live_state = payload.get("source_review_state")
+            if isinstance(live_review, dict):
+                live_commit_id = live_review.get("commit_id")
+                live_submitted_at = live_review.get("submitted_at") or live_submitted_at
+                live_state = live_review.get("state") or live_state
+            else:
+                live_commit_id = payload.get("source_commit_id")
+            actor = str(payload.get("actor_login", ""))
+            changed = bot.maybe_record_head_observation_repair(pr_number, review_data)
+            if isinstance(review_data.get("current_reviewer"), str) and review_data.get("current_reviewer", "").lower() == actor.lower() and isinstance(live_commit_id, str) and isinstance(live_submitted_at, str):
+                bot.reviews_module.accept_channel_event(
+                    review_data,
+                    "reviewer_review",
+                    semantic_key=source_event_key,
+                    timestamp=live_submitted_at,
+                    actor=actor,
+                    reviewed_head_sha=live_commit_id,
+                    source_precedence=1,
+                )
+            _record_review_rebuild(bot, state, pr_number, review_data)
+            _mark_reconciled_source_event(review_data, source_event_key)
+            _clear_source_event_key(review_data, source_event_key)
+            return changed or True
+
+        if event_name == "pull_request_review" and event_action == "dismissed":
+            _validate_deferred_review_artifact(payload)
+            _validate_workflow_run_artifact_identity(payload)
+            review_id_value = payload.get("review_id")
+            if not isinstance(review_id_value, int):
+                raise RuntimeError("Deferred review artifact review_id must be an integer")
+            if source_event_key != f"pull_request_review_dismissed:{review_id_value}":
+                raise RuntimeError("Deferred review-dismissed artifact source_event_key mismatch")
+            bot.reviews_module.accept_channel_event(
+                review_data,
+                "review_dismissal",
+                semantic_key=source_event_key,
+                timestamp=_now_iso(bot),
+                dismissal_only=True,
+            )
+            bot.maybe_record_head_observation_repair(pr_number, review_data)
+            _record_review_rebuild(bot, state, pr_number, review_data)
+            _mark_reconciled_source_event(review_data, source_event_key)
+            _clear_source_event_key(review_data, source_event_key)
+            return True
+    except RuntimeError as exc:
+        _update_deferred_gap(bot, review_data, payload, "reconcile_failed_closed", f"{exc} See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
+        raise
+    raise RuntimeError("Unsupported deferred workflow_run payload")


### PR DESCRIPTION
## Summary
- extract the trusted deferred-reconcile cluster out of events.py into a dedicated reconcile module
- keep behavior unchanged while reducing the size and coupling of the events module
- route workflow_run reconcile through the new module explicitly

## What Changed
- add scripts/reviewer_bot_lib/reconcile.py and move the trusted deferred-reconcile cluster there:
  - active review rectification helpers
  - deferred artifact validation
  - workflow_run reconcile handling
  - reconcile-side deferred gap bookkeeping helpers
- remove those implementations from scripts/reviewer_bot_lib/events.py and import the needed helpers instead
- update scripts/reviewer_bot.py to route handle_workflow_run_event and reconcile entrypoints through the new reconcile module
- add small adapter wrappers needed by the moved reconcile logic

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Notes
- this is a structural extraction only; sweeper/run/artifact correlation and maintenance dispatch remain in events.py for later slices
- follow-up slices can target sweeper extraction and maintenance extraction separately
