### PR TITLE
Refactor reviewer-bot sweeper helper wrappers

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from scripts import reviewer_bot
-from scripts.reviewer_bot_lib import comment_routing
+from scripts.reviewer_bot_lib import comment_routing, sweeper
 
 
 def make_state(epoch: str = "freshness_v15"):
@@ -451,8 +451,8 @@ def test_execute_pending_privileged_command_revalidates_live_state(monkeypatch):
 
 def test_observer_run_reason_mapping_and_near_miss_signature():
     signature = {"status": "waiting", "conclusion": None, "name": "approval_pending"}
-    assert reviewer_bot.observer_run_reason_from_details({"status": "waiting", "conclusion": None, "name": "approval_pending"}, signature) == "awaiting_observer_approval"
-    assert reviewer_bot.observer_run_reason_from_details({"status": "waiting", "conclusion": None, "name": "almost"}, signature) == "observer_state_unknown"
+    assert sweeper.observer_run_reason_from_details({"status": "waiting", "conclusion": None, "name": "approval_pending"}, signature) == "awaiting_observer_approval"
+    assert sweeper.observer_run_reason_from_details({"status": "waiting", "conclusion": None, "name": "almost"}, signature) == "observer_state_unknown"
 
 
 def test_negative_missing_run_requires_full_scan_and_recheck():
@@ -463,14 +463,14 @@ def test_negative_missing_run_requires_full_scan_and_recheck():
         "correlated_run_found": False,
         "approval_pending_evidence_retained": False,
     }
-    assert reviewer_bot.can_mark_observer_run_missing(gap) is True
+    assert sweeper.can_mark_observer_run_missing(gap) is True
     gap["later_recheck_complete"] = False
-    assert reviewer_bot.can_mark_observer_run_missing(gap) is False
+    assert sweeper.can_mark_observer_run_missing(gap) is False
 
 
 def test_stage_a_candidate_run_correlation_is_exact_to_workflow_event_pr_and_window():
     os.environ["GITHUB_REPOSITORY"] = "rustfoundation/safety-critical-rust-coding-guidelines"
-    result = reviewer_bot.correlate_candidate_observer_runs(
+    result = sweeper.correlate_candidate_observer_runs(
         "issue_comment:101",
         source_event_kind="issue_comment:created",
         source_event_created_at="2026-03-17T10:00:00Z",
@@ -499,7 +499,7 @@ def test_stage_a_candidate_run_correlation_is_exact_to_workflow_event_pr_and_win
 
 
 def test_stage_b_artifact_correlation_rejects_ambiguous_exact_matches():
-    result = reviewer_bot.correlate_run_artifacts_exact(
+    result = sweeper.correlate_run_artifacts_exact(
         {
             10: [{"source_event_key": "issue_comment:101", "source_run_id": 10, "source_run_attempt": 1, "pr_number": 42}],
             11: [{"source_event_key": "issue_comment:101", "source_run_id": 11, "source_run_attempt": 1, "pr_number": 42}],
@@ -512,7 +512,7 @@ def test_stage_b_artifact_correlation_rejects_ambiguous_exact_matches():
 
 
 def test_evaluate_gap_state_only_emits_missing_after_negative_inference_contract():
-    reason, diagnostic = reviewer_bot.evaluate_deferred_gap_state(
+    reason, diagnostic = sweeper.evaluate_deferred_gap_state(
         {
             "source_event_created_at": "2026-03-15T00:00:00Z",
             "full_scan_complete": True,
@@ -534,7 +534,7 @@ def test_evaluate_gap_state_only_emits_missing_after_negative_inference_contract
 
 
 def test_evaluate_gap_state_completed_success_without_exact_artifact_is_artifact_missing():
-    reason, diagnostic = reviewer_bot.evaluate_deferred_gap_state(
+    reason, diagnostic = sweeper.evaluate_deferred_gap_state(
         {"source_event_created_at": "2026-03-17T00:00:00Z"},
         {"status": "candidate_runs_found", "correlated_run": 10},
         {"status": "completed", "conclusion": "success"},
@@ -545,7 +545,7 @@ def test_evaluate_gap_state_completed_success_without_exact_artifact_is_artifact
 
 
 def test_evaluate_gap_state_completed_success_with_expired_artifact_marks_artifact_expired():
-    reason, diagnostic = reviewer_bot.evaluate_deferred_gap_state(
+    reason, diagnostic = sweeper.evaluate_deferred_gap_state(
         {"source_event_created_at": "2026-03-17T00:00:00Z"},
         {"status": "candidate_runs_found", "correlated_run": 10},
         {"status": "completed", "conclusion": "success"},
@@ -560,12 +560,12 @@ def test_artifact_gap_reason_requires_prior_visibility_or_documented_retention()
         "artifact_seen_at": "2026-03-10T00:00:00Z",
         "run_created_at": "2026-03-10T00:00:00Z",
     }
-    assert reviewer_bot.classify_artifact_gap_reason(expired) == "artifact_expired"
+    assert sweeper.classify_artifact_gap_reason(expired) == "artifact_expired"
     missing = {
         "artifact_inspection_complete": True,
         "run_created_at": "2026-03-17T00:00:00Z",
     }
-    assert reviewer_bot.classify_artifact_gap_reason(missing) == "artifact_missing"
+    assert sweeper.classify_artifact_gap_reason(missing) == "artifact_missing"
 
 
 def test_sweeper_creates_keyed_deferred_gaps_only_for_visible_comments_and_submitted_reviews(monkeypatch):
@@ -586,7 +586,7 @@ def test_sweeper_creates_keyed_deferred_gaps_only_for_visible_comments_and_submi
         "get_pull_request_reviews",
         lambda issue_number: [{"id": 202, "submitted_at": "2026-03-17T11:00:00Z", "state": "APPROVED"}],
     )
-    assert reviewer_bot.sweep_deferred_gaps(state) is True
+    assert sweeper.sweep_deferred_gaps(reviewer_bot, state) is True
     gaps = state["active_reviews"]["42"]["deferred_gaps"]
     assert "issue_comment:101" in gaps
     assert "pull_request_review:202" in gaps
@@ -608,7 +608,7 @@ def test_sweeper_skips_events_already_reconciled_by_source_event_key(monkeypatch
         }.get(endpoint),
     )
     monkeypatch.setattr(reviewer_bot, "get_pull_request_reviews", lambda issue_number: [{"id": 202, "submitted_at": "2026-03-17T11:00:00Z", "state": "APPROVED"}])
-    assert reviewer_bot.sweep_deferred_gaps(state) is False
+    assert sweeper.sweep_deferred_gaps(reviewer_bot, state) is False
     assert state["active_reviews"]["42"]["deferred_gaps"] == {}
 
 

--- a/scripts/reviewer_bot.py
+++ b/scripts/reviewer_bot.py
@@ -74,7 +74,6 @@ try:
     import scripts.reviewer_bot_lib.reconcile as reconcile_module
     import scripts.reviewer_bot_lib.reviews as reviews_module
     import scripts.reviewer_bot_lib.state_store as state_store_module
-    import scripts.reviewer_bot_lib.sweeper as sweeper_module
     from scripts.reviewer_bot_lib import app as app_module
     from scripts.reviewer_bot_lib.config import (  # noqa: F401
         AUTHOR_ASSOCIATION_TRUST_ALLOWLIST,
@@ -165,7 +164,6 @@ except ImportError:
     import reviewer_bot_lib.reconcile as reconcile_module
     import reviewer_bot_lib.reviews as reviews_module
     import reviewer_bot_lib.state_store as state_store_module
-    import reviewer_bot_lib.sweeper as sweeper_module
     from reviewer_bot_lib.config import (  # noqa: F401
         AUTHOR_ASSOCIATION_TRUST_ALLOWLIST,
         BOT_MENTION,
@@ -784,63 +782,6 @@ def sync_status_labels_for_items(state: dict, issue_numbers: Iterable[int]) -> b
 
 def list_open_items_with_status_labels() -> list[int]:
     return reviews_module.list_open_items_with_status_labels(_runtime_bot())
-
-
-def observer_run_reason_from_details(run_details: dict, runbook_signature: dict | None) -> str:
-    return sweeper_module.observer_run_reason_from_details(run_details, runbook_signature)
-
-
-def can_mark_observer_run_missing(gap: dict, now: datetime | None = None) -> bool:
-    return sweeper_module.can_mark_observer_run_missing(gap, now)
-
-
-def classify_artifact_gap_reason(gap: dict, now: datetime | None = None) -> str:
-    return sweeper_module.classify_artifact_gap_reason(gap, now)
-
-
-def sweep_deferred_gaps(state: dict) -> bool:
-    return sweeper_module.sweep_deferred_gaps(_runtime_bot(), state)
-
-
-def correlate_candidate_observer_runs(
-    source_event_key: str,
-    *,
-    source_event_kind: str,
-    source_event_created_at: str,
-    pr_number: int,
-    workflow_file: str,
-    workflow_runs: list[dict] | None,
-) -> dict:
-    return sweeper_module.correlate_candidate_observer_runs(
-        source_event_key,
-        source_event_kind=source_event_kind,
-        source_event_created_at=source_event_created_at,
-        pr_number=pr_number,
-        workflow_file=workflow_file,
-        workflow_runs=workflow_runs,
-    )
-
-
-def correlate_run_artifacts_exact(
-    payloads_by_run: dict[int, list[dict]] | None,
-    source_event_key: str,
-    *,
-    pr_number: int,
-) -> dict:
-    return sweeper_module.correlate_run_artifacts_exact(
-        payloads_by_run,
-        source_event_key,
-        pr_number=pr_number,
-    )
-
-
-def evaluate_deferred_gap_state(
-    existing_gap: dict,
-    run_correlation: dict,
-    run_detail: dict | None,
-    artifact_correlation: dict | None,
-) -> tuple[str, str]:
-    return sweeper_module.evaluate_deferred_gap_state(existing_gap, run_correlation, run_detail, artifact_correlation)
 
 
 def reconcile_active_review_entry(


### PR DESCRIPTION
## Summary
- remove sweeper-domain helper wrappers from scripts/reviewer_bot.py
- update tests to import sweeper.py directly for sweeper-domain behavior
- keep the entrypoint focused on true runtime adapter services instead of sweeper helper passthroughs

## What Changed
- remove these sweeper helper wrappers from scripts/reviewer_bot.py:
  - observer_run_reason_from_details
  - can_mark_observer_run_missing
  - classify_artifact_gap_reason
  - sweep_deferred_gaps
  - correlate_candidate_observer_runs
  - correlate_run_artifacts_exact
  - evaluate_deferred_gap_state
- update focused tests to import scripts.reviewer_bot_lib.sweeper directly where they are testing sweeper-domain behavior
- remove the now-unused sweeper module import from the entrypoint
- leave runtime behavior unchanged

## Validation
- uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py

## Notes
- this is the next slice of the scripts/reviewer_bot.py wrapper reduction work
- follow-up slices can target the remaining reconcile helper wrapper and final adapter cleanup
