### PR TITLE
Refactor reviewer-bot console entrypoint invocation

### DIFF
--- a/.github/workflows/reviewer-bot-issue-comment-direct.yml
+++ b/.github/workflows/reviewer-bot-issue-comment-direct.yml
@@ -75,4 +75,4 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-issue-comment-direct.yml
-        run: uv run python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"
+        run: uv run --project "$BOT_SRC_ROOT" reviewer-bot

--- a/.github/workflows/reviewer-bot-issues.yml
+++ b/.github/workflows/reviewer-bot-issues.yml
@@ -71,4 +71,4 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-issues.yml
-        run: uv run python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"
+        run: uv run --project "$BOT_SRC_ROOT" reviewer-bot

--- a/.github/workflows/reviewer-bot-pr-comment-trusted.yml
+++ b/.github/workflows/reviewer-bot-pr-comment-trusted.yml
@@ -75,4 +75,4 @@ jobs:
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-pr-comment-trusted.yml
           REVIEWER_BOT_TRUST_CLASS: pr_trusted_direct
-        run: uv run python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"
+        run: uv run --project "$BOT_SRC_ROOT" reviewer-bot

--- a/.github/workflows/reviewer-bot-pr-metadata.yml
+++ b/.github/workflows/reviewer-bot-pr-metadata.yml
@@ -62,4 +62,4 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-pr-metadata.yml
-        run: uv run python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"
+        run: uv run --project "$BOT_SRC_ROOT" reviewer-bot

--- a/.github/workflows/reviewer-bot-privileged-commands.yml
+++ b/.github/workflows/reviewer-bot-privileged-commands.yml
@@ -52,4 +52,4 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-privileged-commands.yml
-        run: uv run python scripts/reviewer_bot.py
+        run: uv run reviewer-bot

--- a/.github/workflows/reviewer-bot-reconcile.yml
+++ b/.github/workflows/reviewer-bot-reconcile.yml
@@ -85,7 +85,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-reconcile.yml
-        run: uv run python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"
+        run: uv run --project "$BOT_SRC_ROOT" reviewer-bot
       - name: Workflow summary
         run: |
           {

--- a/.github/workflows/reviewer-bot-sweeper-repair.yml
+++ b/.github/workflows/reviewer-bot-sweeper-repair.yml
@@ -69,7 +69,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-sweeper-repair.yml
-        run: uv run python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"
+        run: uv run --project "$BOT_SRC_ROOT" reviewer-bot
       - name: Workflow summary
         run: |
           {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "pyyaml>=6.0.1",
 ]
 
+[project.scripts]
+reviewer-bot = "scripts.reviewer_bot:main"
+
 [tool.uv.workspace]
 members = ["builder", "exts"]
 


### PR DESCRIPTION
## Summary
- add a real reviewer-bot console entry point to the packaged project
- standardize reviewer-bot workflow invocation on the console entry point instead of executing the script by file path
- establish the canonical invocation model needed for later bootstrap and fallback cleanup

## What Changed
- add a `reviewer-bot = "scripts.reviewer_bot:main"` console entry point in `pyproject.toml`
- update reviewer-bot workflows to run the bot through the packaged entry point:
  - `uv run --project "$BOT_SRC_ROOT" reviewer-bot` for tarball-based trusted runs
  - `uv run reviewer-bot` for the checked-out privileged workflow
- leave reviewer-bot behavior unchanged

## Validation
- `uv run python -m pytest .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py`
- `uv run ruff check --fix scripts .github/reviewer-bot-tests/test_main.py .github/reviewer-bot-tests/test_reviewer_bot.py`
- `uv run python -c "import importlib.metadata as m; print(next(ep.value for ep in m.entry_points(group='console_scripts') if ep.name == 'reviewer-bot'))"`

## Notes
- this is PR 1 of the console-entrypoint cleanup sequence
- follow-up work can remove the dual import fallback and further shrink `scripts/reviewer_bot.py`
