### PR TITLE
fix(reviewer-bot): ignore direct comments on closed issues

### DIFF
--- a/.github/reviewer-bot-tests/test_main.py
+++ b/.github/reviewer-bot-tests/test_main.py
@@ -211,6 +211,30 @@ def test_main_reloads_state_before_syncing_status_labels(monkeypatch):
     ]
 
 
+def test_issue_close_then_close_comment_does_not_leave_active_review(monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_TITLE", "Validation issue")
+    monkeypatch.setenv("ISSUE_BODY", "body")
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("ISSUE_STATE", "closed")
+    monkeypatch.setenv("COMMENT_USER_TYPE", "User")
+    monkeypatch.setenv("COMMENT_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_ID", "100")
+    monkeypatch.setenv("COMMENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    monkeypatch.setenv("COMMENT_BODY", "reviewer-bot validation close-path comment")
+
+    assert reviewer_bot.handle_closed_event(state) is True
+    assert "42" not in state["active_reviews"]
+    assert reviewer_bot.handle_comment_event(state) is False
+    assert "42" not in state["active_reviews"]
+
+
 def test_main_fails_when_save_state_fails(monkeypatch):
     monkeypatch.setenv("EVENT_NAME", "issue_comment")
     monkeypatch.setenv("EVENT_ACTION", "created")

--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -151,6 +151,79 @@ def test_handle_non_pr_issue_comment_creates_pending_privileged_command(monkeypa
     assert pending["issue_comment:100"]["authorization"]["authorized"] is True
 
 
+def test_closed_non_pr_plain_text_comment_does_not_create_review_entry(monkeypatch):
+    state = make_state()
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_STATE", "closed")
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_USER_TYPE", "User")
+    monkeypatch.setenv("COMMENT_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_ID", "100")
+    monkeypatch.setenv("COMMENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    monkeypatch.setenv("COMMENT_BODY", "reviewer-bot validation: close comment")
+    assert reviewer_bot.handle_comment_event(state) is False
+    assert state["active_reviews"] == {}
+
+
+def test_closed_non_pr_command_comment_does_not_create_pending_privileged_command(monkeypatch):
+    state = make_state()
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_STATE", "closed")
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_USER_TYPE", "User")
+    monkeypatch.setenv("COMMENT_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_ID", "100")
+    monkeypatch.setenv("COMMENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    monkeypatch.setenv("COMMENT_BODY", "@guidelines-bot /accept-no-fls-changes")
+    called = {"post_comment": 0}
+    monkeypatch.setattr(reviewer_bot, "parse_issue_labels", lambda: [reviewer_bot.FLS_AUDIT_LABEL])
+    monkeypatch.setattr(reviewer_bot, "check_user_permission", lambda username, required_permission="triage": True)
+    monkeypatch.setattr(reviewer_bot, "add_reaction", lambda *args, **kwargs: True)
+    monkeypatch.setattr(reviewer_bot, "post_comment", lambda *args, **kwargs: called.__setitem__("post_comment", called["post_comment"] + 1) or True)
+    assert reviewer_bot.handle_comment_event(state) is False
+    assert state["active_reviews"] == {}
+    assert called["post_comment"] == 0
+
+
+def test_closed_non_pr_comment_removes_stale_review_entry(monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_STATE", "closed")
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_USER_TYPE", "User")
+    monkeypatch.setenv("COMMENT_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_ID", "100")
+    monkeypatch.setenv("COMMENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    monkeypatch.setenv("COMMENT_BODY", "reviewer-bot validation: close comment")
+    assert reviewer_bot.handle_comment_event(state) is False
+    assert "42" not in state["active_reviews"]
+
+
+def test_open_non_pr_plain_text_comment_still_updates_freshness(monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_STATE", "open")
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_USER_TYPE", "User")
+    monkeypatch.setenv("COMMENT_AUTHOR", "dana")
+    monkeypatch.setenv("COMMENT_ID", "100")
+    monkeypatch.setenv("COMMENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    monkeypatch.setenv("COMMENT_BODY", "reviewer-bot validation: contributor plain text comment")
+    assert reviewer_bot.handle_comment_event(state) is True
+    accepted = state["active_reviews"]["42"]["contributor_comment"]["accepted"]
+    assert accepted["semantic_key"] == "issue_comment:100"
+
+
 def test_pr_comment_direct_path_is_epoch_gated(monkeypatch):
     state = make_state(epoch="legacy_v14")
     entry = reviewer_bot.ensure_review_entry(state, 42, create=True)
@@ -982,6 +1055,11 @@ def test_trusted_pr_comment_workflow_preflights_same_repo_before_mutation():
     workflow_text = Path(".github/workflows/reviewer-bot-pr-comment-trusted.yml").read_text(encoding="utf-8")
     assert "https://api.github.com/repos/{repo}/pulls/{pr_number}" in workflow_text
     assert "RUN_TRUSTED_PR_COMMENT" in workflow_text
+
+
+def test_issue_comment_direct_workflow_exports_issue_state():
+    workflow_text = Path(".github/workflows/reviewer-bot-issue-comment-direct.yml").read_text(encoding="utf-8")
+    assert "ISSUE_STATE: ${{ github.event.issue.state }}" in workflow_text
 
 
 def test_mutating_reviewer_bot_workflows_do_not_share_global_github_concurrency():

--- a/.github/workflows/reviewer-bot-issue-comment-direct.yml
+++ b/.github/workflows/reviewer-bot-issue-comment-direct.yml
@@ -51,6 +51,7 @@ jobs:
           EVENT_NAME: issue_comment
           EVENT_ACTION: created
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_STATE: ${{ github.event.issue.state }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           ISSUE_HTML_URL: ${{ github.event.issue.html_url }}

--- a/scripts/reviewer_bot_lib/comment_routing.py
+++ b/scripts/reviewer_bot_lib/comment_routing.py
@@ -24,6 +24,10 @@ def _is_pr_event() -> bool:
     return os.environ.get("IS_PULL_REQUEST", "false").lower() == "true"
 
 
+def _issue_state() -> str:
+    return os.environ.get("ISSUE_STATE", "").strip().lower()
+
+
 def _require_v18_for_pr(state: dict, context: str) -> bool:
     if not _is_pr_event():
         return True
@@ -320,6 +324,10 @@ def handle_comment_event(bot, state: dict) -> bool:
     if route == "safe_noop":
         return False
     if route == "issue_direct":
+        if _issue_state() == "closed":
+            state.get("active_reviews", {}).pop(str(issue_number), None)
+            print(f"Ignoring direct comment on closed issue #{issue_number}")
+            return False
         return _process_comment_event(bot, state, issue_number)
     if route == "pr_trusted_direct":
         if not _require_v18_for_pr(state, "pr_trusted_direct_comment"):


### PR DESCRIPTION
## Summary
- pass issue state into the direct non-PR issue-comment workflow and short-circuit closed issues before any freshness or command handling can recreate state
- defensively drop stale active review entries when a direct comment lands on a closed issue so issue-close cleanup remains authoritative
- add regression tests covering close-comment resurrection, closed-issue safe no-op behavior, and the open-issue control path

## Testing
- uv run ruff check --fix scripts/reviewer_bot_lib/comment_routing.py .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py