### PR TITLE
fix(reviewer-bot): restore PR context in deferred comment reconcile

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -388,10 +388,157 @@ def test_deferred_comment_missing_live_object_preserves_source_time_freshness(tm
     monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ID", "501")
     monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ATTEMPT", "1")
     monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_CONCLUSION", "success")
-    monkeypatch.setattr(reviewer_bot, "github_api", lambda method, endpoint, data=None: None)
+    monkeypatch.setattr(
+        reviewer_bot,
+        "github_api",
+        lambda method, endpoint, data=None: (
+            {"user": {"login": "dana"}, "labels": []} if endpoint == "pulls/42" else None
+        ),
+    )
     assert reviewer_bot.handle_workflow_run_event(state) is True
     assert state["active_reviews"]["42"]["reviewer_comment"]["accepted"]["semantic_key"] == "issue_comment:99"
     assert state["active_reviews"]["42"]["deferred_gaps"]["issue_comment:99"]["reason"] == "reconcile_failed_closed"
+
+
+def test_deferred_comment_reconcile_hydrates_pr_author_context_for_contributor_freshness(tmp_path, monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    payload_path = tmp_path / "deferred-comment.json"
+    live_body = "reviewer-bot validation: contributor plain text comment"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "source_workflow_name": "Reviewer Bot PR Comment Observer",
+                "source_workflow_file": ".github/workflows/reviewer-bot-pr-comment-observer.yml",
+                "source_run_id": 601,
+                "source_run_attempt": 1,
+                "source_event_name": "issue_comment",
+                "source_event_action": "created",
+                "source_event_key": "issue_comment:199",
+                "pr_number": 42,
+                "comment_id": 199,
+                "comment_class": "plain_text",
+                "has_non_command_text": True,
+                "source_body_digest": comment_routing._digest_body(live_body),
+                "source_created_at": "2026-03-17T10:00:00Z",
+                "actor_login": "dana",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEFERRED_CONTEXT_PATH", str(payload_path))
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_NAME", "Reviewer Bot PR Comment Observer")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ID", "601")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ATTEMPT", "1")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_CONCLUSION", "success")
+
+    def fake_github_api(method, endpoint, data=None):
+        if endpoint == "pulls/42":
+            return {"user": {"login": "dana"}, "labels": [{"name": "coding guideline"}]}
+        if endpoint == "issues/comments/199":
+            return {
+                "body": live_body,
+                "user": {"login": "dana", "type": "User"},
+                "author_association": "CONTRIBUTOR",
+                "performed_via_github_app": None,
+            }
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(reviewer_bot, "github_api", fake_github_api)
+    assert reviewer_bot.handle_workflow_run_event(state) is True
+    assert state["active_reviews"]["42"]["contributor_comment"]["accepted"]["semantic_key"] == "issue_comment:199"
+    assert state["active_reviews"]["42"]["reviewer_comment"]["accepted"] is None
+    assert os.environ["IS_PULL_REQUEST"] == "true"
+    assert os.environ["ISSUE_AUTHOR"] == "dana"
+    assert json.loads(os.environ["ISSUE_LABELS"]) == ["coding guideline"]
+
+
+def test_deferred_comment_reconcile_uses_pr_assignment_semantics_for_claim(tmp_path, monkeypatch):
+    state = make_state()
+    state["queue"] = [{"github": "bob", "name": "Bob"}]
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    payload_path = tmp_path / "deferred-command.json"
+    live_body = "@guidelines-bot /claim"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "source_workflow_name": "Reviewer Bot PR Comment Observer",
+                "source_workflow_file": ".github/workflows/reviewer-bot-pr-comment-observer.yml",
+                "source_run_id": 602,
+                "source_run_attempt": 1,
+                "source_event_name": "issue_comment",
+                "source_event_action": "created",
+                "source_event_key": "issue_comment:200",
+                "pr_number": 42,
+                "comment_id": 200,
+                "comment_class": "command_only",
+                "has_non_command_text": False,
+                "source_body_digest": comment_routing._digest_body(live_body),
+                "source_created_at": "2026-03-17T10:00:00Z",
+                "actor_login": "bob",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEFERRED_CONTEXT_PATH", str(payload_path))
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_NAME", "Reviewer Bot PR Comment Observer")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ID", "602")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ATTEMPT", "1")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_CONCLUSION", "success")
+    assignment_calls = []
+    removed_reviewers = []
+    posted_comments = []
+
+    def fake_github_api(method, endpoint, data=None):
+        if endpoint == "pulls/42":
+            return {
+                "user": {"login": "dana"},
+                "labels": [{"name": "coding guideline"}],
+                "requested_reviewers": [{"login": "alice"}],
+            }
+        if endpoint == "issues/comments/200":
+            return {
+                "body": live_body,
+                "user": {"login": "bob", "type": "User"},
+                "author_association": "MEMBER",
+                "performed_via_github_app": None,
+            }
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    def fake_request(issue_number, username):
+        assignment_calls.append(
+            {
+                "issue_number": issue_number,
+                "username": username,
+                "is_pull_request": os.environ.get("IS_PULL_REQUEST"),
+                "issue_author": os.environ.get("ISSUE_AUTHOR"),
+            }
+        )
+        return reviewer_bot.AssignmentAttempt(success=True, status_code=201)
+
+    monkeypatch.setattr(reviewer_bot, "github_api", fake_github_api)
+    monkeypatch.setattr(reviewer_bot, "request_reviewer_assignment", fake_request)
+    monkeypatch.setattr(reviewer_bot, "unassign_reviewer", lambda issue_number, username: removed_reviewers.append((issue_number, username)) or True)
+    monkeypatch.setattr(reviewer_bot, "post_comment", lambda issue_number, body: posted_comments.append((issue_number, body)) or True)
+    monkeypatch.setattr(reviewer_bot, "add_reaction", lambda *args, **kwargs: True)
+    assert reviewer_bot.handle_workflow_run_event(state) is True
+    assert assignment_calls == [
+        {
+            "issue_number": 42,
+            "username": "bob",
+            "is_pull_request": "true",
+            "issue_author": "dana",
+        }
+    ]
+    assert removed_reviewers == [(42, "alice")]
+    assert state["active_reviews"]["42"]["current_reviewer"] == "bob"
+    assert posted_comments
 
 
 def test_observer_noop_payload_is_safe_noop(tmp_path, monkeypatch):

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -188,6 +188,64 @@ def _load_deferred_context() -> dict:
     return payload
 
 
+def _set_env_if_present(name: str, value) -> None:
+    if value is None:
+        return
+    os.environ[name] = str(value)
+
+
+def _hydrate_reconcile_pr_context(bot, pr_number: int) -> dict:
+    pull_request = bot.github_api("GET", f"pulls/{pr_number}")
+    if not isinstance(pull_request, dict):
+        raise RuntimeError(f"Failed to fetch live PR #{pr_number} for reconcile context")
+    author = pull_request.get("user")
+    if not isinstance(author, dict):
+        raise RuntimeError(f"Live PR #{pr_number} is missing author metadata")
+    author_login = author.get("login")
+    if not isinstance(author_login, str) or not author_login.strip():
+        raise RuntimeError(f"Live PR #{pr_number} is missing a valid author login")
+    labels = pull_request.get("labels")
+    if labels is None:
+        labels = []
+    if not isinstance(labels, list):
+        raise RuntimeError(f"Live PR #{pr_number} labels are malformed")
+    label_names: list[str] = []
+    for label in labels:
+        if not isinstance(label, dict):
+            raise RuntimeError(f"Live PR #{pr_number} contains malformed label metadata")
+        name = label.get("name")
+        if not isinstance(name, str):
+            raise RuntimeError(f"Live PR #{pr_number} contains a label without a valid name")
+        label_names.append(name)
+    os.environ["IS_PULL_REQUEST"] = "true"
+    os.environ["ISSUE_AUTHOR"] = author_login
+    os.environ["ISSUE_LABELS"] = json.dumps(label_names)
+    return pull_request
+
+
+def _hydrate_reconcile_comment_context(live_comment: dict, payload: dict) -> None:
+    user = live_comment.get("user")
+    if not isinstance(user, dict):
+        raise RuntimeError("Live deferred comment user metadata is unavailable")
+    comment_author = user.get("login") or payload.get("actor_login") or ""
+    if not isinstance(comment_author, str) or not comment_author.strip():
+        raise RuntimeError("Live deferred comment author login is unavailable")
+    comment_user_type = user.get("type")
+    if not isinstance(comment_user_type, str) or not comment_user_type.strip():
+        raise RuntimeError("Live deferred comment user type is unavailable")
+    author_association = live_comment.get("author_association")
+    if not isinstance(author_association, str) or not author_association.strip():
+        raise RuntimeError("Live deferred comment author association is unavailable")
+    _set_env_if_present("COMMENT_AUTHOR", comment_author)
+    _set_env_if_present("COMMENT_ID", payload.get("comment_id"))
+    _set_env_if_present("COMMENT_CREATED_AT", payload.get("source_created_at"))
+    _set_env_if_present("COMMENT_USER_TYPE", comment_user_type)
+    _set_env_if_present("COMMENT_AUTHOR_ASSOCIATION", author_association)
+    _set_env_if_present("COMMENT_SENDER_TYPE", comment_user_type)
+    os.environ["COMMENT_INSTALLATION_ID"] = ""
+    os.environ["COMMENT_PERFORMED_VIA_GITHUB_APP"] = "true" if live_comment.get("performed_via_github_app") else "false"
+
+
 def _validate_observer_noop_payload(payload: dict) -> None:
     required = {
         "schema_version",
@@ -338,6 +396,7 @@ def handle_workflow_run_event(bot, state: dict) -> bool:
         if event_name == "issue_comment":
             _validate_deferred_comment_artifact(payload)
             _validate_workflow_run_artifact_identity(payload)
+            _hydrate_reconcile_pr_context(bot, pr_number)
             if source_event_key != f"issue_comment:{payload['comment_id']}":
                 raise RuntimeError("Deferred comment artifact source_event_key mismatch")
             comment_author = str(payload.get("actor_login", ""))
@@ -355,6 +414,7 @@ def handle_workflow_run_event(bot, state: dict) -> bool:
                     changed = _record_conversation_freshness(bot, state, pr_number, comment_author, comment_id, comment_created_at)
                 _update_deferred_gap(bot, review_data, payload, "reconcile_failed_closed", f"Deferred comment {payload['comment_id']} is no longer visible; source-time freshness only may be preserved. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.")
                 return changed
+            _hydrate_reconcile_comment_context(live_comment, payload)
             live_body = live_comment.get("body")
             if not isinstance(live_body, str):
                 raise RuntimeError("Live deferred comment body is unavailable")


### PR DESCRIPTION
## Summary
- hydrate live PR context during deferred PR comment reconcile so contributor freshness and command replay run with PR semantics instead of issue semantics
- hydrate live comment actor metadata before replaying deferred commands so trusted human comments on fork PRs can classify and execute correctly
- add targeted tests covering contributor freshness hydration and PR-style `/claim` replay in the deferred comment path

## Testing
- uv run ruff check --fix scripts/reviewer_bot_lib/reconcile.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py