### PR TITLE
fix(reviewer-bot): ignore bootstrap noise in privileged execution

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -878,6 +879,39 @@ def test_execute_pending_privileged_command_fails_closed_without_live_fls_audit_
     pending = review["pending_privileged_commands"]["issue_comment:100"]
     assert pending["status"] == "failed_closed"
     assert pending["result"] == "live_revalidation_failed"
+
+
+def test_list_changed_files_ignores_untracked_bootstrap_noise(monkeypatch, tmp_path):
+    commands_seen = []
+
+    def fake_run_command(command, cwd, check=True):
+        commands_seen.append(command)
+        if command == ["git", "diff", "--name-only"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command == ["git", "diff", "--cached", "--name-only"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(reviewer_bot.automation_module, "run_command", fake_run_command)
+    assert reviewer_bot.automation_module.list_changed_files(tmp_path) == []
+    assert commands_seen == [["git", "diff", "--name-only"], ["git", "diff", "--cached", "--name-only"]]
+
+
+def test_list_changed_files_reports_tracked_changes_only(monkeypatch, tmp_path):
+    def fake_run_command(command, cwd, check=True):
+        if command == ["git", "diff", "--name-only"]:
+            return subprocess.CompletedProcess(command, 0, stdout="README.md\nsrc/spec.lock\n", stderr="")
+        if command == ["git", "diff", "--cached", "--name-only"]:
+            return subprocess.CompletedProcess(command, 0, stdout="src/spec.lock\n", stderr="")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(reviewer_bot.automation_module, "run_command", fake_run_command)
+    assert reviewer_bot.automation_module.list_changed_files(tmp_path) == ["README.md", "src/spec.lock"]
+
+
+def test_privileged_commands_workflow_executes_source_entrypoint():
+    workflow_text = Path(".github/workflows/reviewer-bot-privileged-commands.yml").read_text(encoding="utf-8")
+    assert "run: uv run python scripts/reviewer_bot.py" in workflow_text
 
 
 def test_observer_run_reason_mapping_and_near_miss_signature():

--- a/.github/workflows/reviewer-bot-privileged-commands.yml
+++ b/.github/workflows/reviewer-bot-privileged-commands.yml
@@ -49,4 +49,4 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-privileged-commands.yml
-        run: uv run reviewer-bot
+        run: uv run python scripts/reviewer_bot.py

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 build/
 *.egg-info/
 .cache/
+.venv/

--- a/scripts/reviewer_bot_lib/automation.py
+++ b/scripts/reviewer_bot_lib/automation.py
@@ -22,16 +22,14 @@ def summarize_output(result: subprocess.CompletedProcess, limit: int = 20) -> st
 
 
 def list_changed_files(repo_root: Path) -> list[str]:
-    result = run_command(["git", "status", "--porcelain"], cwd=repo_root)
-    files = []
-    for line in result.stdout.splitlines():
-        if not line:
-            continue
-        path = line[3:]
-        if " -> " in path:
-            path = path.split(" -> ")[-1]
-        files.append(path)
-    return files
+    files: list[str] = []
+    for command in (["git", "diff", "--name-only"], ["git", "diff", "--cached", "--name-only"]):
+        result = run_command(command, cwd=repo_root)
+        for line in result.stdout.splitlines():
+            path = line.strip()
+            if path:
+                files.append(path)
+    return sorted(set(files))
 
 
 def get_default_branch(bot) -> str:

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -251,16 +251,14 @@ def summarize_output(result: subprocess.CompletedProcess, limit: int = 20) -> st
 
 
 def list_changed_files(repo_root: Path) -> list[str]:
-    result = run_command(["git", "status", "--porcelain"], cwd=repo_root)
-    files = []
-    for line in result.stdout.splitlines():
-        if not line:
-            continue
-        path = line[3:]
-        if " -> " in path:
-            path = path.split(" -> ")[-1]
-        files.append(path)
-    return files
+    files: list[str] = []
+    for command in (["git", "diff", "--name-only"], ["git", "diff", "--cached", "--name-only"]):
+        result = run_command(command, cwd=repo_root)
+        for line in result.stdout.splitlines():
+            path = line.strip()
+            if path:
+                files.append(path)
+    return sorted(set(files))
 
 
 def get_default_branch(bot) -> str:


### PR DESCRIPTION
## Summary
- narrow reviewer-bot clean-worktree checks to tracked git diffs so untracked bootstrap artifacts do not falsely block privileged execution
- run the privileged workflow via `uv run python scripts/reviewer_bot.py` and ignore `.venv/` as repo-local tooling noise
- add regression tests for tracked-only cleanliness semantics and the privileged workflow entrypoint contract

## Testing
- uv run ruff check --fix scripts/reviewer_bot_lib/automation.py scripts/reviewer_bot_lib/commands.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py