### PR TITLE
fix(reviewer-bot): gate trusted PR comments to same-repo PRs

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -653,6 +653,21 @@ def test_workflow_summaries_and_runbook_references_exist():
     assert "docs/reviewer-bot-review-freshness-operator-runbook.md" in reconcile
 
 
+def test_trusted_pr_comment_workflow_preflights_same_repo_before_mutation():
+    data = yaml.safe_load(Path(".github/workflows/reviewer-bot-pr-comment-trusted.yml").read_text(encoding="utf-8"))
+    job = data["jobs"]["reviewer-bot-pr-comment-trusted"]
+    steps = job["steps"]
+    assert steps[0]["name"] == "Decide whether same-repo trusted path applies"
+    assert steps[1]["if"] == "env.RUN_TRUSTED_PR_COMMENT == 'true'"
+    assert steps[2]["if"] == "env.RUN_TRUSTED_PR_COMMENT == 'true'"
+    assert steps[3]["if"] == "env.RUN_TRUSTED_PR_COMMENT == 'true'"
+    assert steps[4]["name"] == "Trusted path skipped"
+    assert steps[4]["if"] == "env.RUN_TRUSTED_PR_COMMENT != 'true'"
+    workflow_text = Path(".github/workflows/reviewer-bot-pr-comment-trusted.yml").read_text(encoding="utf-8")
+    assert "https://api.github.com/repos/{repo}/pulls/{pr_number}" in workflow_text
+    assert "RUN_TRUSTED_PR_COMMENT" in workflow_text
+
+
 def test_classify_event_intent_treats_supported_workflow_run_sources_as_mutating(monkeypatch):
     monkeypatch.setenv("WORKFLOW_RUN_EVENT", "issue_comment")
     assert reviewer_bot.classify_event_intent("workflow_run", "completed") == reviewer_bot.EVENT_INTENT_MUTATING

--- a/.github/workflows/reviewer-bot-pr-comment-trusted.yml
+++ b/.github/workflows/reviewer-bot-pr-comment-trusted.yml
@@ -27,9 +27,49 @@ jobs:
       pull-requests: write
       actions: read
     steps:
+      - name: Decide whether same-repo trusted path applies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          pr_number = os.environ['PR_NUMBER']
+          repo = os.environ['GITHUB_REPOSITORY']
+          req = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
+              headers={
+                  'Authorization': f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  'Accept': 'application/vnd.github+json',
+              },
+          )
+          with urllib.request.urlopen(req) as response:
+              pull_request = json.load(response)
+
+          head_repo = pull_request.get('head', {}).get('repo') or {}
+          head_full_name = str(head_repo.get('full_name') or '').strip()
+          pr_author = str(pull_request.get('user', {}).get('login') or '').strip()
+          is_same_repo = head_full_name == repo
+          is_dependabot_restricted = pr_author == 'dependabot[bot]'
+          run_trusted_path = is_same_repo and not is_dependabot_restricted
+          with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as handle:
+              print(f"RUN_TRUSTED_PR_COMMENT={str(run_trusted_path).lower()}", file=handle)
+          if run_trusted_path:
+              print(f"Trusted same-repo PR comment path enabled for PR #{pr_number}.")
+          else:
+              reason = 'cross-repo' if not is_same_repo else 'restricted-author'
+              print(
+                  f"Skipping trusted same-repo PR comment path for PR #{pr_number}: {reason}."
+              )
+          PY
       - name: Install uv
+        if: env.RUN_TRUSTED_PR_COMMENT == 'true'
         run: python -m pip install uv
       - name: Fetch trusted bot source tarball
+        if: env.RUN_TRUSTED_PR_COMMENT == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -50,6 +90,7 @@ jobs:
           print(f'BOT_SRC_ROOT={roots[0]}', file=open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8'))
           PY
       - name: Run reviewer bot
+        if: env.RUN_TRUSTED_PR_COMMENT == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: issue_comment
@@ -76,3 +117,7 @@ jobs:
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-pr-comment-trusted.yml
           REVIEWER_BOT_TRUST_CLASS: pr_trusted_direct
         run: uv run --project "$BOT_SRC_ROOT" reviewer-bot
+      - name: Trusted path skipped
+        if: env.RUN_TRUSTED_PR_COMMENT != 'true'
+        run: |
+          echo 'Trusted same-repo PR comment workflow skipped after PR metadata preflight.'


### PR DESCRIPTION
## Summary
- add a PR metadata preflight to the trusted PR comment workflow so fork PR comments skip the same-repo direct mutation path cleanly
- gate all mutating trusted-comment steps on the preflight result and leave the workflow green when the comment belongs to a cross-repo or restricted PR
- add a workflow policy test covering the new same-repo preflight contract

## Testing
- uv run ruff check --fix .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py