### PR TITLE
fix(reviewer-bot): lock nested uv execution

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -933,6 +933,57 @@ def test_accept_no_fls_changes_honors_explicit_target_repo_root(monkeypatch, tmp
     assert observed["cwd"] == tmp_path
 
 
+def test_accept_no_fls_changes_uses_locked_nested_uv_commands(monkeypatch, tmp_path):
+    monkeypatch.setenv("REVIEWER_BOT_TARGET_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_LABELS", json.dumps([reviewer_bot.FLS_AUDIT_LABEL]))
+    monkeypatch.setattr(reviewer_bot, "check_user_permission", lambda username, required_permission="triage": True)
+    list_calls = {"count": 0}
+
+    def fake_list_changed_files(repo_root):
+        list_calls["count"] += 1
+        assert repo_root == tmp_path
+        return []
+
+    commands = []
+
+    def fake_run_command(command, cwd, check=False):
+        commands.append((command, cwd, check))
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(reviewer_bot, "list_changed_files", fake_list_changed_files)
+    monkeypatch.setattr(reviewer_bot, "run_command", fake_run_command)
+    message, success = reviewer_bot.handle_accept_no_fls_changes_command(42, "alice")
+    assert (message, success) == ("✅ `src/spec.lock` is already up to date; no PR needed.", True)
+    assert list_calls["count"] == 2
+    assert commands == [
+        (["uv", "run", "--locked", "python", "scripts/fls_audit.py", "--summary-only", "--fail-on-impact"], tmp_path, False),
+        (["uv", "run", "--locked", "python", "./make.py", "--update-spec-lock-file"], tmp_path, False),
+    ]
+
+
+def test_accept_no_fls_changes_surfaces_locked_uv_failure_details(monkeypatch, tmp_path):
+    monkeypatch.setenv("REVIEWER_BOT_TARGET_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_LABELS", json.dumps([reviewer_bot.FLS_AUDIT_LABEL]))
+    monkeypatch.setattr(reviewer_bot, "check_user_permission", lambda username, required_permission="triage": True)
+    monkeypatch.setattr(reviewer_bot, "list_changed_files", lambda repo_root: [])
+
+    def fake_run_command(command, cwd, check=False):
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr="error: lockfile at uv.lock needs to be updated, but --locked was provided",
+        )
+
+    monkeypatch.setattr(reviewer_bot, "run_command", fake_run_command)
+    message, success = reviewer_bot.handle_accept_no_fls_changes_command(42, "alice")
+    assert success is False
+    assert "Audit command failed." in message
+    assert "--locked was provided" in message
+
+
 def test_observer_run_reason_mapping_and_near_miss_signature():
     signature = {"status": "waiting", "conclusion": None, "name": "approval_pending"}
     assert sweeper.observer_run_reason_from_details({"status": "waiting", "conclusion": None, "name": "approval_pending"}, signature) == "awaiting_observer_approval"

--- a/scripts/reviewer_bot_lib/automation.py
+++ b/scripts/reviewer_bot_lib/automation.py
@@ -92,7 +92,7 @@ def handle_accept_no_fls_changes_command(bot, issue_number: int, comment_author:
         return "❌ Working tree is not clean; refusing to update spec.lock.", False
 
     audit_result = bot.run_command(
-        ["uv", "run", "python", "scripts/fls_audit.py", "--summary-only", "--fail-on-impact"],
+        ["uv", "run", "--locked", "python", "scripts/fls_audit.py", "--summary-only", "--fail-on-impact"],
         cwd=repo_root,
         check=False,
     )
@@ -108,7 +108,7 @@ def handle_accept_no_fls_changes_command(bot, issue_number: int, comment_author:
         return f"❌ Audit command failed.{detail_text}", False
 
     update_result = bot.run_command(
-        ["uv", "run", "python", "./make.py", "--update-spec-lock-file"],
+        ["uv", "run", "--locked", "python", "./make.py", "--update-spec-lock-file"],
         cwd=repo_root,
         check=False,
     )

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -346,14 +346,14 @@ def handle_accept_no_fls_changes_command(bot, issue_number: int, comment_author:
     repo_root = get_target_repo_root()
     if bot.list_changed_files(repo_root):
         return "❌ Working tree is not clean; refusing to update spec.lock.", False
-    audit_result = bot.run_command(["uv", "run", "python", "scripts/fls_audit.py", "--summary-only", "--fail-on-impact"], cwd=repo_root, check=False)
+    audit_result = bot.run_command(["uv", "run", "--locked", "python", "scripts/fls_audit.py", "--summary-only", "--fail-on-impact"], cwd=repo_root, check=False)
     if audit_result.returncode == 2:
         return ("❌ The audit reports affected guidelines. Please review and open a PR with the necessary guideline updates instead."), False
     if audit_result.returncode != 0:
         details = bot.summarize_output(audit_result)
         detail_text = f"\n\nDetails:\n```\n{details}\n```" if details else ""
         return (f"❌ Audit command failed.{detail_text}"), False
-    update_result = bot.run_command(["uv", "run", "python", "./make.py", "--update-spec-lock-file"], cwd=repo_root, check=False)
+    update_result = bot.run_command(["uv", "run", "--locked", "python", "./make.py", "--update-spec-lock-file"], cwd=repo_root, check=False)
     if update_result.returncode != 0:
         details = bot.summarize_output(update_result)
         detail_text = f"\n\nDetails:\n```\n{details}\n```" if details else ""


### PR DESCRIPTION
## Summary
- require `uv run --locked` for the nested audit and spec-lock update commands used by `/accept-no-fls-changes` so the bot no longer rewrites `uv.lock` as a side effect of privileged execution
- keep the tracked-file allowlist narrow while surfacing uv lock drift as an explicit command failure instead of an unexpected tracked change late in the flow
- add regression tests covering the locked uv argv contract and the error message returned when uv refuses to update the lockfile under `--locked`

## Testing
- uv run ruff check --fix scripts/reviewer_bot_lib/automation.py scripts/reviewer_bot_lib/commands.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py