### PR TITLE
fix(reviewer-bot): make spec-lock updates pure

### DIFF
--- a/.github/reviewer-bot-tests/test_reviewer_bot.py
+++ b/.github/reviewer-bot-tests/test_reviewer_bot.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from builder import build_cli
 from scripts import reviewer_bot
 from scripts.reviewer_bot_lib import comment_routing, sweeper
 
@@ -982,6 +983,28 @@ def test_accept_no_fls_changes_surfaces_locked_uv_failure_details(monkeypatch, t
     assert success is False
     assert "Audit command failed." in message
     assert "--locked was provided" in message
+
+
+def test_update_spec_lock_file_mode_exits_before_build_docs(monkeypatch, tmp_path):
+    monkeypatch.setattr(build_cli.argparse.ArgumentParser, "parse_args", lambda self: type("Args", (), {
+        "clear": False,
+        "offline": False,
+        "ignore_spec_lock_diff": False,
+        "update_spec_lock_file": True,
+        "validate_urls": False,
+        "serve": False,
+        "check_links": False,
+        "xml": False,
+        "verbose": False,
+        "debug": False,
+    })())
+    called = {"update": 0, "build": 0}
+    monkeypatch.setattr(build_cli, "update_spec_lockfile", lambda url, path: called.__setitem__("update", called["update"] + 1) or True)
+    monkeypatch.setattr(build_cli, "build_docs", lambda *args, **kwargs: called.__setitem__("build", called["build"] + 1))
+    with pytest.raises(SystemExit) as exc_info:
+        build_cli.main(tmp_path)
+    assert exc_info.value.code == 0
+    assert called == {"update": 1, "build": 0}
 
 
 def test_observer_run_reason_mapping_and_near_miss_signature():

--- a/builder/build_cli.py
+++ b/builder/build_cli.py
@@ -288,7 +288,8 @@ def main(root):
     builder = "linkcheck" if args.check_links else "xml" if args.xml else "html"
 
     if args.update_spec_lock_file:
-        update_spec_lockfile(SPEC_CHECKSUM_URL, root / "src" / SPEC_LOCKFILE)
+        success = update_spec_lockfile(SPEC_CHECKSUM_URL, root / "src" / SPEC_LOCKFILE)
+        raise SystemExit(0 if success else 1)
 
     build_docs(
         root,


### PR DESCRIPTION
## Summary
- stop `make.py --update-spec-lock-file` from continuing into the full docs build path so `/accept-no-fls-changes` only performs the intended spec-lock update work
- preserve the existing success and failure semantics by exiting with an explicit status immediately after the spec-lock update step
- add a regression test proving update-spec-lock mode exits before `build_docs(...)` is invoked

## Testing
- uv run ruff check --fix builder/build_cli.py scripts/reviewer_bot_lib/automation.py .github/reviewer-bot-tests/test_reviewer_bot.py
- uv run python -m pytest .github/reviewer-bot-tests/test_reviewer_bot.py .github/reviewer-bot-tests/test_main.py