### PR TITLE
Refactor reviewer-bot review helper wrappers

### DIFF
--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -763,29 +763,6 @@ def get_pull_request_reviews(issue_number: int) -> list[dict] | None:
     return reviews_module.get_pull_request_reviews(_runtime_bot(), issue_number)
 
 
-def collapse_latest_reviews_by_login(reviews: list[dict]) -> dict[str, dict]:
-    return reviews_module.collapse_latest_reviews_by_login(reviews)
-
-
-def get_current_cycle_boundary(review_data: dict) -> datetime | None:
-    return reviews_module.get_current_cycle_boundary(_runtime_bot(), review_data)
-
-
-def pr_has_current_write_approval(
-    issue_number: int,
-    review_data: dict,
-    permission_cache: dict[str, bool] | None = None,
-    reviews: list[dict] | None = None,
-) -> bool | None:
-    return reviews_module.pr_has_current_write_approval(
-        _runtime_bot(),
-        issue_number,
-        review_data,
-        permission_cache=permission_cache,
-        reviews=reviews,
-    )
-
-
 def project_status_labels_for_item(
     issue_number: int,
     state: dict,
@@ -807,17 +784,6 @@ def sync_status_labels_for_items(state: dict, issue_numbers: Iterable[int]) -> b
 
 def list_open_items_with_status_labels() -> list[int]:
     return reviews_module.list_open_items_with_status_labels(_runtime_bot())
-
-
-def get_latest_review_by_reviewer(reviews: list[dict], reviewer: str) -> dict | None:
-    return reviews_module.get_latest_review_by_reviewer(_runtime_bot(), reviews, reviewer)
-
-
-def find_triage_approval_after(
-    reviews: list[dict],
-    since: datetime | None,
-) -> tuple[str, datetime] | None:
-    return reviews_module.find_triage_approval_after(_runtime_bot(), reviews, since)
 
 
 def classify_comment_payload(comment_body: str) -> dict:

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import os
 
+from .reviews import find_triage_approval_after, get_latest_review_by_reviewer
+
 
 def _now_iso(bot) -> str:
     return bot.datetime.now(bot.timezone.utc).isoformat()
@@ -45,7 +47,7 @@ def _record_review_rebuild(bot, state: dict, issue_number: int, review_data: dic
     completion, _ = bot.reviews_module.rebuild_pr_approval_state(bot, issue_number, review_data, pull_request=pull_request, reviews=reviews)
     if completion is None:
         raise RuntimeError(f"Unable to rebuild approval state for PR #{issue_number}")
-    latest = bot.get_latest_review_by_reviewer(reviews, str(review_data.get("current_reviewer", "")))
+    latest = get_latest_review_by_reviewer(bot, reviews, str(review_data.get("current_reviewer", "")))
     if latest is not None:
         commit_id = latest.get("commit_id")
         submitted_at = latest.get("submitted_at")
@@ -84,7 +86,7 @@ def reconcile_active_review_entry(
     reviews = bot.get_pull_request_reviews(issue_number)
     if reviews is None:
         return f"❌ Failed to fetch reviews for PR #{issue_number}; cannot run `/rectify`.", False, False
-    latest_review = bot.get_latest_review_by_reviewer(reviews, assigned_reviewer)
+    latest_review = get_latest_review_by_reviewer(bot, reviews, assigned_reviewer)
     messages: list[str] = []
     if latest_review is not None:
         latest_state = str(latest_review.get("state", "")).upper()
@@ -106,7 +108,7 @@ def reconcile_active_review_entry(
         review_data["review_completion_source"] = completion_source
     if review_data.get("mandatory_approver_required"):
         escalation_opened_at = bot.parse_iso8601_timestamp(review_data.get("mandatory_approver_pinged_at")) or bot.parse_iso8601_timestamp(review_data.get("mandatory_approver_label_applied_at"))
-        triage_approval = bot.find_triage_approval_after(reviews, escalation_opened_at)
+        triage_approval = find_triage_approval_after(bot, reviews, escalation_opened_at)
         if triage_approval is not None:
             approver, _ = triage_approval
             if bot.satisfy_mandatory_approver_requirement(state, issue_number, approver):


### PR DESCRIPTION
## Summary
- remove review-domain helper wrappers from scripts/reviewer_bot.py
- update internal runtime consumers to call reviews.py directly
- keep the entrypoint focused on true runtime adapter services instead of domain helper passthroughs

## What Changed
- remove these review helper wrappers from scripts/reviewer_bot.py:
  - get_latest_review_by_reviewer
  - find_triage_approval_after
  - collapse_latest_reviews_by_login
  - get_current_cycle_boundary
  - pr_has_current_write_approval
- update scripts/reviewer_bot_lib/reconcile.py to import the needed review helpers directly from scripts/reviewer_bot_lib/reviews.py
- leave runtime behavior unchanged

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Notes
- this is the first slice of the scripts/reviewer_bot.py wrapper reduction work
- follow-up slices can remove comment-routing and sweeper helper wrappers next
