### PR TITLE
fix(reviewer-bot): isolate privileged execution bootstrap

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -911,7 +911,26 @@ def test_list_changed_files_reports_tracked_changes_only(monkeypatch, tmp_path):
 
 def test_privileged_commands_workflow_executes_source_entrypoint():
     workflow_text = Path(".github/workflows/reviewer-bot-privileged-commands.yml").read_text(encoding="utf-8")
-    assert "run: uv run python scripts/reviewer_bot.py" in workflow_text
+    assert "Fetch trusted bot source tarball" in workflow_text
+    assert 'REVIEWER_BOT_TARGET_REPO_ROOT: ${{ github.workspace }}' in workflow_text
+    assert 'run: uv run --project "$BOT_SRC_ROOT" python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"' in workflow_text
+
+
+def test_accept_no_fls_changes_honors_explicit_target_repo_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("REVIEWER_BOT_TARGET_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_LABELS", json.dumps([reviewer_bot.FLS_AUDIT_LABEL]))
+    monkeypatch.setattr(reviewer_bot, "check_user_permission", lambda username, required_permission="triage": True)
+    observed = {"cwd": None}
+
+    def fake_list_changed_files(repo_root):
+        observed["cwd"] = repo_root
+        return ["README.md"]
+
+    monkeypatch.setattr(reviewer_bot, "list_changed_files", fake_list_changed_files)
+    message, success = reviewer_bot.handle_accept_no_fls_changes_command(42, "alice")
+    assert (message, success) == ("❌ Working tree is not clean; refusing to update spec.lock.", False)
+    assert observed["cwd"] == tmp_path
 
 
 def test_observer_run_reason_mapping_and_near_miss_signature():

--- a/.github/workflows/reviewer-bot-privileged-commands.yml
+++ b/.github/workflows/reviewer-bot-privileged-commands.yml
@@ -25,6 +25,29 @@ jobs:
     steps:
       - name: Checkout trusted default-branch bot code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Fetch trusted bot source tarball
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python - <<'PY'
+          import io, os, tarfile, urllib.request
+          from pathlib import Path
+
+          req = urllib.request.Request(
+              f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}/tarball/{os.environ['GITHUB_SHA']}",
+              headers={'Authorization': f"Bearer {os.environ['GITHUB_TOKEN']}", 'Accept': 'application/vnd.github+json'},
+          )
+          target = Path(os.environ['RUNNER_TEMP']) / 'reviewer-bot-src'
+          target.mkdir(parents=True, exist_ok=True)
+          with urllib.request.urlopen(req) as response:
+              data = response.read()
+          with tarfile.open(fileobj=io.BytesIO(data), mode='r:gz') as archive:
+              archive.extractall(target)
+          roots = list(target.iterdir())
+          print(f'BOT_SRC_ROOT={roots[0]}', file=open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8'))
+          PY
       - name: Document isolated privileged execution boundary
         run: |
           {
@@ -32,8 +55,6 @@ jobs:
             echo 'It must consume persisted trusted records from issue #314.'
             echo 'Operator guidance: docs/reviewer-bot-review-freshness-operator-runbook.md'
           } >> "$GITHUB_STEP_SUMMARY"
-      - name: Install uv
-        run: python -m pip install uv
       - name: Execute persisted privileged command
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,4 +70,5 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
           CURRENT_WORKFLOW_FILE: .github/workflows/reviewer-bot-privileged-commands.yml
-        run: uv run python scripts/reviewer_bot.py
+          REVIEWER_BOT_TARGET_REPO_ROOT: ${{ github.workspace }}
+        run: uv run --project "$BOT_SRC_ROOT" python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"

--- a/scripts/reviewer_bot_lib/automation.py
+++ b/scripts/reviewer_bot_lib/automation.py
@@ -32,6 +32,13 @@ def list_changed_files(repo_root: Path) -> list[str]:
     return sorted(set(files))
 
 
+def get_target_repo_root() -> Path:
+    configured = os.environ.get("REVIEWER_BOT_TARGET_REPO_ROOT", "").strip()
+    if configured:
+        return Path(configured)
+    return Path(__file__).resolve().parents[2]
+
+
 def get_default_branch(bot) -> str:
     repo_info = bot.github_api("GET", "")
     if isinstance(repo_info, dict):
@@ -80,7 +87,7 @@ def handle_accept_no_fls_changes_command(bot, issue_number: int, comment_author:
     if not bot.check_user_permission(comment_author, "triage"):
         return "❌ You must have triage permissions to run this command.", False
 
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = get_target_repo_root()
     if bot.list_changed_files(repo_root):
         return "❌ Working tree is not clean; refusing to update spec.lock.", False
 

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -261,6 +261,13 @@ def list_changed_files(repo_root: Path) -> list[str]:
     return sorted(set(files))
 
 
+def get_target_repo_root() -> Path:
+    configured = os.environ.get("REVIEWER_BOT_TARGET_REPO_ROOT", "").strip()
+    if configured:
+        return Path(configured)
+    return Path(__file__).resolve().parents[2]
+
+
 def get_default_branch(bot) -> str:
     repo_info = bot.github_api("GET", "")
     if isinstance(repo_info, dict):
@@ -336,7 +343,7 @@ def handle_accept_no_fls_changes_command(bot, issue_number: int, comment_author:
         return "❌ This command is only available on issues labeled `fls-audit`.", False
     if not bot.check_user_permission(comment_author, "triage"):
         return "❌ You must have triage permissions to run this command.", False
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = get_target_repo_root()
     if bot.list_changed_files(repo_root):
         return "❌ Working tree is not clean; refusing to update spec.lock.", False
     audit_result = bot.run_command(["uv", "run", "python", "scripts/fls_audit.py", "--summary-only", "--fail-on-impact"], cwd=repo_root, check=False)


### PR DESCRIPTION
## Summary
- run the privileged workflow from a trusted temp-source tarball and point privileged command logic at the checked-out target repo explicitly instead of bootstrapping reviewer-bot inside that repo
- add explicit target-repo-root helpers in the automation and commands paths so clean-worktree checks and spec-lock updates operate on the intended checkout
- add regression tests covering the privileged workflow contract and explicit target repo root resolution

## Testing
- uv run ruff check --fix scripts/reviewer_bot_lib/automation.py scripts/reviewer_bot_lib/commands.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py