### PR TITLE
fix(reviewer-bot): hydrate labels for privileged execution

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -809,6 +809,77 @@ def test_execute_pending_privileged_command_revalidates_live_state(monkeypatch):
     assert review["pending_privileged_commands"]["issue_comment:100"]["status"] == "executed"
 
 
+def test_execute_pending_privileged_command_hydrates_issue_labels_for_executor(monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["pending_privileged_commands"]["issue_comment:100"] = {
+        "source_event_key": "issue_comment:100",
+        "command_name": "accept-no-fls-changes",
+        "issue_number": 42,
+        "actor": "alice",
+        "status": "pending",
+    }
+    monkeypatch.setenv("MANUAL_ACTION", "execute-pending-privileged-command")
+    monkeypatch.setenv("PRIVILEGED_SOURCE_EVENT_KEY", "issue_comment:100")
+    monkeypatch.delenv("ISSUE_LABELS", raising=False)
+    monkeypatch.setattr(
+        reviewer_bot,
+        "get_issue_or_pr_snapshot",
+        lambda issue_number: {"number": issue_number, "labels": [{"name": reviewer_bot.FLS_AUDIT_LABEL}]},
+    )
+    monkeypatch.setattr(reviewer_bot, "check_user_permission", lambda username, required_permission="triage": True)
+
+    observed = {}
+
+    def fake_handle(issue_number, actor):
+        observed["issue_number"] = issue_number
+        observed["actor"] = actor
+        observed["issue_labels"] = json.loads(os.environ["ISSUE_LABELS"])
+        return ("ok", True)
+
+    monkeypatch.setattr(reviewer_bot, "handle_accept_no_fls_changes_command", fake_handle)
+    assert reviewer_bot.handle_manual_dispatch(state) is True
+    assert observed == {
+        "issue_number": 42,
+        "actor": "alice",
+        "issue_labels": [reviewer_bot.FLS_AUDIT_LABEL],
+    }
+    assert review["pending_privileged_commands"]["issue_comment:100"]["status"] == "executed"
+
+
+def test_execute_pending_privileged_command_fails_closed_without_live_fls_audit_label(monkeypatch):
+    state = make_state()
+    review = reviewer_bot.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["pending_privileged_commands"]["issue_comment:100"] = {
+        "source_event_key": "issue_comment:100",
+        "command_name": "accept-no-fls-changes",
+        "issue_number": 42,
+        "actor": "alice",
+        "status": "pending",
+    }
+    monkeypatch.setenv("MANUAL_ACTION", "execute-pending-privileged-command")
+    monkeypatch.setenv("PRIVILEGED_SOURCE_EVENT_KEY", "issue_comment:100")
+    monkeypatch.setattr(
+        reviewer_bot,
+        "get_issue_or_pr_snapshot",
+        lambda issue_number: {"number": issue_number, "labels": [{"name": "status: awaiting reviewer response"}]},
+    )
+    monkeypatch.setattr(reviewer_bot, "check_user_permission", lambda username, required_permission="triage": True)
+    called = {"handle": 0}
+    monkeypatch.setattr(
+        reviewer_bot,
+        "handle_accept_no_fls_changes_command",
+        lambda issue_number, actor: called.__setitem__("handle", called["handle"] + 1) or ("ok", True),
+    )
+    assert reviewer_bot.handle_manual_dispatch(state) is True
+    assert called["handle"] == 0
+    pending = review["pending_privileged_commands"]["issue_comment:100"]
+    assert pending["status"] == "failed_closed"
+    assert pending["result"] == "live_revalidation_failed"
+
+
 def test_observer_run_reason_mapping_and_near_miss_signature():
     signature = {"status": "waiting", "conclusion": None, "name": "approval_pending"}
     assert sweeper.observer_run_reason_from_details({"status": "waiting", "conclusion": None, "name": "approval_pending"}, signature) == "awaiting_observer_approval"

--- a/scripts/reviewer_bot_lib/maintenance.py
+++ b/scripts/reviewer_bot_lib/maintenance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 
 import yaml
@@ -59,16 +60,19 @@ def handle_manual_dispatch(bot, state: dict) -> bool:
                 record["completed_at"] = _now_iso(bot)
                 record["result"] = "live_target_invalid"
                 return True
-            labels = {
-                label.get("name")
-                for label in issue_snapshot.get("labels", [])
-                if isinstance(label, dict) and isinstance(label.get("name"), str)
-            }
+            labels: set[str] = set()
+            for label in issue_snapshot.get("labels", []):
+                if not isinstance(label, dict):
+                    continue
+                name = label.get("name")
+                if isinstance(name, str):
+                    labels.add(name)
             if bot.FLS_AUDIT_LABEL not in labels or not bot.check_user_permission(actor, "triage"):
                 record["status"] = "failed_closed"
                 record["completed_at"] = _now_iso(bot)
                 record["result"] = "live_revalidation_failed"
                 return True
+            os.environ["ISSUE_LABELS"] = json.dumps(sorted(labels))
             message, success = bot.handle_accept_no_fls_changes_command(issue_number, actor)
             record["completed_at"] = _now_iso(bot)
             record["result_message"] = message


### PR DESCRIPTION
## Summary
- hydrate `ISSUE_LABELS` from the executor's live issue snapshot before invoking `/accept-no-fls-changes` so isolated privileged execution sees the same label context as the trusted handoff path
- preserve live revalidation as the authoritative gate while avoiding false fail-closed results caused by missing workflow-dispatch env
- add regression tests covering executor label hydration and the fail-closed path when the live `fls-audit` label is truly absent

## Testing
- uv run ruff check --fix scripts/reviewer_bot_lib/maintenance.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py