### PR TITLE
Refactor reviewer-bot comment helper wrappers

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from scripts import reviewer_bot
+from scripts.reviewer_bot_lib import comment_routing
 
 
 def make_state(epoch: str = "freshness_v15"):
@@ -79,11 +80,11 @@ def test_load_state_sets_schema_and_epoch_defaults(monkeypatch):
 def test_classify_issue_comment_actor(monkeypatch, env, expected):
     for key, value in env.items():
         monkeypatch.setenv(key, value)
-    assert reviewer_bot.classify_issue_comment_actor() == expected
+    assert comment_routing.classify_issue_comment_actor() == expected
 
 
 def test_classify_comment_payload_distinguishes_command_plus_text():
-    payload = reviewer_bot.classify_comment_payload("hello\n@guidelines-bot /queue")
+    payload = comment_routing.classify_comment_payload(reviewer_bot, "hello\n@guidelines-bot /queue")
     assert payload["comment_class"] == "command_plus_text"
     assert payload["has_non_command_text"] is True
 
@@ -104,7 +105,7 @@ def test_route_issue_comment_trust_allows_only_same_repo_repo_user_principal(mon
             "user": {"login": "carol"},
         },
     )
-    assert reviewer_bot.route_issue_comment_trust(42) == "pr_trusted_direct"
+    assert comment_routing.route_issue_comment_trust(reviewer_bot, 42) == "pr_trusted_direct"
 
 
 def test_route_issue_comment_trust_fails_closed_for_ambiguous_same_repo(monkeypatch):
@@ -124,7 +125,7 @@ def test_route_issue_comment_trust_fails_closed_for_ambiguous_same_repo(monkeypa
         },
     )
     with pytest.raises(RuntimeError, match="Ambiguous same-repo PR comment trust posture"):
-        reviewer_bot.route_issue_comment_trust(42)
+        comment_routing.route_issue_comment_trust(reviewer_bot, 42)
 
 
 def test_handle_non_pr_issue_comment_creates_pending_privileged_command(monkeypatch):

--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -786,45 +786,6 @@ def list_open_items_with_status_labels() -> list[int]:
     return reviews_module.list_open_items_with_status_labels(_runtime_bot())
 
 
-def classify_comment_payload(comment_body: str) -> dict:
-    return comment_routing_module.classify_comment_payload(_runtime_bot(), comment_body)
-
-
-def _digest_body(body: str) -> str:
-    return comment_routing_module._digest_body(body)
-
-
-def classify_issue_comment_actor() -> str:
-    return comment_routing_module.classify_issue_comment_actor()
-
-
-def route_issue_comment_trust(issue_number: int) -> str:
-    return comment_routing_module.route_issue_comment_trust(_runtime_bot(), issue_number)
-
-
-def _record_conversation_freshness(
-    state: dict,
-    issue_number: int,
-    comment_author: str,
-    comment_id: int,
-    created_at: str,
-) -> bool:
-    return comment_routing_module._record_conversation_freshness(
-        _runtime_bot(), state, issue_number, comment_author, comment_id, created_at
-    )
-
-
-def _handle_comment_command(
-    state: dict,
-    issue_number: int,
-    comment_author: str,
-    classified: dict,
-) -> bool:
-    return comment_routing_module._handle_command(
-        _runtime_bot(), state, issue_number, comment_author, classified
-    )
-
-
 def observer_run_reason_from_details(run_details: dict, runbook_signature: dict | None) -> str:
     return sweeper_module.observer_run_reason_from_details(run_details, runbook_signature)
 

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import json
 import os
 
+from .comment_routing import (
+    _digest_body,
+    _handle_command,
+    _record_conversation_freshness,
+    classify_comment_payload,
+)
 from .reviews import find_triage_approval_after, get_latest_review_by_reviewer
 
 
@@ -346,25 +352,25 @@ def handle_workflow_run_event(bot, state: dict) -> bool:
             if not isinstance(live_comment, dict):
                 changed = False
                 if source_freshness_eligible:
-                    changed = bot._record_conversation_freshness(state, pr_number, comment_author, comment_id, comment_created_at)
+                    changed = _record_conversation_freshness(bot, state, pr_number, comment_author, comment_id, comment_created_at)
                 _update_deferred_gap(bot, review_data, payload, "reconcile_failed_closed", f"Deferred comment {payload['comment_id']} is no longer visible; source-time freshness only may be preserved. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
                 return changed
             live_body = live_comment.get("body")
             if not isinstance(live_body, str):
                 raise RuntimeError("Live deferred comment body is unavailable")
-            if bot._digest_body(live_body) != payload.get("source_body_digest"):
+            if _digest_body(live_body) != payload.get("source_body_digest"):
                 changed = False
                 if source_freshness_eligible:
-                    changed = bot._record_conversation_freshness(state, pr_number, comment_author, comment_id, comment_created_at)
+                    changed = _record_conversation_freshness(bot, state, pr_number, comment_author, comment_id, comment_created_at)
                 _update_deferred_gap(bot, review_data, payload, "reconcile_failed_closed", f"Deferred comment {payload['comment_id']} body digest changed; command execution suppressed. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
                 return changed
             changed = False
             if source_freshness_eligible:
-                changed = bot._record_conversation_freshness(state, pr_number, comment_author, comment_id, comment_created_at) or changed
+                changed = _record_conversation_freshness(bot, state, pr_number, comment_author, comment_id, comment_created_at) or changed
             if classified in {"command_only", "command_plus_text"}:
-                live_classified = bot.classify_comment_payload(live_body)
+                live_classified = classify_comment_payload(bot, live_body)
                 if int(live_classified.get("command_count", 0)) == 1:
-                    changed = bot._handle_comment_command(state, pr_number, comment_author, live_classified) or changed
+                    changed = _handle_command(bot, state, pr_number, comment_author, live_classified) or changed
             _mark_reconciled_source_event(review_data, source_event_key)
             _clear_source_event_key(review_data, source_event_key)
             return changed


### PR DESCRIPTION
## Summary
- remove comment-routing helper wrappers from scripts/reviewer_bot.py
- update internal runtime consumers and tests to use comment_routing.py directly
- keep the entrypoint focused on true runtime adapter services instead of comment-domain helper passthroughs

## What Changed
- remove these comment helper wrappers from scripts/reviewer_bot.py:
  - classify_comment_payload
  - classify_issue_comment_actor
  - route_issue_comment_trust
  - _digest_body
  - _record_conversation_freshness
  - _handle_comment_command
- update scripts/reviewer_bot_lib/reconcile.py to import the needed comment helpers directly from scripts/reviewer_bot_lib/comment_routing.py
- update focused tests to import the extracted comment routing module directly where they are testing comment-domain behavior
- leave runtime behavior unchanged

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Notes
- this is the next slice of the scripts/reviewer_bot.py wrapper reduction work
- follow-up slices can remove sweeper helper wrappers next
