### PR TITLE
Fix reviewer-bot lease lock visibility race

### DIFF
--- a/.github/reviewer-bot-tests/test_main.py
+++ b/.github/reviewer-bot-tests/test_main.py
@@ -319,6 +319,94 @@ def test_main_mutating_event_does_not_sync_or_save_when_state_unavailable(monkey
     }
 
 
+def test_acquire_lock_retries_until_expected_token_visible(monkeypatch):
+    snapshots = iter(
+        [
+            ("old-ref", "tree", {"lock_state": "unlocked", "lock_token": None}),
+            ("stale-ref", "tree", {"lock_state": "unlocked", "lock_token": None}),
+            ("stale-ref-2", "tree", {"lock_state": "unlocked", "lock_token": None}),
+            ("new-ref", "tree", {"lock_state": "locked", "lock_token": "token-123"}),
+        ]
+    )
+
+    monkeypatch.setattr(reviewer_bot.lease_lock_module.uuid, "uuid4", lambda: type("U", (), {"hex": "token-123"})())
+    monkeypatch.setattr(reviewer_bot.lease_lock_module.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(reviewer_bot, "get_lock_ref_snapshot", lambda: next(snapshots))
+    monkeypatch.setattr(reviewer_bot, "create_lock_commit", lambda parent_sha, tree_sha, lock_meta: reviewer_bot.GitHubApiResult(201, {"sha": "commit-1"}, {}, "", True))
+    monkeypatch.setattr(reviewer_bot, "cas_update_lock_ref", lambda new_sha: reviewer_bot.GitHubApiResult(200, {}, {}, "", True))
+    monkeypatch.setattr(reviewer_bot, "get_state_issue_html_url", lambda: "https://example.com/issues/314")
+    monkeypatch.setattr(reviewer_bot, "ACTIVE_LEASE_CONTEXT", None)
+
+    context = reviewer_bot.acquire_state_issue_lease_lock()
+
+    assert context.lock_token == "token-123"
+    assert reviewer_bot.ACTIVE_LEASE_CONTEXT is context
+
+
+def test_acquire_lock_fails_closed_on_conflicting_visible_token(monkeypatch):
+    snapshots = iter(
+        [
+            ("old-ref", "tree", {"lock_state": "unlocked", "lock_token": None}),
+            ("new-ref", "tree", {"lock_state": "locked", "lock_token": "other-token"}),
+        ]
+    )
+
+    monkeypatch.setattr(reviewer_bot.lease_lock_module.uuid, "uuid4", lambda: type("U", (), {"hex": "token-123"})())
+    monkeypatch.setattr(reviewer_bot.lease_lock_module.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(reviewer_bot, "get_lock_ref_snapshot", lambda: next(snapshots))
+    monkeypatch.setattr(reviewer_bot, "create_lock_commit", lambda parent_sha, tree_sha, lock_meta: reviewer_bot.GitHubApiResult(201, {"sha": "commit-1"}, {}, "", True))
+    monkeypatch.setattr(reviewer_bot, "cas_update_lock_ref", lambda new_sha: reviewer_bot.GitHubApiResult(200, {}, {}, "", True))
+    monkeypatch.setattr(reviewer_bot, "get_state_issue_html_url", lambda: "https://example.com/issues/314")
+    monkeypatch.setattr(reviewer_bot, "ACTIVE_LEASE_CONTEXT", None)
+
+    with pytest.raises(RuntimeError, match="unexpected lock state"):
+        reviewer_bot.acquire_state_issue_lease_lock()
+
+
+def test_release_lock_retries_stale_unlocked_predecessor(monkeypatch):
+    context = reviewer_bot.LeaseContext(
+        lock_token="token-123",
+        lock_owner_run_id="run",
+        lock_owner_workflow="workflow",
+        lock_owner_job="job",
+        state_issue_url="https://example.com/issues/314",
+        lock_ref="refs/heads/reviewer-bot-state-lock",
+        lock_expires_at="2999-01-01T00:00:00+00:00",
+    )
+    snapshots = iter(
+        [
+            ("stale-ref", "tree", {"lock_state": "unlocked", "lock_token": None}),
+            ("new-ref", "tree", {"lock_state": "locked", "lock_token": "token-123"}),
+        ]
+    )
+
+    monkeypatch.setattr(reviewer_bot, "ACTIVE_LEASE_CONTEXT", context)
+    monkeypatch.setattr(reviewer_bot.lease_lock_module.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(reviewer_bot, "get_lock_ref_snapshot", lambda: next(snapshots))
+    monkeypatch.setattr(reviewer_bot, "create_lock_commit", lambda parent_sha, tree_sha, lock_meta: reviewer_bot.GitHubApiResult(201, {"sha": "commit-2"}, {}, "", True))
+    monkeypatch.setattr(reviewer_bot, "cas_update_lock_ref", lambda new_sha: reviewer_bot.GitHubApiResult(200, {}, {}, "", True))
+
+    assert reviewer_bot.release_state_issue_lease_lock() is True
+    assert reviewer_bot.ACTIVE_LEASE_CONTEXT is None
+
+
+def test_release_lock_fails_closed_on_conflicting_token(monkeypatch):
+    context = reviewer_bot.LeaseContext(
+        lock_token="token-123",
+        lock_owner_run_id="run",
+        lock_owner_workflow="workflow",
+        lock_owner_job="job",
+        state_issue_url="https://example.com/issues/314",
+        lock_ref="refs/heads/reviewer-bot-state-lock",
+        lock_expires_at="2999-01-01T00:00:00+00:00",
+    )
+    monkeypatch.setattr(reviewer_bot, "ACTIVE_LEASE_CONTEXT", context)
+    monkeypatch.setattr(reviewer_bot, "get_lock_ref_snapshot", lambda: ("new-ref", "tree", {"lock_state": "locked", "lock_token": "other-token"}))
+
+    assert reviewer_bot.release_state_issue_lease_lock() is False
+    assert reviewer_bot.ACTIVE_LEASE_CONTEXT is None
+
+
 def test_schedule_guard_blocks_empty_active_reviews_wipe(monkeypatch):
     monkeypatch.setenv("EVENT_NAME", "schedule")
     monkeypatch.setenv("EVENT_ACTION", "")

--- a/scripts/reviewer_bot_lib/lease_lock.py
+++ b/scripts/reviewer_bot_lib/lease_lock.py
@@ -129,6 +129,22 @@ def extract_commit_sha(payload: Any) -> str | None:
     return sha if isinstance(sha, str) and sha else None
 
 
+def _snapshot_matches_expected_lock(current_lock: dict, expected_token: str) -> bool:
+    return (
+        isinstance(current_lock, dict)
+        and current_lock.get("lock_state") == "locked"
+        and current_lock.get("lock_token") == expected_token
+    )
+
+
+def _snapshot_is_stale_unlocked_predecessor(current_lock: dict) -> bool:
+    return (
+        isinstance(current_lock, dict)
+        and current_lock.get("lock_state") == "unlocked"
+        and current_lock.get("lock_token") is None
+    )
+
+
 def render_lock_commit_message(bot: LeaseLockContext, lock_meta: dict) -> str:
     lock_json = json.dumps(bot.normalize_lock_metadata(lock_meta), sort_keys=False)
     return f"{LOCK_COMMIT_MARKER}\n{lock_json}"
@@ -375,20 +391,36 @@ def acquire_state_issue_lease_lock(bot: LeaseLockContext) -> LeaseContext:
                 raise RuntimeError("Lock acquire commit response did not include commit SHA")
             update_response = bot.cas_update_lock_ref(new_commit_sha)
             if update_response.status_code == 200:
-                bot.ACTIVE_LEASE_CONTEXT = LeaseContext(
-                    lock_token=lock_token,
-                    lock_owner_run_id=lock_owner_run_id,
-                    lock_owner_workflow=lock_owner_workflow,
-                    lock_owner_job=lock_owner_job,
-                    state_issue_url=bot.get_state_issue_html_url(),
-                    lock_ref=bot.get_lock_ref_display(),
-                    lock_expires_at=desired_lock.get("lock_expires_at"),
+                snapshot_ref_sha, snapshot_tree_sha, snapshot_lock = bot.get_lock_ref_snapshot()
+                del snapshot_ref_sha, snapshot_tree_sha
+                if _snapshot_matches_expected_lock(snapshot_lock, lock_token):
+                    bot.ACTIVE_LEASE_CONTEXT = LeaseContext(
+                        lock_token=lock_token,
+                        lock_owner_run_id=lock_owner_run_id,
+                        lock_owner_workflow=lock_owner_workflow,
+                        lock_owner_job=lock_owner_job,
+                        state_issue_url=bot.get_state_issue_html_url(),
+                        lock_ref=bot.get_lock_ref_display(),
+                        lock_expires_at=desired_lock.get("lock_expires_at"),
+                    )
+                    print(
+                        "Acquired reviewer-bot lease lock "
+                        f"(run_id={lock_owner_run_id}, token_prefix={lock_token[:8]}, lock_ref={bot.get_lock_ref_display()})"
+                    )
+                    return bot.ACTIVE_LEASE_CONTEXT
+                if _snapshot_is_stale_unlocked_predecessor(snapshot_lock):
+                    print(
+                        "Lease lock acquire visibility lag detected; retrying confirmation "
+                        f"(attempt {attempt}, token_prefix={lock_token[:8]})"
+                    )
+                    delay = retry_base + random.uniform(0, retry_base)
+                    time.sleep(delay)
+                    continue
+                conflicting_token = snapshot_lock.get("lock_token") if isinstance(snapshot_lock, dict) else None
+                raise RuntimeError(
+                    "Lease lock acquire confirmed unexpected lock state after ref update "
+                    f"(expected prefix={lock_token[:8]}, got prefix={str(conflicting_token)[:8]})"
                 )
-                print(
-                    "Acquired reviewer-bot lease lock "
-                    f"(run_id={lock_owner_run_id}, token_prefix={lock_token[:8]}, lock_ref={bot.get_lock_ref_display()})"
-                )
-                return bot.ACTIVE_LEASE_CONTEXT
             if update_response.status_code in {409, 422}:
                 print(
                     "Lease lock acquire conflict "
@@ -438,6 +470,15 @@ def release_state_issue_lease_lock(bot: LeaseLockContext) -> bool:
                 break
             current_token = current_lock.get("lock_token")
             if current_token != context.lock_token:
+                if _snapshot_is_stale_unlocked_predecessor(current_lock):
+                    print(
+                        "Lease lock release observed stale unlocked predecessor; retrying "
+                        f"(attempt {attempt}, token_prefix={context.lock_token[:8]})",
+                        file=bot.sys.stderr,
+                    )
+                    delay = retry_base + random.uniform(0, retry_base)
+                    time.sleep(delay)
+                    continue
                 print(
                     "WARNING: Lease lock token mismatch during release; "
                     f"expected prefix={context.lock_token[:8]}, got prefix={str(current_token)[:8]}",


### PR DESCRIPTION
## Summary
- confirm reviewer-bot lock visibility after a successful ref update before treating acquisition as complete
- retry release when a snapshot still shows the stale unlocked predecessor state
- keep fail-closed behavior for true conflicting lock token mismatches

## What Changed
- update scripts/reviewer_bot_lib/lease_lock.py so acquire only succeeds after a fresh snapshot confirms the expected locked token-bearing state is visible
- treat stale unlocked/null-token predecessor reads during release as retryable rather than immediate hard failure
- keep hard failure when a different non-empty token is observed
- add focused regression tests for:
  - acquire visibility confirmation after a stale predecessor read
  - acquire hard-fail on conflicting visible token
  - release retry on stale unlocked predecessor
  - release hard-fail on conflicting token

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Context
- fixes the live failure mode where a fast trusted mutating workflow acquires the lock successfully but release immediately reads the previous unlocked lock-ref commit and fails with got prefix=None
