### PR TITLE
fix(reviewer-bot): surface dismissed review gaps

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -855,7 +855,7 @@ def test_artifact_gap_reason_requires_prior_visibility_or_documented_retention()
     assert sweeper.classify_artifact_gap_reason(missing) == "artifact_missing"
 
 
-def test_sweeper_creates_keyed_deferred_gaps_only_for_visible_comments_and_submitted_reviews(monkeypatch):
+def test_sweeper_creates_keyed_deferred_gaps_for_visible_comments_reviews_and_dismissals(monkeypatch):
     state = make_state()
     review = reviewer_bot.ensure_review_entry(state, 42, create=True)
     assert review is not None
@@ -871,13 +871,42 @@ def test_sweeper_creates_keyed_deferred_gaps_only_for_visible_comments_and_submi
     monkeypatch.setattr(
         reviewer_bot,
         "get_pull_request_reviews",
-        lambda issue_number: [{"id": 202, "submitted_at": "2026-03-17T11:00:00Z", "state": "APPROVED"}],
+        lambda issue_number: [
+            {"id": 202, "submitted_at": "2026-03-17T11:00:00Z", "state": "APPROVED"},
+            {"id": 303, "submitted_at": "2026-03-17T09:00:00Z", "updated_at": "2026-03-17T12:00:00Z", "state": "DISMISSED"},
+        ],
     )
     assert sweeper.sweep_deferred_gaps(reviewer_bot, state) is True
     gaps = state["active_reviews"]["42"]["deferred_gaps"]
     assert "issue_comment:101" in gaps
     assert "pull_request_review:202" in gaps
-    assert not any(key.startswith("pull_request_review_dismissed:") for key in gaps)
+    assert "pull_request_review_dismissed:303" in gaps
+    assert gaps["pull_request_review_dismissed:303"]["source_workflow_file"] == ".github/workflows/reviewer-bot-pr-review-dismissed-observer.yml"
+
+
+def test_sweeper_skips_dismissed_reviews_already_reconciled_by_source_event_key(monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["reconciled_source_events"] = ["pull_request_review_dismissed:303"]
+    monkeypatch.setattr(
+        reviewer_bot,
+        "github_api",
+        lambda method, endpoint, data=None: {
+            "pulls/42": {"state": "open", "head": {"sha": "head-1"}},
+            "issues/42/comments?per_page=100&page=1": [],
+        }.get(endpoint),
+    )
+    monkeypatch.setattr(
+        reviewer_bot,
+        "get_pull_request_reviews",
+        lambda issue_number: [
+            {"id": 303, "submitted_at": "2026-03-17T09:00:00Z", "updated_at": "2026-03-17T12:00:00Z", "state": "DISMISSED"},
+        ],
+    )
+    assert sweeper.sweep_deferred_gaps(reviewer_bot, state) is False
+    assert state["active_reviews"]["42"]["deferred_gaps"] == {}
 
 
 def test_sweeper_skips_events_already_reconciled_by_source_event_key(monkeypatch):

--- a/scripts/reviewer_bot_lib/sweeper.py
+++ b/scripts/reviewer_bot_lib/sweeper.py
@@ -475,7 +475,10 @@ def _discover_visible_review_events(bot, issue_number: int, review_data: dict) -
     for review in reviews:
         review_id = review.get("id") if isinstance(review, dict) else None
         submitted_at = review.get("submitted_at") if isinstance(review, dict) else None
+        state = str(review.get("state", "")).strip().upper() if isinstance(review, dict) else ""
         if not isinstance(review_id, int) or not isinstance(submitted_at, str):
+            continue
+        if state == "DISMISSED":
             continue
         submitted_dt = parse_timestamp(submitted_at)
         if submitted_dt is None or submitted_dt < floor:
@@ -488,6 +491,40 @@ def _discover_visible_review_events(bot, issue_number: int, review_data: dict) -
                 "source_created_at": submitted_at,
                 "object_id": str(review_id),
                 "surface": "reviews_submitted",
+            }
+        )
+    return discovered, True
+
+
+def _discover_visible_review_dismissal_events(bot, issue_number: int, review_data: dict) -> tuple[list[dict] | None, bool]:
+    watermark = _load_surface_watermark(review_data, "reviews_dismissed")
+    watermark["last_scan_started_at"] = _now_iso()
+    reviews = bot.get_pull_request_reviews(issue_number)
+    if reviews is None:
+        return None, False
+    floor = _surface_scan_floor(bot, watermark)
+    discovered: list[dict] = []
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        review_id = review.get("id")
+        state = str(review.get("state", "")).strip().upper()
+        dismissed_at = review.get("dismissed_at") or review.get("updated_at") or review.get("submitted_at")
+        if state != "DISMISSED":
+            continue
+        if not isinstance(review_id, int) or not isinstance(dismissed_at, str):
+            continue
+        dismissed_dt = parse_timestamp(dismissed_at)
+        if dismissed_dt is None or dismissed_dt < floor:
+            continue
+        discovered.append(
+            {
+                "source_event_key": f"pull_request_review_dismissed:{review_id}",
+                "source_event_name": "pull_request_review",
+                "source_event_action": "dismissed",
+                "source_created_at": dismissed_at,
+                "object_id": str(review_id),
+                "surface": "reviews_dismissed",
             }
         )
     return discovered, True
@@ -713,6 +750,73 @@ def sweep_deferred_gaps(bot, state: dict) -> bool:
                 _update_observer_watermark(bot, review_data, "reviews_submitted", last_review["source_created_at"], last_review["object_id"])
             else:
                 watermark = _load_surface_watermark(review_data, "reviews_submitted")
+                watermark["last_scan_started_at"] = watermark.get("last_scan_started_at") or _now_iso()
+                watermark["last_scan_completed_at"] = _now_iso()
+                watermark["bootstrap_completed_at"] = watermark.get("bootstrap_completed_at") or _now_iso()
+        discovered_dismissals, dismissals_complete = _discover_visible_review_dismissal_events(bot, issue_number, review_data)
+        if dismissals_complete and isinstance(discovered_dismissals, list):
+            for discovered in discovered_dismissals:
+                source_event_key = discovered["source_event_key"]
+                dismissed_at = discovered["source_created_at"]
+                if _should_skip_discovered_key(bot, review_data, source_event_key, ("review_dismissal",)):
+                    continue
+                existing_gap = review_data.get("deferred_gaps", {}).get(source_event_key, {})
+                workflow_file = ".github/workflows/reviewer-bot-pr-review-dismissed-observer.yml"
+                workflow_runs = _fetch_workflow_runs_for_file(bot, workflow_file, "pull_request_review")
+                run_correlation = correlate_candidate_observer_runs(
+                    source_event_key,
+                    source_event_kind="pull_request_review:dismissed",
+                    source_event_created_at=dismissed_at,
+                    pr_number=issue_number,
+                    workflow_file=workflow_file,
+                    workflow_runs=workflow_runs,
+                )
+                run_correlation["later_recheck_complete"] = bool(existing_gap.get("full_scan_complete"))
+                artifact_correlation = None
+                run_detail = None
+                if run_correlation.get("status") == "candidate_runs_found":
+                    artifact_correlation = inspect_run_artifact_payloads(
+                        bot,
+                        run_correlation.get("candidate_runs", []),
+                        source_event_key,
+                        pr_number=issue_number,
+                        source_event_kind="pull_request_review:dismissed",
+                    )
+                    exact_run_id = artifact_correlation.get("correlated_run") if isinstance(artifact_correlation, dict) else None
+                    if isinstance(exact_run_id, int):
+                        run_correlation["correlated_run"] = exact_run_id
+                        run_correlation["correlated_run_found"] = True
+                        run_detail = _fetch_run_detail(bot, exact_run_id)
+                reason, diagnostic_reason = evaluate_deferred_gap_state(
+                    {
+                        **existing_gap,
+                        "source_event_created_at": dismissed_at,
+                    },
+                    run_correlation,
+                    run_detail,
+                    artifact_correlation,
+                )
+                _record_gap_diagnostics(
+                    bot,
+                    review_data,
+                    source_event_key,
+                    source_event_name="pull_request_review",
+                    source_event_action="dismissed",
+                    issue_number=issue_number,
+                    source_created_at=dismissed_at,
+                    workflow_file=workflow_file,
+                    run_correlation=run_correlation,
+                    run_detail=run_detail,
+                    artifact_correlation=artifact_correlation,
+                    reason=reason,
+                    diagnostic_reason=diagnostic_reason,
+                )
+                changed = True
+            if discovered_dismissals:
+                last_dismissal = discovered_dismissals[-1]
+                _update_observer_watermark(bot, review_data, "reviews_dismissed", last_dismissal["source_created_at"], last_dismissal["object_id"])
+            else:
+                watermark = _load_surface_watermark(review_data, "reviews_dismissed")
                 watermark["last_scan_started_at"] = watermark.get("last_scan_started_at") or _now_iso()
                 watermark["last_scan_completed_at"] = _now_iso()
                 watermark["bootstrap_completed_at"] = watermark.get("bootstrap_completed_at") or _now_iso()


### PR DESCRIPTION
## Summary
- extend deferred-gap sweeping to surface visible dismissed PR reviews as their own keyed deferred gaps and correlate them against the dismissed-review observer workflow
- stop treating dismissed reviews as submitted-review discoveries so sweeper diagnostics stay aligned with the real event type
- add focused tests covering dismissed-review gap creation and skipping already reconciled dismissed-review source keys

## Testing
- uv run ruff check --fix scripts/reviewer_bot_lib/sweeper.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py