### PR TITLE
Refactor reviewer-bot final events cleanup

### DIFF
--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -70,6 +70,7 @@ try:
     import scripts.reviewer_bot_lib.github_api as github_api_module
     import scripts.reviewer_bot_lib.lease_lock as lease_lock_module
     import scripts.reviewer_bot_lib.lifecycle as lifecycle_module
+    import scripts.reviewer_bot_lib.maintenance as maintenance_module
     import scripts.reviewer_bot_lib.reconcile as reconcile_module
     import scripts.reviewer_bot_lib.reviews as reviews_module
     import scripts.reviewer_bot_lib.state_store as state_store_module
@@ -160,6 +161,7 @@ except ImportError:
     import reviewer_bot_lib.github_api as github_api_module
     import reviewer_bot_lib.lease_lock as lease_lock_module
     import reviewer_bot_lib.lifecycle as lifecycle_module
+    import reviewer_bot_lib.maintenance as maintenance_module
     import reviewer_bot_lib.reconcile as reconcile_module
     import reviewer_bot_lib.reviews as reviews_module
     import reviewer_bot_lib.state_store as state_store_module
@@ -808,45 +810,14 @@ def list_open_items_with_status_labels() -> list[int]:
 
 
 def get_latest_review_by_reviewer(reviews: list[dict], reviewer: str) -> dict | None:
-    return events_module.get_latest_review_by_reviewer(_runtime_bot(), reviews, reviewer)
+    return reviews_module.get_latest_review_by_reviewer(_runtime_bot(), reviews, reviewer)
 
 
 def find_triage_approval_after(
     reviews: list[dict],
     since: datetime | None,
 ) -> tuple[str, datetime] | None:
-    """Find the first triage+ approval submitted after `since`."""
-    permission_cache: dict[str, bool] = {}
-    approvals: list[tuple[datetime, int, str]] = []
-
-    for index, review in enumerate(reviews):
-        state = str(review.get("state", "")).upper()
-        if state != "APPROVED":
-            continue
-
-        author = review.get("user", {}).get("login")
-        if not isinstance(author, str) or not author:
-            continue
-
-        submitted_at = parse_github_timestamp(review.get("submitted_at"))
-        if submitted_at is None:
-            continue
-
-        if since is not None and submitted_at <= since:
-            continue
-
-        approvals.append((submitted_at, index, author))
-
-    approvals.sort(key=lambda item: (item[0], item[1]))
-
-    for submitted_at, _, author in approvals:
-        cache_key = author.lower()
-        if cache_key not in permission_cache:
-            permission_cache[cache_key] = is_triage_or_higher(author)
-        if permission_cache[cache_key]:
-            return author, submitted_at
-
-    return None
+    return reviews_module.find_triage_approval_after(_runtime_bot(), reviews, since)
 
 
 def classify_comment_payload(comment_body: str) -> dict:
@@ -1166,11 +1137,11 @@ def handle_comment_event(state: dict) -> bool:
 
 
 def handle_manual_dispatch(state: dict) -> bool:
-    return events_module.handle_manual_dispatch(_runtime_bot(), state)
+    return maintenance_module.handle_manual_dispatch(_runtime_bot(), state)
 
 
 def handle_scheduled_check(state: dict) -> bool:
-    return events_module.handle_scheduled_check(_runtime_bot(), state)
+    return maintenance_module.handle_scheduled_check(_runtime_bot(), state)
 
 
 # ==============================================================================

--- a/scripts/reviewer_bot_lib/events.py
+++ b/scripts/reviewer_bot_lib/events.py
@@ -3,20 +3,6 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone
-
-import yaml
-
-from .lifecycle import maybe_record_head_observation_repair
-from .sweeper import sweep_deferred_gaps
-
-
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _now_iso() -> str:
-    return _now().isoformat()
 
 
 def _runtime_epoch(state: dict) -> str:
@@ -45,53 +31,6 @@ def _require_legacy_for_legacy_pr(state: dict, context: str) -> bool:
         print(f"Legacy PR freshness path safe-noop for {context}; epoch is {epoch}")
         return False
     return True
-
-
-
-def get_latest_review_by_reviewer(bot, reviews: list[dict], reviewer: str) -> dict | None:
-    latest_review = None
-    latest_key = (datetime.min.replace(tzinfo=timezone.utc), "")
-    for review in reviews:
-        author = review.get("user", {}).get("login")
-        if not isinstance(author, str) or author.lower() != reviewer.lower():
-            continue
-        submitted_at = bot.parse_github_timestamp(review.get("submitted_at"))
-        if submitted_at is None:
-            continue
-        review_id = str(review.get("id", ""))
-        review_key = (submitted_at, review_id)
-        if review_key >= latest_key:
-            latest_key = review_key
-            latest_review = review
-    return latest_review
-
-
-def find_triage_approval_after(bot, reviews: list[dict], since: datetime | None) -> tuple[str, datetime] | None:
-    permission_cache: dict[str, bool] = {}
-    approvals: list[tuple[datetime, str, str]] = []
-    for review in reviews:
-        state = str(review.get("state", "")).upper()
-        if state != "APPROVED":
-            continue
-        author = review.get("user", {}).get("login")
-        if not isinstance(author, str) or not author:
-            continue
-        submitted_at = bot.parse_github_timestamp(review.get("submitted_at"))
-        if submitted_at is None:
-            continue
-        if since is not None and submitted_at <= since:
-            continue
-        approvals.append((submitted_at, str(review.get("id", "")), author))
-    approvals.sort(key=lambda item: (item[0], item[1]))
-    for submitted_at, _, author in approvals:
-        cache_key = author.lower()
-        if cache_key not in permission_cache:
-            permission_cache[cache_key] = bot.is_triage_or_higher(author)
-        if permission_cache[cache_key]:
-            return author, submitted_at
-    return None
-
-
 def handle_pull_request_review_event(bot, state: dict) -> bool:
     issue_number = int(os.environ.get("ISSUE_NUMBER", 0))
     if not issue_number:
@@ -105,96 +44,3 @@ def handle_pull_request_review_event(bot, state: dict) -> bool:
         return False
     print(f"Deferring pull_request_review {review_action} for #{issue_number}")
     return False
-
-
-def handle_manual_dispatch(bot, state: dict) -> bool:
-    action = os.environ.get("MANUAL_ACTION", "")
-    if action == "show-state":
-        print(f"Current state:\n{yaml.dump(state, default_flow_style=False)}")
-        return False
-    bot.assert_lock_held("handle_manual_dispatch")
-    if action == "sync-members":
-        _, changes = bot.sync_members_with_queue(state)
-        return bool(changes)
-    if action == "repair-review-status-labels":
-        for issue_number in bot.list_open_items_with_status_labels():
-            bot.collect_touched_item(issue_number)
-        return False
-    if action == "check-overdue":
-        return bot.handle_scheduled_check(state)
-    if action == "execute-pending-privileged-command":
-        source_event_key = os.environ.get("PRIVILEGED_SOURCE_EVENT_KEY", "").strip()
-        if not source_event_key:
-            raise RuntimeError("Missing PRIVILEGED_SOURCE_EVENT_KEY for privileged command execution")
-        for issue_key, review_data in (state.get("active_reviews") or {}).items():
-            if not isinstance(review_data, dict):
-                continue
-            pending = review_data.get("pending_privileged_commands")
-            if not isinstance(pending, dict) or source_event_key not in pending:
-                continue
-            record = pending[source_event_key]
-            if not isinstance(record, dict):
-                raise RuntimeError("Pending privileged command record is malformed")
-            if record.get("status") != "pending":
-                return False
-            issue_number = int(record.get("issue_number") or int(issue_key))
-            actor = str(record.get("actor", "")).strip()
-            command_name = record.get("command_name")
-            if command_name != "accept-no-fls-changes":
-                record["status"] = "failed_closed"
-                record["completed_at"] = _now_iso()
-                record["result"] = "unsupported_command"
-                return True
-            issue_snapshot = bot.get_issue_or_pr_snapshot(issue_number)
-            if not isinstance(issue_snapshot, dict) or isinstance(issue_snapshot.get("pull_request"), dict):
-                record["status"] = "failed_closed"
-                record["completed_at"] = _now_iso()
-                record["result"] = "live_target_invalid"
-                return True
-            labels = {
-                label.get("name")
-                for label in issue_snapshot.get("labels", [])
-                if isinstance(label, dict) and isinstance(label.get("name"), str)
-            }
-            if bot.FLS_AUDIT_LABEL not in labels or not bot.check_user_permission(actor, "triage"):
-                record["status"] = "failed_closed"
-                record["completed_at"] = _now_iso()
-                record["result"] = "live_revalidation_failed"
-                return True
-            message, success = bot.handle_accept_no_fls_changes_command(issue_number, actor)
-            record["completed_at"] = _now_iso()
-            record["result_message"] = message
-            record["status"] = "executed" if success else "failed_closed"
-            return True
-        raise RuntimeError(f"Pending privileged command not found for {source_event_key}")
-    return False
-
-
-
-def handle_scheduled_check(bot, state: dict) -> bool:
-    bot.assert_lock_held("handle_scheduled_check")
-    changed = sweep_deferred_gaps(bot, state)
-    active_reviews = state.get("active_reviews")
-    if isinstance(active_reviews, dict):
-        for issue_key, review_data in active_reviews.items():
-            if not isinstance(review_data, dict) or not review_data.get("current_reviewer"):
-                continue
-            issue_number = int(issue_key)
-            issue_snapshot = bot.get_issue_or_pr_snapshot(issue_number)
-            if not isinstance(issue_snapshot, dict) or not isinstance(issue_snapshot.get("pull_request"), dict):
-                continue
-            if maybe_record_head_observation_repair(bot, issue_number, review_data):
-                changed = True
-    overdue_reviews = bot.check_overdue_reviews(state)
-    if not overdue_reviews:
-        return changed
-    for review in overdue_reviews:
-        issue_number = review["issue_number"]
-        reviewer = review["reviewer"]
-        if review["needs_warning"]:
-            if bot.handle_overdue_review_warning(state, issue_number, reviewer):
-                changed = True
-        elif review["needs_transition"]:
-            bot.handle_transition_notice(state, issue_number, reviewer)
-            changed = True
-    return changed

--- a/scripts/reviewer_bot_lib/maintenance.py
+++ b/scripts/reviewer_bot_lib/maintenance.py
@@ -1,0 +1,106 @@
+"""Maintenance and operator-dispatch handlers for reviewer-bot."""
+
+from __future__ import annotations
+
+import os
+
+import yaml
+
+from .lifecycle import maybe_record_head_observation_repair
+from .sweeper import sweep_deferred_gaps
+
+
+def _now_iso(bot) -> str:
+    return bot.datetime.now(bot.timezone.utc).isoformat()
+
+
+def handle_manual_dispatch(bot, state: dict) -> bool:
+    action = os.environ.get("MANUAL_ACTION", "")
+    if action == "show-state":
+        print(f"Current state:\n{yaml.dump(state, default_flow_style=False)}")
+        return False
+    bot.assert_lock_held("handle_manual_dispatch")
+    if action == "sync-members":
+        _, changes = bot.sync_members_with_queue(state)
+        return bool(changes)
+    if action == "repair-review-status-labels":
+        for issue_number in bot.list_open_items_with_status_labels():
+            bot.collect_touched_item(issue_number)
+        return False
+    if action == "check-overdue":
+        return bot.handle_scheduled_check(state)
+    if action == "execute-pending-privileged-command":
+        source_event_key = os.environ.get("PRIVILEGED_SOURCE_EVENT_KEY", "").strip()
+        if not source_event_key:
+            raise RuntimeError("Missing PRIVILEGED_SOURCE_EVENT_KEY for privileged command execution")
+        for issue_key, review_data in (state.get("active_reviews") or {}).items():
+            if not isinstance(review_data, dict):
+                continue
+            pending = review_data.get("pending_privileged_commands")
+            if not isinstance(pending, dict) or source_event_key not in pending:
+                continue
+            record = pending[source_event_key]
+            if not isinstance(record, dict):
+                raise RuntimeError("Pending privileged command record is malformed")
+            if record.get("status") != "pending":
+                return False
+            issue_number = int(record.get("issue_number") or int(issue_key))
+            actor = str(record.get("actor", "")).strip()
+            command_name = record.get("command_name")
+            if command_name != "accept-no-fls-changes":
+                record["status"] = "failed_closed"
+                record["completed_at"] = _now_iso(bot)
+                record["result"] = "unsupported_command"
+                return True
+            issue_snapshot = bot.get_issue_or_pr_snapshot(issue_number)
+            if not isinstance(issue_snapshot, dict) or isinstance(issue_snapshot.get("pull_request"), dict):
+                record["status"] = "failed_closed"
+                record["completed_at"] = _now_iso(bot)
+                record["result"] = "live_target_invalid"
+                return True
+            labels = {
+                label.get("name")
+                for label in issue_snapshot.get("labels", [])
+                if isinstance(label, dict) and isinstance(label.get("name"), str)
+            }
+            if bot.FLS_AUDIT_LABEL not in labels or not bot.check_user_permission(actor, "triage"):
+                record["status"] = "failed_closed"
+                record["completed_at"] = _now_iso(bot)
+                record["result"] = "live_revalidation_failed"
+                return True
+            message, success = bot.handle_accept_no_fls_changes_command(issue_number, actor)
+            record["completed_at"] = _now_iso(bot)
+            record["result_message"] = message
+            record["status"] = "executed" if success else "failed_closed"
+            return True
+        raise RuntimeError(f"Pending privileged command not found for {source_event_key}")
+    return False
+
+
+def handle_scheduled_check(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_scheduled_check")
+    changed = sweep_deferred_gaps(bot, state)
+    active_reviews = state.get("active_reviews")
+    if isinstance(active_reviews, dict):
+        for issue_key, review_data in active_reviews.items():
+            if not isinstance(review_data, dict) or not review_data.get("current_reviewer"):
+                continue
+            issue_number = int(issue_key)
+            issue_snapshot = bot.get_issue_or_pr_snapshot(issue_number)
+            if not isinstance(issue_snapshot, dict) or not isinstance(issue_snapshot.get("pull_request"), dict):
+                continue
+            if maybe_record_head_observation_repair(bot, issue_number, review_data):
+                changed = True
+    overdue_reviews = bot.check_overdue_reviews(state)
+    if not overdue_reviews:
+        return changed
+    for review in overdue_reviews:
+        issue_number = review["issue_number"]
+        reviewer = review["reviewer"]
+        if review["needs_warning"]:
+            if bot.handle_overdue_review_warning(state, issue_number, reviewer):
+                changed = True
+        elif review["needs_transition"]:
+            bot.handle_transition_notice(state, issue_number, reviewer)
+            changed = True
+    return changed

--- a/scripts/reviewer_bot_lib/reviews.py
+++ b/scripts/reviewer_bot_lib/reviews.py
@@ -30,6 +30,50 @@ def parse_github_timestamp(value: str | None) -> datetime | None:
         return None
 
 
+def get_latest_review_by_reviewer(bot, reviews: list[dict], reviewer: str) -> dict | None:
+    latest_review = None
+    latest_key = (datetime.min.replace(tzinfo=timezone.utc), "")
+    for review in reviews:
+        author = review.get("user", {}).get("login")
+        if not isinstance(author, str) or author.lower() != reviewer.lower():
+            continue
+        submitted_at = bot.parse_github_timestamp(review.get("submitted_at"))
+        if submitted_at is None:
+            continue
+        review_id = str(review.get("id", ""))
+        review_key = (submitted_at, review_id)
+        if review_key >= latest_key:
+            latest_key = review_key
+            latest_review = review
+    return latest_review
+
+
+def find_triage_approval_after(bot, reviews: list[dict], since: datetime | None) -> tuple[str, datetime] | None:
+    permission_cache: dict[str, bool] = {}
+    approvals: list[tuple[datetime, str, str]] = []
+    for review in reviews:
+        state = str(review.get("state", "")).upper()
+        if state != "APPROVED":
+            continue
+        author = review.get("user", {}).get("login")
+        if not isinstance(author, str) or not author:
+            continue
+        submitted_at = bot.parse_github_timestamp(review.get("submitted_at"))
+        if submitted_at is None:
+            continue
+        if since is not None and submitted_at <= since:
+            continue
+        approvals.append((submitted_at, str(review.get("id", "")), author))
+    approvals.sort(key=lambda item: (item[0], item[1]))
+    for submitted_at, _, author in approvals:
+        cache_key = author.lower()
+        if cache_key not in permission_cache:
+            permission_cache[cache_key] = bot.is_triage_or_higher(author)
+        if permission_cache[cache_key]:
+            return author, submitted_at
+    return None
+
+
 def _ensure_channel_map(review_entry: dict, name: str) -> dict:
     value = review_entry.get(name)
     if not isinstance(value, dict):


### PR DESCRIPTION
## Summary
- extract maintenance dispatch out of events.py
- relocate the remaining review helper functions to reviews.py
- leave events.py as a small residual event helper module instead of a miscellaneous bucket

## What Changed
- add scripts/reviewer_bot_lib/maintenance.py and move:
  - handle_manual_dispatch
  - handle_scheduled_check
- move the remaining review helper functions from scripts/reviewer_bot_lib/events.py into scripts/reviewer_bot_lib/reviews.py:
  - get_latest_review_by_reviewer
  - find_triage_approval_after
- update scripts/reviewer_bot.py wrappers to route maintenance and review helpers through their new homes
- reduce scripts/reviewer_bot_lib/events.py to a small residual module focused on runtime epoch helpers and direct PR review source-event deferral

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Notes
- this is the final cleanup slice for the events.py untangling work
- the major spaghetti has already been split into lifecycle, comment routing, reconcile, and sweeper modules; this PR cleans up the remaining miscellaneous bucket
