### PR TITLE
fix(reviewer-bot): fail closed on incomplete deferred comment replay

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -541,6 +541,146 @@ def test_deferred_comment_reconcile_uses_pr_assignment_semantics_for_claim(tmp_p
     assert posted_comments
 
 
+def test_deferred_comment_reconcile_fails_closed_when_command_replay_is_ambiguous(tmp_path, monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    payload_path = tmp_path / "deferred-command.json"
+    live_body = "@guidelines-bot /claim"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "source_workflow_name": "Reviewer Bot PR Comment Observer",
+                "source_workflow_file": ".github/workflows/reviewer-bot-pr-comment-observer.yml",
+                "source_run_id": 603,
+                "source_run_attempt": 1,
+                "source_event_name": "issue_comment",
+                "source_event_action": "created",
+                "source_event_key": "issue_comment:201",
+                "pr_number": 42,
+                "comment_id": 201,
+                "comment_class": "command_only",
+                "has_non_command_text": False,
+                "source_body_digest": comment_routing._digest_body(live_body),
+                "source_created_at": "2026-03-17T10:00:00Z",
+                "actor_login": "bob",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEFERRED_CONTEXT_PATH", str(payload_path))
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_NAME", "Reviewer Bot PR Comment Observer")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ID", "603")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ATTEMPT", "1")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_CONCLUSION", "success")
+
+    def fake_github_api(method, endpoint, data=None):
+        if endpoint == "pulls/42":
+            return {"user": {"login": "dana"}, "labels": []}
+        if endpoint == "issues/comments/201":
+            return {
+                "body": live_body,
+                "user": {"login": "bob", "type": "User"},
+                "author_association": "MEMBER",
+                "performed_via_github_app": None,
+            }
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(reviewer_bot, "github_api", fake_github_api)
+    monkeypatch.setattr(
+        reviewer_bot.reconcile_module,
+        "classify_comment_payload",
+        lambda bot, body: {
+            "comment_class": "command_only",
+            "has_non_command_text": False,
+            "command_count": 2,
+            "command": None,
+            "args": [],
+            "normalized_body": body,
+        },
+    )
+    command_calls = []
+    monkeypatch.setattr(
+        reviewer_bot.reconcile_module,
+        "_handle_command",
+        lambda *args, **kwargs: command_calls.append("called") or True,
+    )
+
+    assert reviewer_bot.handle_workflow_run_event(state) is False
+    assert command_calls == []
+    assert state["active_reviews"]["42"]["deferred_gaps"]["issue_comment:201"]["reason"] == "reconcile_failed_closed"
+    assert "issue_comment:201" not in state["active_reviews"]["42"]["reconciled_source_events"]
+
+
+def test_deferred_comment_reconcile_fails_closed_when_comment_classification_drifts(tmp_path, monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    payload_path = tmp_path / "deferred-comment.json"
+    live_body = "reviewer-bot validation: contributor plain text comment"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "source_workflow_name": "Reviewer Bot PR Comment Observer",
+                "source_workflow_file": ".github/workflows/reviewer-bot-pr-comment-observer.yml",
+                "source_run_id": 604,
+                "source_run_attempt": 1,
+                "source_event_name": "issue_comment",
+                "source_event_action": "created",
+                "source_event_key": "issue_comment:202",
+                "pr_number": 42,
+                "comment_id": 202,
+                "comment_class": "plain_text",
+                "has_non_command_text": True,
+                "source_body_digest": comment_routing._digest_body(live_body),
+                "source_created_at": "2026-03-17T10:00:00Z",
+                "actor_login": "dana",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEFERRED_CONTEXT_PATH", str(payload_path))
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_NAME", "Reviewer Bot PR Comment Observer")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ID", "604")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_ATTEMPT", "1")
+    monkeypatch.setenv("WORKFLOW_RUN_TRIGGERING_CONCLUSION", "success")
+
+    def fake_github_api(method, endpoint, data=None):
+        if endpoint == "pulls/42":
+            return {"user": {"login": "dana"}, "labels": []}
+        if endpoint == "issues/comments/202":
+            return {
+                "body": live_body,
+                "user": {"login": "dana", "type": "User"},
+                "author_association": "CONTRIBUTOR",
+                "performed_via_github_app": None,
+            }
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(reviewer_bot, "github_api", fake_github_api)
+    monkeypatch.setattr(
+        reviewer_bot.reconcile_module,
+        "classify_comment_payload",
+        lambda bot, body: {
+            "comment_class": "command_plus_text",
+            "has_non_command_text": True,
+            "command_count": 1,
+            "command": "claim",
+            "args": [],
+            "normalized_body": body,
+        },
+    )
+
+    assert reviewer_bot.handle_workflow_run_event(state) is True
+    assert state["active_reviews"]["42"]["contributor_comment"]["accepted"]["semantic_key"] == "issue_comment:202"
+    assert state["active_reviews"]["42"]["deferred_gaps"]["issue_comment:202"]["reason"] == "reconcile_failed_closed"
+    assert "issue_comment:202" not in state["active_reviews"]["42"]["reconciled_source_events"]
+
+
 def test_observer_noop_payload_is_safe_noop(tmp_path, monkeypatch):
     state = make_state()
     reviewer_bot.ensure_review_entry(state, 42, create=True)

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -367,6 +367,56 @@ def _update_deferred_gap(bot, review_data: dict, payload: dict, reason: str, dia
     review_data["deferred_gaps"][source_event_key] = existing
 
 
+def _validate_live_comment_replay_contract(bot, review_data: dict, payload: dict, live_body: str) -> dict | None:
+    source_comment_class = str(payload.get("comment_class", ""))
+    live_classified = classify_comment_payload(bot, live_body)
+    live_comment_class = str(live_classified.get("comment_class", ""))
+    source_has_non_command_text = bool(payload.get("has_non_command_text"))
+    live_has_non_command_text = bool(live_classified.get("has_non_command_text"))
+
+    if live_comment_class != source_comment_class:
+        _update_deferred_gap(
+            bot,
+            review_data,
+            payload,
+            "reconcile_failed_closed",
+            (
+                f"Deferred comment {payload['comment_id']} classification changed from "
+                f"{source_comment_class} to {live_comment_class}; replay suppressed. "
+                f"See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}."
+            ),
+        )
+        return None
+
+    if live_has_non_command_text != source_has_non_command_text:
+        _update_deferred_gap(
+            bot,
+            review_data,
+            payload,
+            "reconcile_failed_closed",
+            (
+                f"Deferred comment {payload['comment_id']} non-command text classification drifted; "
+                f"replay suppressed. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}."
+            ),
+        )
+        return None
+
+    if source_comment_class in {"command_only", "command_plus_text"} and int(live_classified.get("command_count", 0)) != 1:
+        _update_deferred_gap(
+            bot,
+            review_data,
+            payload,
+            "reconcile_failed_closed",
+            (
+                f"Deferred comment {payload['comment_id']} no longer resolves to exactly one command; "
+                f"replay suppressed. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}."
+            ),
+        )
+        return None
+
+    return live_classified
+
+
 def handle_workflow_run_event(bot, state: dict) -> bool:
     bot.assert_lock_held("handle_workflow_run_event")
     if str(state.get("freshness_runtime_epoch", "")).strip() != "freshness_v15":
@@ -427,10 +477,11 @@ def handle_workflow_run_event(bot, state: dict) -> bool:
             changed = False
             if source_freshness_eligible:
                 changed = _record_conversation_freshness(bot, state, pr_number, comment_author, comment_id, comment_created_at) or changed
+            live_classified = _validate_live_comment_replay_contract(bot, review_data, payload, live_body)
+            if live_classified is None:
+                return changed
             if classified in {"command_only", "command_plus_text"}:
-                live_classified = classify_comment_payload(bot, live_body)
-                if int(live_classified.get("command_count", 0)) == 1:
-                    changed = _handle_command(bot, state, pr_number, comment_author, live_classified) or changed
+                changed = _handle_command(bot, state, pr_number, comment_author, live_classified) or changed
             _mark_reconciled_source_event(review_data, source_event_key)
             _clear_source_event_key(review_data, source_event_key)
             return changed


### PR DESCRIPTION
## Summary
- validate deferred PR comment replay before marking events reconciled so classification drift and ambiguous command parsing become explicit fail-closed deferred gaps
- preserve source-time freshness updates when safe, but suppress command replay when the live comment no longer satisfies the original replay contract
- add targeted tests covering ambiguous command replay and comment-classification drift in deferred reconcile

## Testing
- uv run ruff check --fix scripts/reviewer_bot_lib/reconcile.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py