### PR TITLE
fix(reviewer-bot): close reminder authority and completion gaps

### DIFF
--- a/.github/workflows/reviewer-bot-issues.yml
+++ b/.github/workflows/reviewer-bot-issues.yml
@@ -2,7 +2,7 @@ name: Reviewer Bot Issues
 
 on:
   issues:
-    types: [opened, labeled, edited, closed]
+    types: [opened, edited, labeled, unlabeled, assigned, unassigned, reopened, closed]
 
 permissions:
   contents: read
@@ -50,6 +50,8 @@ jobs:
           EVENT_NAME: issues
           EVENT_ACTION: ${{ github.event.action }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          IS_PULL_REQUEST: 'false'
+          ISSUE_STATE: ${{ github.event.issue.state }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_UPDATED_AT: ${{ github.event.issue.updated_at }}

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -6,7 +6,7 @@ If you are contributing a guideline, start with [CONTRIBUTING.md](CONTRIBUTING.m
 ## Reviewer Bot Commands
 
 > [!NOTE]
-> These commands only apply in the context of coding guideline issues.
+> These commands apply to tracked reviewer-bot issue reviews. Some commands remain specific to coding-guideline or FLS-audit issues.
 
 Before we continue, here's a preamble on how the reviewer bot helps reviewers do their job.
 
@@ -96,6 +96,23 @@ What it does (for the current PR only):
 **Example:**
 ```
 @guidelines-bot /rectify
+```
+
+### Mark a Tracked Issue Review Complete
+
+```
+@guidelines-bot /done
+```
+
+Use this to mark a tracked non-PR issue review complete when the review work is finished.
+
+- Available on generic tracked issues and FLS audit issues
+- Not available on pull requests
+- Not available on coding guideline issues, which still use `sign-off: create pr`
+
+**Example:**
+```
+@guidelines-bot /done
 ```
 
 ### Assign a Specific Reviewer

--- a/scripts/reviewer_bot_core/comment_command_policy.py
+++ b/scripts/reviewer_bot_core/comment_command_policy.py
@@ -11,6 +11,7 @@ from . import privileged_command_policy
 class OrdinaryCommandId(StrEnum):
     PASS = "pass"
     AWAY = "away"
+    DONE = "done"
     LABEL = "label"
     SYNC_MEMBERS = "sync-members"
     QUEUE = "queue"
@@ -101,6 +102,14 @@ def decide_comment_command(bot, request, classified, *, actor_class: str, comman
             response=f"❌ Missing date. Usage: `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]`",
             success=False,
             react=True,
+        )
+    if command == OrdinaryCommandId.DONE.value:
+        return ExecuteOrdinaryCommandDecision(
+            command_id=OrdinaryCommandId.DONE,
+            issue_number=issue_number,
+            actor=comment_author,
+            raw_args=args,
+            needs_assignment_request=True,
         )
     if command == OrdinaryCommandId.LABEL.value:
         return ExecuteOrdinaryCommandDecision(

--- a/scripts/reviewer_bot_core/review_state_machine.py
+++ b/scripts/reviewer_bot_core/review_state_machine.py
@@ -193,6 +193,21 @@ def set_current_reviewer(
     _reset_cycle_state(review_data)
 
 
+def clear_current_reviewer(state: dict, issue_number: int) -> bool:
+    review_data = ensure_review_entry(state, issue_number)
+    if review_data is None:
+        return False
+    changed = False
+    if review_data.get("current_reviewer") is not None:
+        review_data["current_reviewer"] = None
+        changed = True
+    if review_data.get("assignment_method") is not None:
+        review_data["assignment_method"] = None
+        changed = True
+    clear_transition_timers(review_data)
+    return changed
+
+
 def update_reviewer_activity(state: dict, issue_number: int, reviewer: str, *, now: str) -> bool:
     review_data = ensure_review_entry(state, issue_number)
     if review_data is None:

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -55,6 +55,17 @@ def _initial_reviewer_anchor(review_data: dict) -> str | None:
     return None
 
 
+def _record_for_current_reviewer(record: dict | None | object, current_reviewer: str) -> dict | None:
+    if not isinstance(record, dict):
+        return None
+    actor = record.get("actor")
+    if not isinstance(actor, str) or not actor.strip():
+        return record
+    if actor.lower() != current_reviewer.lower():
+        return None
+    return record
+
+
 def _contributor_revision_handoff_record(review_data: dict, current_head: str | None, reviewer_review: dict | None) -> dict | None:
     contributor_revision = review_data.get("contributor_revision", {}).get("accepted")
     if not isinstance(contributor_revision, dict):
@@ -93,16 +104,8 @@ def derive_reviewer_response_state(
         contributor_comment = review_data.get("contributor_comment", {}).get("accepted")
 
     if not issue_is_pull_request:
-        if not reviewer_comment and not reviewer_review:
-            return {
-                "state": "awaiting_reviewer_response",
-                "reason": "no_reviewer_activity",
-                "anchor_timestamp": _initial_reviewer_anchor(review_data),
-                "reviewer_comment": reviewer_comment,
-                "reviewer_review": reviewer_review,
-                "contributor_comment": contributor_comment,
-                "contributor_handoff": None,
-            }
+        reviewer_comment = _record_for_current_reviewer(reviewer_comment, current_reviewer)
+        reviewer_review = _record_for_current_reviewer(reviewer_review, current_reviewer)
         latest_reviewer_response = reviewer_comment
         if reviewer_review_helpers.compare_records(
             reviewer_review,
@@ -111,15 +114,59 @@ def derive_reviewer_response_state(
         ) > 0:
             latest_reviewer_response = reviewer_review
         completion = review_data.get("current_cycle_completion")
-        if not isinstance(completion, dict) or not completion.get("completed"):
-            if review_data.get("review_completed_at"):
-                return {"state": "done", "reason": None}
+        if isinstance(completion, dict) and completion.get("completed"):
             return {
-                "state": "awaiting_contributor_response",
-                "reason": "completion_missing",
+                "state": "done",
+                "reason": None,
                 "anchor_timestamp": latest_reviewer_response.get("timestamp") if isinstance(latest_reviewer_response, dict) else None,
+                "reviewer_comment": reviewer_comment,
+                "reviewer_review": reviewer_review,
+                "contributor_comment": contributor_comment,
+                "contributor_handoff": contributor_comment,
             }
-        return {"state": "done", "reason": None}
+        if review_data.get("review_completed_at"):
+            return {
+                "state": "done",
+                "reason": None,
+                "anchor_timestamp": latest_reviewer_response.get("timestamp") if isinstance(latest_reviewer_response, dict) else None,
+                "reviewer_comment": reviewer_comment,
+                "reviewer_review": reviewer_review,
+                "contributor_comment": contributor_comment,
+                "contributor_handoff": contributor_comment,
+            }
+        if not latest_reviewer_response:
+            return {
+                "state": "awaiting_reviewer_response",
+                "reason": "no_reviewer_activity",
+                "anchor_timestamp": _initial_reviewer_anchor(review_data),
+                "reviewer_comment": reviewer_comment,
+                "reviewer_review": reviewer_review,
+                "contributor_comment": contributor_comment,
+                "contributor_handoff": contributor_comment,
+            }
+        if _compare_cross_channel_conversation(
+            contributor_comment,
+            latest_reviewer_response,
+            parse_timestamp=live_review_support.parse_github_timestamp,
+        ) > 0:
+            return {
+                "state": "awaiting_reviewer_response",
+                "reason": "contributor_comment_newer",
+                "anchor_timestamp": contributor_comment.get("timestamp") if isinstance(contributor_comment, dict) else None,
+                "reviewer_comment": reviewer_comment,
+                "reviewer_review": reviewer_review,
+                "contributor_comment": contributor_comment,
+                "contributor_handoff": contributor_comment,
+            }
+        return {
+            "state": "awaiting_contributor_response",
+            "reason": "completion_missing",
+            "anchor_timestamp": latest_reviewer_response.get("timestamp") if isinstance(latest_reviewer_response, dict) else None,
+            "reviewer_comment": reviewer_comment,
+            "reviewer_review": reviewer_review,
+            "contributor_comment": contributor_comment,
+            "contributor_handoff": contributor_comment,
+        }
 
     if not isinstance(current_head, str) or not current_head.strip():
         return {"state": "projection_failed", "reason": "pull_request_head_unavailable"}

--- a/scripts/reviewer_bot_core/state_adapters.py
+++ b/scripts/reviewer_bot_core/state_adapters.py
@@ -21,6 +21,14 @@ _CANONICAL_REPAIR_MARKERS = (
     "review_repair",
     "head_observation_repair",
     "status_label_projection",
+    "issue_snapshot_read",
+    "warning_dedupe_read",
+    "warning_post",
+    "transition_dedupe_read",
+    "transition_post",
+    "assignment_add_write",
+    "assignment_remove_write",
+    "assignment_confirm_read",
 )
 
 _DEFERRED_GAP_MIGRATION_DROP_KEYS = {
@@ -36,9 +44,13 @@ def _migrate_repair_marker(marker: Any) -> dict[str, Any] | None:
         return None
     return {
         "kind": marker.get("kind"),
+        "phase": marker.get("phase"),
+        "status_code": marker.get("status_code"),
         "reason": marker.get("reason"),
         "failure_kind": marker.get("failure_kind"),
+        "retry_attempts": marker.get("retry_attempts"),
         "recorded_at": marker.get("recorded_at"),
+        "live_assignees": deepcopy(marker.get("live_assignees")),
     }
 
 

--- a/scripts/reviewer_bot_lib/app.py
+++ b/scripts/reviewer_bot_lib/app.py
@@ -51,7 +51,17 @@ def _classify_event_intent_from_context(bot: AppEventContextRuntime, context: Ev
     event_action = context.event_action
 
     if event_name in {"issues", "pull_request_target"}:
-        if event_action in {"opened", "labeled", "edited", "closed", "synchronize"}:
+        if event_action in {
+            "opened",
+            "edited",
+            "labeled",
+            "unlabeled",
+            "assigned",
+            "unassigned",
+            "reopened",
+            "closed",
+            "synchronize",
+        }:
             return bot.EVENT_INTENT_MUTATING
         return bot.EVENT_INTENT_NON_MUTATING_READONLY
 
@@ -174,10 +184,18 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
         if event_name == "issues":
             if event_action == "opened":
                 state_changed = bot.handlers.handle_issue_or_pr_opened(state)
+            elif event_action == "assigned":
+                state_changed = bot.handlers.handle_assigned_event(state)
+            elif event_action == "unassigned":
+                state_changed = bot.handlers.handle_unassigned_event(state)
             elif event_action == "labeled":
                 state_changed = bot.handlers.handle_labeled_event(state)
+            elif event_action == "unlabeled":
+                state_changed = bot.handlers.handle_unlabeled_event(state)
             elif event_action == "edited":
                 state_changed = bot.handlers.handle_issue_edited_event(state)
+            elif event_action == "reopened":
+                state_changed = bot.handlers.handle_reopened_event(state)
             elif event_action == "closed":
                 state_changed = bot.handlers.handle_closed_event(state)
 

--- a/scripts/reviewer_bot_lib/assignment_flow.py
+++ b/scripts/reviewer_bot_lib/assignment_flow.py
@@ -1,0 +1,234 @@
+"""Confirmation-gated reviewer authority transitions."""
+
+from __future__ import annotations
+
+from .config import CODING_GUIDELINE_LABEL
+from .guidance import (
+    get_assignment_failure_comment,
+    get_fls_audit_guidance,
+    get_generic_issue_guidance,
+    get_issue_guidance,
+    get_pr_guidance,
+)
+from .review_state import (
+    clear_current_reviewer,
+    ensure_review_entry,
+    set_current_reviewer,
+)
+
+
+def _log(bot, level: str, message: str, **fields) -> None:
+    bot.logger.event(level, message, **fields)
+
+
+def _now_iso(bot) -> str:
+    return bot.clock.now().isoformat()
+
+
+def _normalize_logins(values: list[str] | None) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    return [value.lower() for value in values if isinstance(value, str)]
+
+
+def _success_attempt(bot, status_code: int = 200):
+    return bot.AssignmentAttempt(success=True, status_code=status_code)
+
+
+def _coerce_attempt(bot, result, *, success_status: int) -> object:
+    if isinstance(result, bool):
+        if result:
+            return _success_attempt(bot, success_status)
+        return bot.AssignmentAttempt(success=False, status_code=None)
+    return result
+
+
+def _post_assignment_guidance(bot, request, reviewer: str) -> None:
+    if request.is_pull_request:
+        bot.github.post_comment(request.issue_number, get_pr_guidance(reviewer, request.issue_author))
+        return
+    labels = set(request.issue_labels)
+    guidance = (
+        get_fls_audit_guidance(reviewer, request.issue_author)
+        if bot.FLS_AUDIT_LABEL in labels
+        else get_issue_guidance(reviewer, request.issue_author)
+        if CODING_GUIDELINE_LABEL in labels
+        else get_generic_issue_guidance(reviewer, request.issue_author)
+    )
+    bot.github.post_comment(request.issue_number, guidance)
+
+
+def _remove_live_assignee(bot, request, issue_number: int, username: str):
+    if request.is_pull_request:
+        return _coerce_attempt(bot, bot.github.remove_pr_reviewer(issue_number, username), success_status=204)
+    return _coerce_attempt(bot, bot.github.remove_issue_assignee(issue_number, username), success_status=204)
+
+
+def _add_live_assignee(bot, request, issue_number: int, username: str):
+    if request.is_pull_request:
+        return _coerce_attempt(bot, bot.github.request_pr_reviewer_assignment(issue_number, username), success_status=201)
+    return _coerce_attempt(bot, bot.github.assign_issue_assignee(issue_number, username), success_status=201)
+
+
+def confirm_reviewer_assignment(
+    bot,
+    state: dict,
+    request,
+    *,
+    reviewer: str,
+    assignment_method: str,
+    cycle_started_at: str | None = None,
+    current_assignees: list[str] | None = None,
+    record_assignment: bool = True,
+    emit_guidance: bool = True,
+    emit_failure_comment: bool = True,
+    pr_head_sha: str | None = None,
+) -> dict[str, object]:
+    issue_number = request.issue_number
+    live_before = current_assignees
+    if live_before is None:
+        live_before = bot.github.get_issue_assignees(issue_number)
+    if live_before is None:
+        return {"confirmed": False, "reason": "assignees_unavailable"}
+    if request.issue_author and reviewer.lower() == request.issue_author.lower():
+        return {
+            "confirmed": False,
+            "reason": "self_review_not_allowed",
+            "current_assignees": live_before,
+        }
+    removal_attempts = {}
+    live_before_normalized = _normalize_logins(live_before)
+    for assignee in live_before:
+        if assignee.lower() == reviewer.lower():
+            continue
+        attempt = _remove_live_assignee(bot, request, issue_number, assignee)
+        removal_attempts[assignee] = attempt
+        if not attempt.success:
+            final_assignees = bot.github.get_issue_assignees(issue_number)
+            return {
+                "confirmed": False,
+                "reason": "remove_failed",
+                "current_assignees": live_before,
+                "final_assignees": final_assignees,
+                "removal_attempts": removal_attempts,
+            }
+    assignment_attempt = None
+    if reviewer.lower() not in live_before_normalized:
+        assignment_attempt = _add_live_assignee(bot, request, issue_number, reviewer)
+    final_assignees = bot.github.get_issue_assignees(issue_number)
+    if final_assignees is None:
+        return {
+            "confirmed": False,
+            "reason": "final_assignees_unknown",
+            "current_assignees": live_before,
+            "assignment_attempt": assignment_attempt,
+            "removal_attempts": removal_attempts,
+        }
+    final_normalized = _normalize_logins(final_assignees)
+    if len(final_assignees) == 1 and final_normalized[0] == reviewer.lower():
+        set_current_reviewer(
+            state,
+            issue_number,
+            reviewer,
+            assignment_method=assignment_method,
+            at=cycle_started_at or _now_iso(bot),
+        )
+        review_data = ensure_review_entry(state, issue_number, create=True)
+        if request.is_pull_request and isinstance(review_data, dict) and isinstance(pr_head_sha, str) and pr_head_sha:
+            review_data["active_head_sha"] = pr_head_sha
+        if record_assignment:
+            bot.adapters.queue.record_assignment(
+                state,
+                reviewer,
+                issue_number,
+                "pr" if request.is_pull_request else "issue",
+            )
+        if emit_guidance:
+            _post_assignment_guidance(bot, request, reviewer)
+        return {
+            "confirmed": True,
+            "reviewer": reviewer,
+            "current_assignees": live_before,
+            "final_assignees": final_assignees,
+            "assignment_attempt": assignment_attempt or _success_attempt(bot),
+            "removal_attempts": removal_attempts,
+        }
+    cleared = False
+    if len(final_assignees) != 1:
+        cleared = clear_current_reviewer(state, issue_number)
+    failure_comment = None
+    if assignment_attempt is not None and not assignment_attempt.success:
+        failure_comment = get_assignment_failure_comment(
+            reviewer,
+            assignment_attempt,
+            is_pull_request=request.is_pull_request,
+        )
+        if emit_failure_comment and failure_comment:
+            bot.github.post_comment(issue_number, failure_comment)
+    return {
+        "confirmed": False,
+        "reason": "final_assignee_mismatch",
+        "current_assignees": live_before,
+        "final_assignees": final_assignees,
+        "assignment_attempt": assignment_attempt,
+        "removal_attempts": removal_attempts,
+        "failure_comment": failure_comment,
+        "cleared_current_reviewer": cleared,
+    }
+
+
+def confirm_reviewer_release(
+    bot,
+    state: dict,
+    request,
+    *,
+    reviewer: str,
+    reposition_reviewer: bool = False,
+) -> dict[str, object]:
+    issue_number = request.issue_number
+    live_before = bot.github.get_issue_assignees(issue_number)
+    if live_before is None:
+        return {"confirmed": False, "reason": "assignees_unavailable"}
+    removal_attempt = None
+    if reviewer.lower() in _normalize_logins(live_before):
+        removal_attempt = _remove_live_assignee(bot, request, issue_number, reviewer)
+        if not removal_attempt.success:
+            return {
+                "confirmed": False,
+                "reason": "remove_failed",
+                "current_assignees": live_before,
+                "removal_attempt": removal_attempt,
+            }
+    final_assignees = bot.github.get_issue_assignees(issue_number)
+    if final_assignees is None:
+        return {
+            "confirmed": False,
+            "reason": "final_assignees_unknown",
+            "current_assignees": live_before,
+            "removal_attempt": removal_attempt,
+        }
+    if final_assignees:
+        return {
+            "confirmed": False,
+            "reason": "final_assignee_mismatch",
+            "current_assignees": live_before,
+            "final_assignees": final_assignees,
+            "removal_attempt": removal_attempt,
+        }
+    cleared = clear_current_reviewer(state, issue_number)
+    if reposition_reviewer:
+        bot.adapters.queue.reposition_member_as_next(state, reviewer)
+    return {
+        "confirmed": True,
+        "current_assignees": live_before,
+        "final_assignees": final_assignees,
+        "removal_attempt": removal_attempt or _success_attempt(bot, status_code=204),
+        "cleared_current_reviewer": cleared,
+    }
+
+
+def clear_reviewer_authority(bot, state: dict, issue_number: int, *, reason: str) -> bool:
+    changed = clear_current_reviewer(state, issue_number)
+    if changed:
+        _log(bot, "warning", f"Cleared reviewer authority for #{issue_number}: {reason}", issue_number=issue_number, reason=reason)
+    return changed

--- a/scripts/reviewer_bot_lib/assignment_flow.py
+++ b/scripts/reviewer_bot_lib/assignment_flow.py
@@ -10,6 +10,7 @@ from .guidance import (
     get_issue_guidance,
     get_pr_guidance,
 )
+from .repair_records import clear_repair_marker, store_repair_marker
 from .review_state import (
     clear_current_reviewer,
     ensure_review_entry,
@@ -39,8 +40,73 @@ def _coerce_attempt(bot, result, *, success_status: int) -> object:
     if isinstance(result, bool):
         if result:
             return _success_attempt(bot, success_status)
-        return bot.AssignmentAttempt(success=False, status_code=None)
+        return bot.AssignmentAttempt(success=False, status_code=None, failure_kind="transport_error")
     return result
+
+
+def _store_assignment_marker(bot, review_data: dict, issue_number: int, *, phase: str, marker: dict) -> bool:
+    changed = store_repair_marker(review_data, phase, marker)
+    if changed:
+        bot.collect_touched_item(issue_number)
+    return changed
+
+
+def _clear_assignment_marker(bot, review_data: dict, issue_number: int, *, phase: str) -> bool:
+    changed = clear_repair_marker(review_data, phase)
+    if changed:
+        bot.collect_touched_item(issue_number)
+    return changed
+
+
+def _assignment_attempt_marker(bot, *, phase: str, attempt) -> dict:
+    return {
+        "kind": "reminder_transport_failure",
+        "phase": phase,
+        "status_code": attempt.status_code,
+        "failure_kind": attempt.failure_kind or "transport_error",
+        "retry_attempts": attempt.retry_attempts,
+        "recorded_at": bot.clock.now().isoformat(),
+    }
+
+
+def _assignment_authority_mismatch_marker(bot, *, live_assignees: list[str], reason: str) -> dict:
+    return {
+        "kind": "reviewer_authority_mismatch",
+        "phase": "assignment_confirm_read",
+        "status_code": None,
+        "failure_kind": "reviewer_authority_mismatch",
+        "retry_attempts": 0,
+        "recorded_at": bot.clock.now().isoformat(),
+        "reason": reason,
+        "live_assignees": list(live_assignees),
+    }
+
+
+def _hard_fail_if_permission_denied(result, *, action: str, issue_number: int) -> None:
+    if result.failure_kind in {"unauthorized", "forbidden"}:
+        raise RuntimeError(
+            f"Permission denied during {action} for #{issue_number} (status {result.status_code})."
+        )
+
+
+def _read_live_assignees(bot, state: dict, issue_number: int, *, is_pull_request: bool | None = None):
+    review_data = ensure_review_entry(state, issue_number, create=True)
+    result = bot.github.get_issue_assignees_result(issue_number, is_pull_request=is_pull_request)
+    diagnostic_changed = False
+    _hard_fail_if_permission_denied(result, action="assignee confirmation read", issue_number=issue_number)
+    if not result.ok or not isinstance(result.payload, list):
+        if isinstance(review_data, dict):
+            diagnostic_changed = _store_assignment_marker(
+                bot,
+                review_data,
+                issue_number,
+                phase="assignment_confirm_read",
+                marker=_assignment_attempt_marker(bot, phase="assignment_confirm_read", attempt=result),
+            )
+        return review_data, None, result, diagnostic_changed
+    if isinstance(review_data, dict):
+        diagnostic_changed = _clear_assignment_marker(bot, review_data, issue_number, phase="assignment_confirm_read")
+    return review_data, result.payload, result, diagnostic_changed
 
 
 def _post_assignment_guidance(bot, request, reviewer: str) -> None:
@@ -85,16 +151,42 @@ def confirm_reviewer_assignment(
     pr_head_sha: str | None = None,
 ) -> dict[str, object]:
     issue_number = request.issue_number
+    review_data = ensure_review_entry(state, issue_number, create=True)
+    stored_reviewer = review_data.get("current_reviewer") if isinstance(review_data, dict) else None
+    diagnostic_changed = False
     live_before = current_assignees
     if live_before is None:
-        live_before = bot.github.get_issue_assignees(issue_number)
+        review_data, live_before, _, marker_changed = _read_live_assignees(
+            bot,
+            state,
+            issue_number,
+            is_pull_request=request.is_pull_request,
+        )
+        diagnostic_changed = marker_changed or diagnostic_changed
     if live_before is None:
-        return {"confirmed": False, "reason": "assignees_unavailable"}
+        return {
+            "confirmed": False,
+            "reason": "assignees_unavailable",
+            "diagnostic_changed": diagnostic_changed,
+        }
     if request.issue_author and reviewer.lower() == request.issue_author.lower():
+        if isinstance(review_data, dict):
+            diagnostic_changed = _store_assignment_marker(
+                bot,
+                review_data,
+                issue_number,
+                phase="assignment_confirm_read",
+                marker=_assignment_authority_mismatch_marker(
+                    bot,
+                    live_assignees=live_before,
+                    reason="self_review_not_allowed",
+                ),
+            ) or diagnostic_changed
         return {
             "confirmed": False,
             "reason": "self_review_not_allowed",
             "current_assignees": live_before,
+            "diagnostic_changed": diagnostic_changed,
         }
     removal_attempts = {}
     live_before_normalized = _normalize_logins(live_before)
@@ -104,18 +196,47 @@ def confirm_reviewer_assignment(
         attempt = _remove_live_assignee(bot, request, issue_number, assignee)
         removal_attempts[assignee] = attempt
         if not attempt.success:
-            final_assignees = bot.github.get_issue_assignees(issue_number)
+            if isinstance(review_data, dict):
+                diagnostic_changed = _store_assignment_marker(
+                    bot,
+                    review_data,
+                    issue_number,
+                    phase="assignment_remove_write",
+                    marker=_assignment_attempt_marker(bot, phase="assignment_remove_write", attempt=attempt),
+                ) or diagnostic_changed
+            _, final_assignees, _, marker_changed = _read_live_assignees(
+                bot,
+                state,
+                issue_number,
+                is_pull_request=request.is_pull_request,
+            )
+            diagnostic_changed = marker_changed or diagnostic_changed
             return {
                 "confirmed": False,
                 "reason": "remove_failed",
                 "current_assignees": live_before,
                 "final_assignees": final_assignees,
                 "removal_attempts": removal_attempts,
+                "diagnostic_changed": diagnostic_changed,
             }
     assignment_attempt = None
     if reviewer.lower() not in live_before_normalized:
         assignment_attempt = _add_live_assignee(bot, request, issue_number, reviewer)
-    final_assignees = bot.github.get_issue_assignees(issue_number)
+        if not assignment_attempt.success and isinstance(review_data, dict):
+            diagnostic_changed = _store_assignment_marker(
+                bot,
+                review_data,
+                issue_number,
+                phase="assignment_add_write",
+                marker=_assignment_attempt_marker(bot, phase="assignment_add_write", attempt=assignment_attempt),
+            ) or diagnostic_changed
+    review_data, final_assignees, _, marker_changed = _read_live_assignees(
+        bot,
+        state,
+        issue_number,
+        is_pull_request=request.is_pull_request,
+    )
+    diagnostic_changed = marker_changed or diagnostic_changed
     if final_assignees is None:
         return {
             "confirmed": False,
@@ -123,6 +244,7 @@ def confirm_reviewer_assignment(
             "current_assignees": live_before,
             "assignment_attempt": assignment_attempt,
             "removal_attempts": removal_attempts,
+            "diagnostic_changed": diagnostic_changed,
         }
     final_normalized = _normalize_logins(final_assignees)
     if len(final_assignees) == 1 and final_normalized[0] == reviewer.lower():
@@ -145,6 +267,11 @@ def confirm_reviewer_assignment(
             )
         if emit_guidance:
             _post_assignment_guidance(bot, request, reviewer)
+        bot.collect_touched_item(issue_number)
+        if isinstance(review_data, dict):
+            diagnostic_changed = _clear_assignment_marker(bot, review_data, issue_number, phase="assignment_add_write") or diagnostic_changed
+            diagnostic_changed = _clear_assignment_marker(bot, review_data, issue_number, phase="assignment_remove_write") or diagnostic_changed
+            diagnostic_changed = _clear_assignment_marker(bot, review_data, issue_number, phase="assignment_confirm_read") or diagnostic_changed
         return {
             "confirmed": True,
             "reviewer": reviewer,
@@ -152,10 +279,29 @@ def confirm_reviewer_assignment(
             "final_assignees": final_assignees,
             "assignment_attempt": assignment_attempt or _success_attempt(bot),
             "removal_attempts": removal_attempts,
+            "diagnostic_changed": diagnostic_changed,
         }
     cleared = False
-    if len(final_assignees) != 1:
+    if len(final_assignees) != 1 or (
+        len(final_assignees) == 1
+        and isinstance(stored_reviewer, str)
+        and final_normalized[0] != stored_reviewer.lower()
+    ):
         cleared = clear_current_reviewer(state, issue_number)
+        if cleared:
+            bot.collect_touched_item(issue_number)
+    if isinstance(review_data, dict):
+        diagnostic_changed = _store_assignment_marker(
+            bot,
+            review_data,
+            issue_number,
+            phase="assignment_confirm_read",
+            marker=_assignment_authority_mismatch_marker(
+                bot,
+                live_assignees=final_assignees,
+                reason="final_assignee_mismatch",
+            ),
+        ) or diagnostic_changed
     failure_comment = None
     if assignment_attempt is not None and not assignment_attempt.success:
         failure_comment = get_assignment_failure_comment(
@@ -174,6 +320,7 @@ def confirm_reviewer_assignment(
         "removal_attempts": removal_attempts,
         "failure_comment": failure_comment,
         "cleared_current_reviewer": cleared,
+        "diagnostic_changed": diagnostic_changed,
     }
 
 
@@ -186,44 +333,100 @@ def confirm_reviewer_release(
     reposition_reviewer: bool = False,
 ) -> dict[str, object]:
     issue_number = request.issue_number
-    live_before = bot.github.get_issue_assignees(issue_number)
+    review_data = ensure_review_entry(state, issue_number, create=True)
+    stored_reviewer = review_data.get("current_reviewer") if isinstance(review_data, dict) else None
+    review_data, live_before, _, diagnostic_changed = _read_live_assignees(
+        bot,
+        state,
+        issue_number,
+        is_pull_request=request.is_pull_request,
+    )
     if live_before is None:
-        return {"confirmed": False, "reason": "assignees_unavailable"}
+        return {
+            "confirmed": False,
+            "reason": "assignees_unavailable",
+            "diagnostic_changed": diagnostic_changed,
+        }
     removal_attempt = None
     if reviewer.lower() in _normalize_logins(live_before):
         removal_attempt = _remove_live_assignee(bot, request, issue_number, reviewer)
         if not removal_attempt.success:
+            if isinstance(review_data, dict):
+                diagnostic_changed = _store_assignment_marker(
+                    bot,
+                    review_data,
+                    issue_number,
+                    phase="assignment_remove_write",
+                    marker=_assignment_attempt_marker(bot, phase="assignment_remove_write", attempt=removal_attempt),
+                ) or diagnostic_changed
             return {
                 "confirmed": False,
                 "reason": "remove_failed",
                 "current_assignees": live_before,
                 "removal_attempt": removal_attempt,
+                "diagnostic_changed": diagnostic_changed,
             }
-    final_assignees = bot.github.get_issue_assignees(issue_number)
+    review_data, final_assignees, _, marker_changed = _read_live_assignees(
+        bot,
+        state,
+        issue_number,
+        is_pull_request=request.is_pull_request,
+    )
+    diagnostic_changed = marker_changed or diagnostic_changed
     if final_assignees is None:
         return {
             "confirmed": False,
             "reason": "final_assignees_unknown",
             "current_assignees": live_before,
             "removal_attempt": removal_attempt,
+            "diagnostic_changed": diagnostic_changed,
         }
     if final_assignees:
+        cleared = False
+        if len(final_assignees) != 1 or (
+            len(final_assignees) == 1
+            and isinstance(stored_reviewer, str)
+            and final_assignees[0].lower() != stored_reviewer.lower()
+        ):
+            cleared = clear_current_reviewer(state, issue_number)
+            if cleared:
+                bot.collect_touched_item(issue_number)
+        if isinstance(review_data, dict):
+            diagnostic_changed = _store_assignment_marker(
+                bot,
+                review_data,
+                issue_number,
+                phase="assignment_confirm_read",
+                marker=_assignment_authority_mismatch_marker(
+                    bot,
+                    live_assignees=final_assignees,
+                    reason="final_assignee_mismatch",
+                ),
+            ) or diagnostic_changed
         return {
             "confirmed": False,
             "reason": "final_assignee_mismatch",
             "current_assignees": live_before,
             "final_assignees": final_assignees,
             "removal_attempt": removal_attempt,
+            "cleared_current_reviewer": cleared,
+            "diagnostic_changed": diagnostic_changed,
         }
     cleared = clear_current_reviewer(state, issue_number)
+    if cleared:
+        bot.collect_touched_item(issue_number)
     if reposition_reviewer:
         bot.adapters.queue.reposition_member_as_next(state, reviewer)
+    if isinstance(review_data, dict):
+        diagnostic_changed = _clear_assignment_marker(bot, review_data, issue_number, phase="assignment_remove_write") or diagnostic_changed
+        diagnostic_changed = _clear_assignment_marker(bot, review_data, issue_number, phase="assignment_confirm_read") or diagnostic_changed
     return {
         "confirmed": True,
         "current_assignees": live_before,
         "final_assignees": final_assignees,
         "removal_attempt": removal_attempt or _success_attempt(bot, status_code=204),
         "cleared_current_reviewer": cleared,
+        "diagnostic_changed": diagnostic_changed,
     }
 
 

--- a/scripts/reviewer_bot_lib/bootstrap_runtime.py
+++ b/scripts/reviewer_bot_lib/bootstrap_runtime.py
@@ -83,8 +83,19 @@ class _BootstrapGitHubServices:
     def ensure_label_exists(self, label, *, color=None, description=None):
         return github_api.ensure_label_exists(self._runtime_getter(), label, color=color, description=description)
 
-    def get_issue_assignees(self, issue_number):
-        return github_api.get_issue_assignees(self._runtime_getter(), issue_number)
+    def get_issue_assignees(self, issue_number, *, is_pull_request=None):
+        return github_api.get_issue_assignees(
+            self._runtime_getter(),
+            issue_number,
+            is_pull_request=is_pull_request,
+        )
+
+    def get_issue_assignees_result(self, issue_number, *, is_pull_request=None):
+        return github_api.get_issue_assignees_result(
+            self._runtime_getter(),
+            issue_number,
+            is_pull_request=is_pull_request,
+        )
 
     def request_pr_reviewer_assignment(self, issue_number, username):
         return github_api.request_pr_reviewer_assignment(self._runtime_getter(), issue_number, username)

--- a/scripts/reviewer_bot_lib/bootstrap_runtime.py
+++ b/scripts/reviewer_bot_lib/bootstrap_runtime.py
@@ -68,6 +68,9 @@ class _BootstrapGitHubServices:
     def post_comment(self, issue_number, body):
         return github_api.post_comment(self._runtime_getter(), issue_number, body)
 
+    def post_comment_result(self, issue_number, body):
+        return github_api.post_comment_result(self._runtime_getter(), issue_number, body)
+
     def get_repo_labels(self):
         return github_api.get_repo_labels(self._runtime_getter())
 
@@ -105,7 +108,18 @@ class _BootstrapGitHubServices:
         return github_api.check_user_permission(self._runtime_getter(), username, required_permission)
 
     def get_issue_or_pr_snapshot(self, issue_number):
-        return github_api.github_api(self._runtime_getter(), "GET", f"issues/{issue_number}")
+        return github_api.get_issue_or_pr_snapshot(self._runtime_getter(), issue_number)
+
+    def get_issue_or_pr_snapshot_result(self, issue_number):
+        return github_api.get_issue_or_pr_snapshot_result(self._runtime_getter(), issue_number)
+
+    def list_issue_comments_result(self, issue_number, *, page=1, per_page=100):
+        return github_api.list_issue_comments_result(
+            self._runtime_getter(),
+            issue_number,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_pull_request_reviews(self, issue_number):
         return reviews.get_pull_request_reviews(self._runtime_getter(), issue_number)
@@ -135,8 +149,20 @@ class _BootstrapHandlerServices:
     def handle_labeled_event(self, current_state):
         return lifecycle.handle_labeled_event(self._runtime_getter(), current_state)
 
+    def handle_unlabeled_event(self, current_state):
+        return lifecycle.handle_unlabeled_event(self._runtime_getter(), current_state)
+
+    def handle_assigned_event(self, current_state):
+        return lifecycle.handle_assigned_event(self._runtime_getter(), current_state)
+
+    def handle_unassigned_event(self, current_state):
+        return lifecycle.handle_unassigned_event(self._runtime_getter(), current_state)
+
     def handle_issue_edited_event(self, current_state):
         return lifecycle.handle_issue_edited_event(self._runtime_getter(), current_state)
+
+    def handle_reopened_event(self, current_state):
+        return lifecycle.handle_reopened_event(self._runtime_getter(), current_state)
 
     def handle_closed_event(self, current_state):
         return lifecycle.handle_closed_event(self._runtime_getter(), current_state)

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -193,7 +193,9 @@ def handle_pass_command(
         current_assignees=current_assignees,
     )
     if not result.get("confirmed"):
-        return _assignment_failure_response(next_reviewer, result), False
+        return _assignment_failure_response(next_reviewer, result), False, bool(
+            result.get("diagnostic_changed") or result.get("cleared_current_reviewer")
+        )
     issue_data["skipped"] = skipped
     bot.adapters.queue.reposition_member_as_next(state, passed_reviewer)
     assignment_line = f"@{next_reviewer} is now assigned as the reviewer."
@@ -236,17 +238,9 @@ def handle_pass_until_command(
                     entry["reason"] = reason
                 return (f"✅ Updated your return date to {normalized_return_date}.\n\nYou're already marked as away."), True
         return (f"❌ @{comment_author} is not in the reviewer queue. Only Producers can use this command."), False
-    state["queue"].remove(user_in_queue)
     pass_entry = {"github": user_in_queue["github"], "name": user_in_queue.get("name", user_in_queue["github"]), "return_date": normalized_return_date, "original_queue_position": user_index}
     if reason:
         pass_entry["reason"] = reason
-    state["pass_until"].append(pass_entry)
-    if state["queue"]:
-        if user_index is not None and user_index < state["current_index"]:
-            state["current_index"] = max(0, state["current_index"] - 1)
-        state["current_index"] = state["current_index"] % len(state["queue"])
-    else:
-        state["current_index"] = 0
     current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
     if assignee_error:
         return assignee_error, False
@@ -255,6 +249,7 @@ def handle_pass_until_command(
     reassigned_msg = ""
     if is_current_reviewer:
         skip_set = {assignment_request.issue_author} if assignment_request.issue_author else set()
+        skip_set.add(comment_author)
         next_reviewer = bot.adapters.queue.get_next_reviewer(state, skip_usernames=skip_set)
         if next_reviewer:
             result = _apply_assignment_transition(
@@ -269,6 +264,9 @@ def handle_pass_until_command(
                 reassigned_msg = f"\n\n@{next_reviewer} has been assigned as the new reviewer for this issue."
             else:
                 reassigned_msg = f"\n\n{_assignment_failure_response(next_reviewer, result)}"
+                return reassigned_msg.strip(), False, bool(
+                    result.get("diagnostic_changed") or result.get("cleared_current_reviewer")
+                )
         else:
             release_result = assignment_flow.confirm_reviewer_release(
                 bot,
@@ -281,6 +279,18 @@ def handle_pass_until_command(
                 if release_result.get("confirmed")
                 else f"\n\n{_assignment_failure_response(comment_author, release_result)}"
             )
+            if not release_result.get("confirmed"):
+                return reassigned_msg.strip(), False, bool(
+                    release_result.get("diagnostic_changed") or release_result.get("cleared_current_reviewer")
+                )
+    state["queue"].remove(user_in_queue)
+    state["pass_until"].append(pass_entry)
+    if state["queue"]:
+        if user_index is not None and user_index < state["current_index"]:
+            state["current_index"] = max(0, state["current_index"] - 1)
+        state["current_index"] = state["current_index"] % len(state["queue"])
+    else:
+        state["current_index"] = 0
     reason_text = f" ({reason})" if reason else ""
     return (f"✅ @{comment_author} is now away until {normalized_return_date}{reason_text}.\n\nYou'll be automatically added back to the queue on that date.{reassigned_msg}"), True
 
@@ -437,7 +447,9 @@ def handle_claim_command(
     )
     prev_text = f" (previously: @{', @'.join(current_assignees)})" if current_assignees else ""
     if not result.get("confirmed"):
-        return _assignment_failure_response(comment_author, result, prefix=""), False
+        return _assignment_failure_response(comment_author, result, prefix=""), False, bool(
+            result.get("diagnostic_changed") or result.get("cleared_current_reviewer")
+        )
     return f"✅ @{comment_author} has claimed this review{prev_text}.", True
 
 
@@ -499,7 +511,9 @@ def handle_release_command(
         reposition_reviewer=assignment_method == "round-robin",
     )
     if not result.get("confirmed"):
-        return _assignment_failure_response(target_username, result), False
+        return _assignment_failure_response(target_username, result), False, bool(
+            result.get("diagnostic_changed") or result.get("cleared_current_reviewer")
+        )
     reason_text = f" Reason: {reason}" if reason else ""
     if releasing_other:
         return (f"✅ @{comment_author} has released @{target_username} from this review.{reason_text}\n\n_This issue/PR is now unassigned. Use `{bot.BOT_MENTION} /r? producers` to assign the next reviewer from the queue, or `{bot.BOT_MENTION} /claim` to claim it._"), True
@@ -540,7 +554,9 @@ def handle_assign_command(
     prev_text = f" (previously: @{', @'.join(current_assignees)})" if current_assignees else ""
     if result.get("confirmed"):
         return f"✅ @{username} has been assigned as reviewer{prev_text}.", True
-    return _assignment_failure_response(username, result), False
+    return _assignment_failure_response(username, result), False, bool(
+        result.get("diagnostic_changed") or result.get("cleared_current_reviewer")
+    )
 
 
 def handle_assign_from_queue_command(
@@ -568,4 +584,6 @@ def handle_assign_from_queue_command(
     prev_text = f" (previously: @{', @'.join(current_assignees)})" if current_assignees else ""
     if result.get("confirmed"):
         return f"✅ @{next_reviewer} (next in queue) has been assigned as reviewer{prev_text}.", True
-    return _assignment_failure_response(next_reviewer, result), False
+    return _assignment_failure_response(next_reviewer, result), False, bool(
+        result.get("diagnostic_changed") or result.get("cleared_current_reviewer")
+    )

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -3,16 +3,10 @@
 import re
 from datetime import datetime
 
-from . import review_state
-from .config import AssignmentAttempt
+from . import assignment_flow, review_state
+from .config import CODING_GUIDELINE_LABEL
 from .context import AssignmentRequest
 from .event_inputs import build_assignment_request as decode_assignment_request
-from .guidance import (
-    get_assignment_failure_comment,
-    get_fls_audit_guidance,
-    get_issue_guidance,
-    get_pr_guidance,
-)
 
 
 def _log(bot, level: str, message: str, **fields) -> None:
@@ -113,39 +107,24 @@ def parse_command(bot, comment_body: str) -> tuple[str, list[str]] | None:
     return command, args
 
 
-def _apply_assignment_side_effects(
+def _apply_assignment_transition(
     bot,
     state: dict,
     request: AssignmentRequest,
     reviewer: str,
     assignment_method: str,
-) -> tuple[AssignmentAttempt, str | None]:
-    issue_number = request.issue_number
-    if request.is_pull_request:
-        assignment_attempt = bot.github.request_pr_reviewer_assignment(issue_number, reviewer)
-    else:
-        assignment_attempt = bot.github.assign_issue_assignee(issue_number, reviewer)
-    review_state.set_current_reviewer(state, issue_number, reviewer, assignment_method=assignment_method)
-    bot.adapters.queue.record_assignment(state, reviewer, issue_number, "pr" if request.is_pull_request else "issue")
-    failure_comment = get_assignment_failure_comment(
-        reviewer,
-        assignment_attempt,
-        is_pull_request=request.is_pull_request,
+    current_assignees: list[str] | None = None,
+) -> dict[str, object]:
+    return assignment_flow.confirm_reviewer_assignment(
+        bot,
+        state,
+        request,
+        reviewer=reviewer,
+        assignment_method=assignment_method,
+        current_assignees=current_assignees,
+        emit_guidance=True,
+        emit_failure_comment=False,
     )
-    if failure_comment:
-        bot.github.post_comment(issue_number, failure_comment)
-    if assignment_attempt.success:
-        if request.is_pull_request:
-            bot.github.post_comment(issue_number, get_pr_guidance(reviewer, request.issue_author))
-        else:
-            labels = set(request.issue_labels)
-            guidance = (
-                get_fls_audit_guidance(reviewer, request.issue_author)
-                if bot.FLS_AUDIT_LABEL in labels
-                else get_issue_guidance(reviewer, request.issue_author)
-            )
-            bot.github.post_comment(issue_number, guidance)
-    return assignment_attempt, failure_comment
 
 
 def _current_assignees_or_error(bot, issue_number: int) -> tuple[list[str] | None, str | None]:
@@ -153,6 +132,26 @@ def _current_assignees_or_error(bot, issue_number: int) -> tuple[list[str] | Non
     if current_assignees is None:
         return None, "❌ Unable to determine current assignees/reviewers from GitHub; refusing to continue."
     return current_assignees, None
+
+
+def _assignment_failure_response(target_reviewer: str, result: dict[str, object], *, prefix: str = "") -> str:
+    failure_comment = result.get("failure_comment")
+    if isinstance(failure_comment, str) and failure_comment:
+        return f"{prefix}{failure_comment}"
+    final_assignees = result.get("final_assignees")
+    if isinstance(final_assignees, list):
+        if not final_assignees:
+            return f"{prefix}❌ GitHub could not confirm @{target_reviewer} as reviewer. The issue is now unassigned."
+        return f"{prefix}❌ GitHub could not confirm @{target_reviewer} as reviewer. Live assignees remain: @{', @'.join(final_assignees)}."
+    return f"{prefix}❌ GitHub could not confirm @{target_reviewer} as reviewer."
+
+
+def _single_current_assignee_or_error(current_assignees: list[str]) -> tuple[str | None, str | None]:
+    if not current_assignees:
+        return None, "❌ No reviewer is currently assigned to pass."
+    if len(current_assignees) != 1:
+        return None, "❌ Unable to confirm a single assigned reviewer from GitHub; refusing to continue."
+    return current_assignees[0], None
 
 
 def handle_pass_command(
@@ -167,44 +166,37 @@ def handle_pass_command(
     issue_data = review_state.ensure_review_entry(state, issue_number, create=True)
     if issue_data is None:
         return "❌ Unable to load review state.", False
-    passed_reviewer = issue_data.get("current_reviewer")
-    if not passed_reviewer:
-        current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
-        if assignee_error:
-            return assignee_error, False
-        passed_reviewer = current_assignees[0] if current_assignees else None
-    if not passed_reviewer:
-        return "❌ No reviewer is currently assigned to pass.", False
+    current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
+    if assignee_error:
+        return assignee_error, False
+    passed_reviewer, reviewer_error = _single_current_assignee_or_error(current_assignees)
+    if reviewer_error:
+        return reviewer_error, False
     if passed_reviewer.lower() != comment_author.lower():
         return "❌ Only the currently assigned reviewer can use `/pass`.", False
-    is_first_pass = len(issue_data["skipped"]) == 0
-    if passed_reviewer not in issue_data["skipped"]:
-        issue_data["skipped"].append(passed_reviewer)
-    skip_set = set(issue_data["skipped"])
+    skipped = list(issue_data["skipped"])
+    is_first_pass = len(skipped) == 0
+    if passed_reviewer not in skipped:
+        skipped.append(passed_reviewer)
+    skip_set = set(skipped)
     if assignment_request.issue_author:
         skip_set.add(assignment_request.issue_author)
     next_reviewer = bot.adapters.queue.get_next_reviewer(state, skip_usernames=skip_set)
     if not next_reviewer:
         return ("❌ No other reviewers available. Everyone in the queue has either passed on this issue or is the author."), False
-    bot.adapters.queue.reposition_member_as_next(state, passed_reviewer)
-    if assignment_request.is_pull_request:
-        bot.github.remove_pr_reviewer(issue_number, passed_reviewer)
-    else:
-        bot.github.remove_issue_assignee(issue_number, passed_reviewer)
-    assignment_attempt, failure_comment = _apply_assignment_side_effects(
+    result = _apply_assignment_transition(
         bot,
         state,
         assignment_request,
         next_reviewer,
         "round-robin",
+        current_assignees=current_assignees,
     )
+    if not result.get("confirmed"):
+        return _assignment_failure_response(next_reviewer, result), False
+    issue_data["skipped"] = skipped
+    bot.adapters.queue.reposition_member_as_next(state, passed_reviewer)
     assignment_line = f"@{next_reviewer} is now assigned as the reviewer."
-    if not assignment_attempt.success:
-        if failure_comment:
-            assignment_line = failure_comment
-        else:
-            status_text = assignment_attempt.status_code or "unknown"
-            assignment_line = f"@{next_reviewer} is designated as reviewer in bot state, but GitHub assignment could not be confirmed (status {status_text})."
     reason_text = f" Reason: {reason}" if reason else ""
     if is_first_pass:
         return (f"✅ @{passed_reviewer} has passed this review.{reason_text}\n\n{assignment_line}\n\n_@{passed_reviewer} is next in queue for future issues._"), True
@@ -255,46 +247,73 @@ def handle_pass_until_command(
         state["current_index"] = state["current_index"] % len(state["queue"])
     else:
         state["current_index"] = 0
-    issue_key = str(issue_number)
-    tracked_reviewer = None
-    if "active_reviews" in state and issue_key in state["active_reviews"]:
-        issue_data = state["active_reviews"][issue_key]
-        if isinstance(issue_data, dict):
-            tracked_reviewer = issue_data.get("current_reviewer")
     current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
     if assignee_error:
         return assignee_error, False
-    is_current_reviewer = ((tracked_reviewer and tracked_reviewer.lower() == comment_author.lower()) or comment_author.lower() in [a.lower() for a in current_assignees])
+    live_reviewer, reviewer_error = _single_current_assignee_or_error(current_assignees)
+    is_current_reviewer = reviewer_error is None and isinstance(live_reviewer, str) and live_reviewer.lower() == comment_author.lower()
     reassigned_msg = ""
     if is_current_reviewer:
-        if assignment_request.is_pull_request:
-            bot.github.remove_pr_reviewer(issue_number, comment_author)
-        else:
-            bot.github.remove_issue_assignee(issue_number, comment_author)
         skip_set = {assignment_request.issue_author} if assignment_request.issue_author else set()
         next_reviewer = bot.adapters.queue.get_next_reviewer(state, skip_usernames=skip_set)
         if next_reviewer:
-            assignment_attempt, failure_comment = _apply_assignment_side_effects(
+            result = _apply_assignment_transition(
                 bot,
                 state,
                 assignment_request,
                 next_reviewer,
                 "round-robin",
+                current_assignees=current_assignees,
             )
-            if assignment_attempt.success:
+            if result.get("confirmed"):
                 reassigned_msg = f"\n\n@{next_reviewer} has been assigned as the new reviewer for this issue."
             else:
-                if failure_comment:
-                    reassigned_msg = f"\n\n{failure_comment}"
-                else:
-                    status_text = assignment_attempt.status_code or "unknown"
-                    reassigned_msg = f"\n\n@{next_reviewer} is designated as the new reviewer in bot state, but GitHub assignment is not confirmed (status {status_text})."
+                reassigned_msg = f"\n\n{_assignment_failure_response(next_reviewer, result)}"
         else:
-            if "active_reviews" in state and issue_key in state["active_reviews"] and isinstance(state["active_reviews"][issue_key], dict):
-                state["active_reviews"][issue_key]["current_reviewer"] = None
-            reassigned_msg = "\n\n⚠️ No other reviewers available to assign."
+            release_result = assignment_flow.confirm_reviewer_release(
+                bot,
+                state,
+                assignment_request,
+                reviewer=comment_author,
+            )
+            reassigned_msg = (
+                "\n\n⚠️ No other reviewers available to assign."
+                if release_result.get("confirmed")
+                else f"\n\n{_assignment_failure_response(comment_author, release_result)}"
+            )
     reason_text = f" ({reason})" if reason else ""
     return (f"✅ @{comment_author} is now away until {normalized_return_date}{reason_text}.\n\nYou'll be automatically added back to the queue on that date.{reassigned_msg}"), True
+
+
+def handle_done_command(
+    bot,
+    state: dict,
+    issue_number: int,
+    comment_author: str,
+    request: AssignmentRequest | None = None,
+) -> tuple[str, bool]:
+    assignment_request = request or build_assignment_request(bot, issue_number=issue_number)
+    if assignment_request.is_pull_request:
+        return "❌ `/done` is not supported on pull requests.", False
+    labels = set(assignment_request.issue_labels)
+    if CODING_GUIDELINE_LABEL in labels:
+        return "❌ `/done` is not supported on coding guideline issues. Use `sign-off: create pr` when the review is ready.", False
+    review_data = review_state.ensure_review_entry(state, issue_number)
+    if review_data is None:
+        return "❌ No active tracked review exists for this issue.", False
+    current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
+    if assignee_error:
+        return assignee_error, False
+    is_current_reviewer = len(current_assignees) == 1 and current_assignees[0].lower() == comment_author.lower()
+    if not is_current_reviewer:
+        permission_status = bot.github.get_user_permission_status(comment_author, "triage")
+        if permission_status == "unavailable":
+            return "❌ Unable to verify triage permissions right now; refusing to continue.", False
+        if permission_status != "granted":
+            return "❌ Only the current reviewer or a maintainer with triage+ permission can use `/done`.", False
+    if not review_state.mark_review_complete(state, issue_number, comment_author, "command: /done"):
+        return "ℹ️ This review is already marked complete.", True
+    return "✅ Review marked complete.", True
 
 
 def handle_label_command(
@@ -323,7 +342,11 @@ def handle_label_command(
                 all_success = False
             elif bot.github.add_label(issue_number, label):
                 results.append(f"✅ Added label `{label}`")
-                if label == "sign-off: create pr" and not assignment_request.is_pull_request:
+                if (
+                    label == "sign-off: create pr"
+                    and not assignment_request.is_pull_request
+                    and CODING_GUIDELINE_LABEL in set(assignment_request.issue_labels)
+                ):
                     review_data = review_state.ensure_review_entry(state, issue_number)
                     reviewer = review_data.get("current_reviewer") if review_data else None
                     completion_changed = review_state.mark_review_complete(
@@ -384,7 +407,7 @@ def handle_queue_command(
 
 
 def handle_commands_command(bot) -> tuple[str, bool]:
-    return (f"ℹ️ **Available Commands**\n\n**Pass or step away:**\n- `{bot.BOT_MENTION} /pass [reason]` - Pass this review to next in queue (current reviewer only)\n- `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from queue until a date\n- `{bot.BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)\n\n**Assign reviewers:**\n- `{bot.BOT_MENTION} /r? @username` - Assign a specific reviewer\n- `{bot.BOT_MENTION} /r? producers` - Request the next reviewer from the queue\n- `{bot.BOT_MENTION} /claim` - Claim this review for yourself\n\n**Other:**\n- `{bot.BOT_MENTION} /label +label-name` - Add a label\n- `{bot.BOT_MENTION} /label -label-name` - Remove a label\n- `{bot.BOT_MENTION} /rectify` - Reconcile this issue/PR review state from GitHub\n- `{bot.BOT_MENTION} /accept-no-fls-changes` - Update spec.lock and open a PR when no guidelines are impacted\n- `{bot.BOT_MENTION} /queue` - Show current queue status\n- `{bot.BOT_MENTION} /sync-members` - Sync queue with members.md"), True
+    return (f"ℹ️ **Available Commands**\n\n**Pass or step away:**\n- `{bot.BOT_MENTION} /pass [reason]` - Pass this review to next in queue (current reviewer only)\n- `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from queue until a date\n- `{bot.BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)\n\n**Assign reviewers:**\n- `{bot.BOT_MENTION} /r? @username` - Assign a specific reviewer\n- `{bot.BOT_MENTION} /r? producers` - Request the next reviewer from the queue\n- `{bot.BOT_MENTION} /claim` - Claim this review for yourself\n\n**Other:**\n- `{bot.BOT_MENTION} /done` - Mark a tracked non-PR issue review complete\n- `{bot.BOT_MENTION} /label +label-name` - Add a label\n- `{bot.BOT_MENTION} /label -label-name` - Remove a label\n- `{bot.BOT_MENTION} /rectify` - Reconcile this issue/PR review state from GitHub\n- `{bot.BOT_MENTION} /accept-no-fls-changes` - Update spec.lock and open a PR when no guidelines are impacted\n- `{bot.BOT_MENTION} /queue` - Show current queue status\n- `{bot.BOT_MENTION} /sync-members` - Sync queue with members.md"), True
 
 
 def handle_claim_command(
@@ -404,24 +427,18 @@ def handle_claim_command(
     current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
     if assignee_error:
         return assignee_error, False
-    for assignee in current_assignees:
-        if assignment_request.is_pull_request:
-            bot.github.remove_pr_reviewer(issue_number, assignee)
-        else:
-            bot.github.remove_issue_assignee(issue_number, assignee)
-    assignment_attempt, failure_comment = _apply_assignment_side_effects(
+    result = _apply_assignment_transition(
         bot,
         state,
         assignment_request,
         comment_author,
         "claim",
+        current_assignees=current_assignees,
     )
     prev_text = f" (previously: @{', @'.join(current_assignees)})" if current_assignees else ""
-    response = f"✅ @{comment_author} has claimed this review{prev_text}."
-    if not assignment_attempt.success:
-        if failure_comment:
-            response = f"{response}\n\n{failure_comment}"
-    return response, True
+    if not result.get("confirmed"):
+        return _assignment_failure_response(comment_author, result, prefix=""), False
+    return f"✅ @{comment_author} has claimed this review{prev_text}.", True
 
 
 def handle_release_command(
@@ -473,15 +490,16 @@ def handle_release_command(
             return (f"❌ @{comment_author} is not the current reviewer. Current reviewer: @{tracked_reviewer}"), False
         if current_assignees:
             return (f"❌ @{comment_author} is not assigned to this issue/PR. Current assignee(s): @{', @'.join(current_assignees)}"), False
-        return "❌ No reviewer is currently assigned to release.", False
-    if request.is_pull_request:
-        bot.github.remove_pr_reviewer(issue_number, target_username)
-    else:
-        bot.github.remove_issue_assignee(issue_number, target_username)
-    if "active_reviews" in state and issue_key in state["active_reviews"] and isinstance(state["active_reviews"][issue_key], dict):
-        state["active_reviews"][issue_key]["current_reviewer"] = None
-    if assignment_method == "round-robin":
-        bot.adapters.queue.reposition_member_as_next(state, target_username)
+            return "❌ No reviewer is currently assigned to release.", False
+    result = assignment_flow.confirm_reviewer_release(
+        bot,
+        state,
+        request,
+        reviewer=target_username,
+        reposition_reviewer=assignment_method == "round-robin",
+    )
+    if not result.get("confirmed"):
+        return _assignment_failure_response(target_username, result), False
     reason_text = f" Reason: {reason}" if reason else ""
     if releasing_other:
         return (f"✅ @{comment_author} has released @{target_username} from this review.{reason_text}\n\n_This issue/PR is now unassigned. Use `{bot.BOT_MENTION} /r? producers` to assign the next reviewer from the queue, or `{bot.BOT_MENTION} /claim` to claim it._"), True
@@ -511,25 +529,18 @@ def handle_assign_command(
     current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
     if assignee_error:
         return assignee_error, False
-    for assignee in current_assignees:
-        if assignment_request.is_pull_request:
-            bot.github.remove_pr_reviewer(issue_number, assignee)
-        else:
-            bot.github.remove_issue_assignee(issue_number, assignee)
-    assignment_attempt, failure_comment = _apply_assignment_side_effects(
+    result = _apply_assignment_transition(
         bot,
         state,
         assignment_request,
         username,
         "manual",
+        current_assignees=current_assignees,
     )
     prev_text = f" (previously: @{', @'.join(current_assignees)})" if current_assignees else ""
-    if assignment_attempt.success:
+    if result.get("confirmed"):
         return f"✅ @{username} has been assigned as reviewer{prev_text}.", True
-    response = f"✅ @{username} remains designated as reviewer in bot state{prev_text}. GitHub reviewer assignment could not be completed."
-    if failure_comment:
-        response = f"{response}\n\n{failure_comment}"
-    return response, True
+    return _assignment_failure_response(username, result), False
 
 
 def handle_assign_from_queue_command(
@@ -542,23 +553,19 @@ def handle_assign_from_queue_command(
     current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
     if assignee_error:
         return assignee_error, False
-    for assignee in current_assignees:
-        if assignment_request.is_pull_request:
-            bot.github.remove_pr_reviewer(issue_number, assignee)
-        else:
-            bot.github.remove_issue_assignee(issue_number, assignee)
     skip_set = {assignment_request.issue_author} if assignment_request.issue_author else set()
     next_reviewer = bot.adapters.queue.get_next_reviewer(state, skip_usernames=skip_set)
     if not next_reviewer:
         return (f"❌ No reviewers available in the queue. Please use `{bot.BOT_MENTION} /sync-members` to update the queue."), False
-    assignment_attempt, _failure_comment = _apply_assignment_side_effects(
+    result = _apply_assignment_transition(
         bot,
         state,
         assignment_request,
         next_reviewer,
         "round-robin",
+        current_assignees=current_assignees,
     )
     prev_text = f" (previously: @{', @'.join(current_assignees)})" if current_assignees else ""
-    if assignment_attempt.success:
+    if result.get("confirmed"):
         return f"✅ @{next_reviewer} (next in queue) has been assigned as reviewer{prev_text}.", True
-    return (f"✅ @{next_reviewer} remains designated as reviewer in bot state{prev_text}. GitHub reviewer assignment could not be completed."), True
+    return _assignment_failure_response(next_reviewer, result), False

--- a/scripts/reviewer_bot_lib/comment_application.py
+++ b/scripts/reviewer_bot_lib/comment_application.py
@@ -95,6 +95,7 @@ def _build_execution_result(command_id: comment_command_policy.OrdinaryCommandId
     if command_id in {
         comment_command_policy.OrdinaryCommandId.PASS,
         comment_command_policy.OrdinaryCommandId.AWAY,
+        comment_command_policy.OrdinaryCommandId.DONE,
         comment_command_policy.OrdinaryCommandId.SYNC_MEMBERS,
         comment_command_policy.OrdinaryCommandId.CLAIM,
         comment_command_policy.OrdinaryCommandId.RELEASE,
@@ -137,6 +138,19 @@ def _execute_away(bot, state: dict, decision, assignment_request: AssignmentRequ
             decision.actor,
             decision.raw_args[0],
             " ".join(decision.raw_args[1:]) if len(decision.raw_args) > 1 else None,
+            request=assignment_request,
+        ),
+    )
+
+
+def _execute_done(bot, state: dict, decision, assignment_request: AssignmentRequest | None) -> CommandExecutionResult:
+    return _build_execution_result(
+        decision.command_id,
+        commands_module.handle_done_command(
+            bot,
+            state,
+            decision.issue_number,
+            decision.actor,
             request=assignment_request,
         ),
     )
@@ -216,6 +230,7 @@ def _execute_assign_from_queue(bot, state: dict, decision, assignment_request: A
 ORDINARY_COMMAND_HANDLERS = {
     comment_command_policy.OrdinaryCommandId.PASS: _execute_pass,
     comment_command_policy.OrdinaryCommandId.AWAY: _execute_away,
+    comment_command_policy.OrdinaryCommandId.DONE: _execute_done,
     comment_command_policy.OrdinaryCommandId.LABEL: _execute_label,
     comment_command_policy.OrdinaryCommandId.SYNC_MEMBERS: _execute_sync_members,
     comment_command_policy.OrdinaryCommandId.QUEUE: _execute_queue,

--- a/scripts/reviewer_bot_lib/comment_application.py
+++ b/scripts/reviewer_bot_lib/comment_application.py
@@ -58,7 +58,21 @@ def record_conversation_freshness(
     review_data = ensure_review_entry(state, issue_number, create=True)
     if review_data is None:
         return False
-    decision = comment_freshness_policy.decide_comment_freshness(review_data, request)
+    effective_review_data = dict(review_data)
+    if not (request.issue_author and request.issue_author.lower() == request.comment_author.lower()):
+        current_reviewer = review_data.get("current_reviewer")
+        confirmed_reviewer = None
+        if isinstance(current_reviewer, str) and current_reviewer.strip():
+            live_assignees = bot.github.get_issue_assignees(
+                issue_number,
+                is_pull_request=request.is_pull_request,
+            )
+            if isinstance(live_assignees, list) and len(live_assignees) == 1:
+                live_reviewer = live_assignees[0]
+                if isinstance(live_reviewer, str) and live_reviewer.lower() == current_reviewer.lower():
+                    confirmed_reviewer = current_reviewer
+        effective_review_data["current_reviewer"] = confirmed_reviewer
+    decision = comment_freshness_policy.decide_comment_freshness(effective_review_data, request)
     if decision.kind != "accept_channel_event":
         return False
     changed = accept_channel_event(
@@ -102,6 +116,9 @@ def _build_execution_result(command_id: comment_command_policy.OrdinaryCommandId
         comment_command_policy.OrdinaryCommandId.ASSIGN_SPECIFIC,
         comment_command_policy.OrdinaryCommandId.ASSIGN_FROM_QUEUE,
     }:
+        if len(result) == 3:
+            response, success, state_changed = result
+            return CommandExecutionResult(response=response, success=success, state_changed=state_changed)
         response, success = result
         return CommandExecutionResult(response=response, success=success, state_changed=success)
     if command_id in {

--- a/scripts/reviewer_bot_lib/config.py
+++ b/scripts/reviewer_bot_lib/config.py
@@ -1,6 +1,6 @@
 """Reviewer-bot configuration constants and small shared types."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 BOT_NAME = "guidelines-bot"
@@ -21,6 +21,7 @@ STATE_BLOCK_END_MARKER = "<!-- REVIEWER_BOT_STATE_END -->"
 LOCK_BLOCK_START_MARKER = "<!-- REVIEWER_BOT_LOCK_START -->"
 LOCK_BLOCK_END_MARKER = "<!-- REVIEWER_BOT_LOCK_END -->"
 TRANSITION_NOTICE_MARKER_PREFIX = "reviewer-bot:transition-notice:v1"
+TRANSITION_WARNING_MARKER_PREFIX = "reviewer-bot:transition-warning:v1"
 
 LOCK_SCHEMA_VERSION = 1
 LOCK_LEASE_TTL_SECONDS_ENV = "REVIEWER_BOT_LOCK_TTL_SECONDS"
@@ -188,6 +189,7 @@ COMMANDS = {
     "rectify": "Reconcile this issue/PR's review state from GitHub",
     "claim": "Claim this review for yourself",
     "r?": "Assign a reviewer (@username or 'producers')",
+    "done": "Mark a tracked non-PR issue review complete",
     "label": "Add/remove labels (+label-name or -label-name)",
     "accept-no-fls-changes": "Update spec.lock and open PR for a clean audit",
     "sync-members": "Sync queue with members.md",
@@ -218,6 +220,10 @@ class AssignmentAttempt:
     success: bool
     status_code: int | None
     exhausted_retryable_failure: bool = False
+    failure_kind: str | None = None
+    retry_attempts: int = 0
+    headers: dict[str, str] = field(default_factory=dict)
+    transport_error: str | None = None
 
 
 @dataclass(frozen=True)

--- a/scripts/reviewer_bot_lib/context.py
+++ b/scripts/reviewer_bot_lib/context.py
@@ -99,9 +99,12 @@ class ManualDispatchRequest:
 
 @dataclass(frozen=True)
 class IssueLifecycleRequest:
+    event_action: str = ""
     issue_number: int = 0
     is_pull_request: bool = False
+    issue_state: str = ""
     issue_labels: tuple[str, ...] = ()
+    label_name: str = ""
     issue_author: str = ""
     sender_login: str = ""
     updated_at: str = ""

--- a/scripts/reviewer_bot_lib/event_inputs.py
+++ b/scripts/reviewer_bot_lib/event_inputs.py
@@ -342,9 +342,12 @@ def build_manual_dispatch_request(bot: EventInputsContext) -> ManualDispatchRequ
 
 def build_issue_lifecycle_request(bot: EventInputsContext) -> IssueLifecycleRequest:
     return IssueLifecycleRequest(
+        event_action=bot.get_config_value("EVENT_ACTION").strip(),
         issue_number=_parse_optional_int(bot.get_config_value("ISSUE_NUMBER")) or 0,
         is_pull_request=bool(_parse_optional_bool(bot.get_config_value("IS_PULL_REQUEST"))),
+        issue_state=bot.get_config_value("ISSUE_STATE").strip(),
         issue_labels=_parse_labels(bot.get_config_value("ISSUE_LABELS")),
+        label_name=bot.get_config_value("LABEL_NAME").strip(),
         issue_author=bot.get_config_value("ISSUE_AUTHOR").strip(),
         sender_login=bot.get_config_value("SENDER_LOGIN").strip(),
         updated_at=bot.get_config_value("ISSUE_UPDATED_AT").strip(),

--- a/scripts/reviewer_bot_lib/github_api.py
+++ b/scripts/reviewer_bot_lib/github_api.py
@@ -430,6 +430,78 @@ def get_issue_or_pr_snapshot(bot: GitHubTransportContext, issue_number: int) -> 
     return response.payload
 
 
+def get_issue_assignees_result(
+    bot: GitHubTransportContext,
+    issue_number: int,
+    *,
+    is_pull_request: bool | None = None,
+):
+    pull_request_mode = _is_pull_request(bot) if is_pull_request is None else is_pull_request
+    endpoint = f"pulls/{issue_number}" if pull_request_mode else f"issues/{issue_number}"
+    field = "requested_reviewers" if pull_request_mode else "assignees"
+    response = bot.github_api_request(
+        "GET",
+        endpoint,
+        retry_policy=RETRY_POLICY_IDEMPOTENT_READ,
+    )
+    if not response.ok:
+        return response
+    payload = response.payload
+    if not isinstance(payload, dict):
+        return _build_result(
+            bot,
+            status_code=response.status_code,
+            payload=None,
+            headers=response.headers,
+            text=response.text,
+            ok=False,
+            failure_kind="invalid_payload",
+            retry_attempts=response.retry_attempts,
+            transport_error=response.transport_error,
+        )
+    assignees = payload.get(field)
+    if not isinstance(assignees, list):
+        return _build_result(
+            bot,
+            status_code=response.status_code,
+            payload=None,
+            headers=response.headers,
+            text=response.text,
+            ok=False,
+            failure_kind="invalid_payload",
+            retry_attempts=response.retry_attempts,
+            transport_error=response.transport_error,
+        )
+    logins: list[str] = []
+    for assignee in assignees:
+        if not isinstance(assignee, dict) or not isinstance(assignee.get("login"), str):
+            return _build_result(
+                bot,
+                status_code=response.status_code,
+                payload=None,
+                headers=response.headers,
+                text=response.text,
+                ok=False,
+                failure_kind="invalid_payload",
+                retry_attempts=response.retry_attempts,
+                transport_error=response.transport_error,
+            )
+        login = assignee.get("login")
+        assert isinstance(login, str)
+        logins.append(login)
+    return _build_result(
+        bot,
+        status_code=response.status_code,
+        payload=logins,
+        headers=response.headers,
+        text=response.text,
+        ok=True,
+        failure_kind=None,
+        retry_attempts=response.retry_attempts,
+        transport_error=response.transport_error,
+    )
+
+
 def list_issue_comments_result(
     bot: GitHubTransportContext,
     issue_number: int,
@@ -652,29 +724,16 @@ def assign_issue_assignee(bot: GitHubTransportContext, issue_number: int, userna
     )
 
 
-def get_issue_assignees(bot: GitHubTransportContext, issue_number: int) -> list[str] | None:
-    is_pr = _is_pull_request(bot)
-    if is_pr:
-        try:
-            response = bot.github_api_request("GET", f"pulls/{issue_number}", retry_policy=RETRY_POLICY_IDEMPOTENT_READ)
-            result = response.payload
-            if not response.ok:
-                return None
-        except SystemExit:
-            result = bot.github_api("GET", f"pulls/{issue_number}")
-        if isinstance(result, dict) and "requested_reviewers" in result:
-            return [reviewer["login"] for reviewer in result["requested_reviewers"]]
-    else:
-        try:
-            response = bot.github_api_request("GET", f"issues/{issue_number}", retry_policy=RETRY_POLICY_IDEMPOTENT_READ)
-            result = response.payload
-            if not response.ok:
-                return None
-        except SystemExit:
-            result = bot.github_api("GET", f"issues/{issue_number}")
-        if isinstance(result, dict) and "assignees" in result:
-            return [assignee["login"] for assignee in result["assignees"]]
-    return []
+def get_issue_assignees(
+    bot: GitHubTransportContext,
+    issue_number: int,
+    *,
+    is_pull_request: bool | None = None,
+) -> list[str] | None:
+    response = get_issue_assignees_result(bot, issue_number, is_pull_request=is_pull_request)
+    if not response.ok or not isinstance(response.payload, list):
+        return None
+    return response.payload
 
 
 def add_reaction(bot: GitHubTransportContext, comment_id: int, reaction: str) -> bool:

--- a/scripts/reviewer_bot_lib/github_api.py
+++ b/scripts/reviewer_bot_lib/github_api.py
@@ -32,10 +32,11 @@ def _sleep(bot: GitHubApiContext, seconds: float) -> None:
 
 
 def _retry_delay(bot: GitHubApiContext, base_seconds: float, retry_attempt: int) -> float:
-    return retrying.bounded_exponential_delay(
+    return retrying.retry_delay_seconds(
         base_seconds,
         retry_attempt,
         jitter=bot.jitter,
+        now=bot.clock.now(),
     )
 
 
@@ -43,27 +44,36 @@ def _is_pull_request(bot: GitHubApiContext) -> bool:
     return bot.get_config_value("IS_PULL_REQUEST", "false").lower() == "true"
 
 
-def _should_retry_status(status_code: int | None) -> bool:
-    return retrying.is_retryable_status(status_code)
+def _should_retry_status(status_code: int | None, *, headers: dict[str, str] | None = None, text: str = "") -> bool:
+    return retrying.is_rate_limited_response(status_code, headers=headers, text=text) or retrying.is_retryable_status(status_code)
 
 
-def _classify_failure(status_code: int | None, *, invalid_payload: bool = False, transport_error: bool = False) -> str | None:
+def _classify_failure(
+    status_code: int | None,
+    *,
+    headers: dict[str, str] | None = None,
+    text: str = "",
+    invalid_payload: bool = False,
+    transport_error: bool = False,
+) -> str | None:
     if invalid_payload:
         return "invalid_payload"
     if transport_error:
         return "transport_error"
     if status_code is None:
         return None
+    if retrying.is_rate_limited_response(status_code, headers=headers, text=text):
+        return "rate_limited"
     if status_code == 404:
         return "not_found"
     if status_code == 401:
         return "unauthorized"
     if status_code == 403:
         return "forbidden"
-    if status_code == 429:
-        return "rate_limited"
     if status_code >= 500:
         return "server_error"
+    if status_code >= 400:
+        return "http_error"
     return None
 
 
@@ -188,8 +198,8 @@ def github_api_request(
             except ValueError:
                 invalid_payload = True
 
-        ok = response.status_code < 400 and not invalid_payload
         normalized_headers = {key.lower(): value for key, value in response.headers.items()}
+        ok = response.status_code < 400 and not invalid_payload
         if ok:
             return _build_result(
                 bot,
@@ -202,10 +212,30 @@ def github_api_request(
                 retry_attempts=retry_attempts,
             )
 
-        failure_kind = _classify_failure(response.status_code, invalid_payload=invalid_payload)
-        if retry_policy == RETRY_POLICY_IDEMPOTENT_READ and _should_retry_status(response.status_code) and attempt < max_attempts:
+        failure_kind = _classify_failure(
+            response.status_code,
+            headers=normalized_headers,
+            text=response.text,
+            invalid_payload=invalid_payload,
+        )
+        if (
+            retry_policy == RETRY_POLICY_IDEMPOTENT_READ
+            and _should_retry_status(response.status_code, headers=normalized_headers, text=response.text)
+            and attempt < max_attempts
+        ):
             retry_attempts += 1
-            _sleep(bot, _retry_delay(bot, LOCK_RETRY_BASE_SECONDS, retry_attempts))
+            _sleep(
+                bot,
+                retrying.retry_delay_seconds(
+                    LOCK_RETRY_BASE_SECONDS,
+                    retry_attempts,
+                    jitter=bot.jitter,
+                    status_code=response.status_code,
+                    headers=normalized_headers,
+                    text=response.text,
+                    now=bot.clock.now(),
+                ),
+            )
             continue
 
         if not suppress_error_log:
@@ -313,11 +343,24 @@ def github_graphql_request(
 
         failure_kind = _classify_failure(
             response.status_code,
+            headers=normalized_headers,
+            text=response.text,
             invalid_payload=invalid_payload or bool(graphql_errors),
         )
-        if _should_retry_status(response.status_code) and attempt < max_attempts:
+        if _should_retry_status(response.status_code, headers=normalized_headers, text=response.text) and attempt < max_attempts:
             retry_attempts += 1
-            _sleep(bot, _retry_delay(bot, LOCK_RETRY_BASE_SECONDS, retry_attempts))
+            _sleep(
+                bot,
+                retrying.retry_delay_seconds(
+                    LOCK_RETRY_BASE_SECONDS,
+                    retry_attempts,
+                    jitter=bot.jitter,
+                    status_code=response.status_code,
+                    headers=normalized_headers,
+                    text=response.text,
+                    now=bot.clock.now(),
+                ),
+            )
             continue
 
         if not suppress_error_log:
@@ -360,8 +403,45 @@ def github_graphql(
     return response.payload
 
 
+def post_comment_result(bot: GitHubTransportContext, issue_number: int, body: str):
+    return bot.github_api_request(
+        "POST",
+        f"issues/{issue_number}/comments",
+        {"body": body},
+    )
+
+
 def post_comment(bot: GitHubTransportContext, issue_number: int, body: str) -> bool:
-    return bot.github_api("POST", f"issues/{issue_number}/comments", {"body": body}) is not None
+    return post_comment_result(bot, issue_number, body).ok
+
+
+def get_issue_or_pr_snapshot_result(bot: GitHubTransportContext, issue_number: int):
+    return bot.github_api_request(
+        "GET",
+        f"issues/{issue_number}",
+        retry_policy=RETRY_POLICY_IDEMPOTENT_READ,
+    )
+
+
+def get_issue_or_pr_snapshot(bot: GitHubTransportContext, issue_number: int) -> dict | None:
+    response = get_issue_or_pr_snapshot_result(bot, issue_number)
+    if not response.ok or not isinstance(response.payload, dict):
+        return None
+    return response.payload
+
+
+def list_issue_comments_result(
+    bot: GitHubTransportContext,
+    issue_number: int,
+    *,
+    page: int = 1,
+    per_page: int = 100,
+):
+    return bot.github_api_request(
+        "GET",
+        f"issues/{issue_number}/comments?per_page={per_page}&page={page}",
+        retry_policy=RETRY_POLICY_IDEMPOTENT_READ,
+    )
 
 
 def get_repo_labels(bot: GitHubTransportContext) -> set[str]:
@@ -462,32 +542,57 @@ def ensure_label_exists(
     return False
 
 
-def _request_assignment(
+def _build_assignment_attempt(bot: GitHubTransportContext, response, *, success: bool, exhausted_retryable_failure: bool = False):
+    return bot.AssignmentAttempt(
+        success=success,
+        status_code=response.status_code,
+        exhausted_retryable_failure=exhausted_retryable_failure,
+        failure_kind=response.failure_kind,
+        retry_attempts=response.retry_attempts,
+        headers=dict(response.headers),
+        transport_error=response.transport_error,
+    )
+
+
+def _request_assignment_write(
     bot: GitHubTransportContext,
+    method: str,
     endpoint: str,
     payload: dict,
     *,
     assignment_target: str,
     issue_number: int,
     username: str,
+    success_statuses: set[int],
 ):
     lock_api_retry_limit = bot.lock_api_retry_limit()
     lock_retry_base_seconds = bot.lock_retry_base_seconds()
+    retry_attempts = 0
 
     for attempt in range(1, lock_api_retry_limit + 1):
-        response = bot.github_api_request("POST", endpoint, payload, suppress_error_log=True)
-        if response.status_code in {200, 201}:
-            return bot.AssignmentAttempt(success=True, status_code=response.status_code)
+        response = bot.github_api_request(method, endpoint, payload, suppress_error_log=True)
+        response.retry_attempts = retry_attempts
+        if response.status_code in success_statuses:
+            return _build_assignment_attempt(bot, response, success=True)
         if response.status_code == 422:
-            return bot.AssignmentAttempt(success=False, status_code=422)
-        if response.status_code in {401, 403}:
+            return _build_assignment_attempt(bot, response, success=False)
+        if response.failure_kind in {"unauthorized", "forbidden"}:
             raise RuntimeError(
                 f"Permission denied requesting {assignment_target} @{username} on "
                 f"#{issue_number} (status {response.status_code}): {response.text}"
             )
-        if response.status_code == 429 or response.status_code >= 500:
+        if response.failure_kind in {"rate_limited", "server_error", "transport_error"}:
             if attempt < lock_api_retry_limit:
-                delay = _retry_delay(bot, lock_retry_base_seconds, attempt)
+                retry_attempts += 1
+                delay = retrying.retry_delay_seconds(
+                    lock_retry_base_seconds,
+                    retry_attempts,
+                    jitter=bot.jitter,
+                    status_code=response.status_code,
+                    headers=response.headers,
+                    text=response.text,
+                    now=bot.clock.now(),
+                )
                 _log(
                     bot,
                     "warning",
@@ -499,11 +604,8 @@ def _request_assignment(
                 )
                 _sleep(bot, delay)
                 continue
-            return bot.AssignmentAttempt(
-                success=False,
-                status_code=response.status_code,
-                exhausted_retryable_failure=True,
-            )
+            response.retry_attempts = retry_attempts
+            return _build_assignment_attempt(bot, response, success=False, exhausted_retryable_failure=True)
 
         _log(
             bot,
@@ -513,30 +615,40 @@ def _request_assignment(
             username=username,
             status_code=response.status_code,
         )
-        return bot.AssignmentAttempt(success=False, status_code=response.status_code)
+        return _build_assignment_attempt(bot, response, success=False)
 
-    return bot.AssignmentAttempt(success=False, status_code=None, exhausted_retryable_failure=True)
+    return bot.AssignmentAttempt(
+        success=False,
+        status_code=None,
+        exhausted_retryable_failure=True,
+        failure_kind="transport_error",
+        retry_attempts=retry_attempts,
+    )
 
 
 def request_pr_reviewer_assignment(bot: GitHubTransportContext, issue_number: int, username: str):
-    return _request_assignment(
+    return _request_assignment_write(
         bot,
+        "POST",
         f"pulls/{issue_number}/requested_reviewers",
         {"reviewers": [username]},
         assignment_target="PR reviewer",
         issue_number=issue_number,
         username=username,
+        success_statuses={200, 201},
     )
 
 
 def assign_issue_assignee(bot: GitHubTransportContext, issue_number: int, username: str):
-    return _request_assignment(
+    return _request_assignment_write(
         bot,
+        "POST",
         f"issues/{issue_number}/assignees",
         {"assignees": [username]},
         assignment_target="issue assignee",
         issue_number=issue_number,
         username=username,
+        success_statuses={200, 201},
     )
 
 
@@ -572,21 +684,29 @@ def add_reaction(bot: GitHubTransportContext, comment_id: int, reaction: str) ->
     )
 
 
-def remove_issue_assignee(bot: GitHubTransportContext, issue_number: int, username: str) -> bool:
-    return (
-        bot.github_api("DELETE", f"issues/{issue_number}/assignees", {"assignees": [username]})
-        is not None
+def remove_issue_assignee(bot: GitHubTransportContext, issue_number: int, username: str):
+    return _request_assignment_write(
+        bot,
+        "DELETE",
+        f"issues/{issue_number}/assignees",
+        {"assignees": [username]},
+        assignment_target="issue assignee removal",
+        issue_number=issue_number,
+        username=username,
+        success_statuses={200, 204},
     )
 
 
-def remove_pr_reviewer(bot: GitHubTransportContext, issue_number: int, username: str) -> bool:
-    return (
-        bot.github_api(
-            "DELETE",
-            f"pulls/{issue_number}/requested_reviewers",
-            {"reviewers": [username]},
-        )
-        is not None
+def remove_pr_reviewer(bot: GitHubTransportContext, issue_number: int, username: str):
+    return _request_assignment_write(
+        bot,
+        "DELETE",
+        f"pulls/{issue_number}/requested_reviewers",
+        {"reviewers": [username]},
+        assignment_target="PR reviewer removal",
+        issue_number=issue_number,
+        username=username,
+        success_statuses={200, 204},
     )
 
 

--- a/scripts/reviewer_bot_lib/guidance.py
+++ b/scripts/reviewer_bot_lib/guidance.py
@@ -63,6 +63,39 @@ Other commands:
 """
 
 
+def get_generic_issue_guidance(reviewer: str, issue_author: str) -> str:
+    """Generate guidance text for a generic tracked issue reviewer."""
+    return f"""👋 Hey @{reviewer}! You've been assigned to review this tracked issue.
+
+## Your Role as Reviewer
+
+Please review the issue, coordinate with @{issue_author}, and use reviewer-bot commands to keep the review moving.
+
+When the review is complete:
+- Comment `{BOT_MENTION} /done` to mark the issue review complete.
+
+## Bot Commands
+
+If you need to pass this review:
+- `{BOT_MENTION} /pass [reason]` - Pass just this issue to the next reviewer
+- `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
+- `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
+
+To assign someone else:
+- `{BOT_MENTION} /r? @username` - Assign a specific reviewer
+- `{BOT_MENTION} /r? producers` - Request the next reviewer from the queue
+
+Other commands:
+- `{BOT_MENTION} /claim` - Claim this review for yourself
+- `{BOT_MENTION} /done` - Mark this review complete
+- `{BOT_MENTION} /rectify` - Reconcile this issue/PR review state from GitHub
+- `{BOT_MENTION} /label +label-name` - Add a label
+- `{BOT_MENTION} /label -label-name` - Remove a label
+- `{BOT_MENTION} /queue` - Show reviewer queue
+- `{BOT_MENTION} /commands` - Show all available commands
+"""
+
+
 def get_fls_audit_guidance(reviewer: str, issue_author: str) -> str:
     """Generate guidance text for an FLS audit issue reviewer."""
     return f"""👋 Hey @{reviewer}! You've been assigned to review this FLS audit issue.
@@ -91,6 +124,7 @@ To assign someone else:
 
 Other commands:
 - `{BOT_MENTION} /claim` - Claim this review for yourself
+- `{BOT_MENTION} /done` - Mark this review complete
 - `{BOT_MENTION} /rectify` - Reconcile this issue/PR review state from GitHub
 - `{BOT_MENTION} /label +label-name` - Add a label
 - `{BOT_MENTION} /label -label-name` - Remove a label

--- a/scripts/reviewer_bot_lib/lifecycle.py
+++ b/scripts/reviewer_bot_lib/lifecycle.py
@@ -56,7 +56,7 @@ def _write_transition_notice_marker_cutover(bot) -> None:
     if not config_dir_value:
         return
     config_dir = Path(config_dir_value)
-    artifact_path = config_dir / "reviewer-bot" / "maintainability-remediation" / "transition-notice-marker-cutover.json"
+    artifact_path = config_dir / "reviewer-bot" / "issue-428-reminder-remediation" / "transition-notice-marker-cutover.json"
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
     artifact_path.write_text(
         json.dumps(
@@ -90,6 +90,10 @@ def handle_transition_notice(bot, state: dict, issue_number: int, reviewer: str)
         reviewer,
     )
     if existing_notice.get("status") == "unavailable":
+        if existing_notice.get("failure_kind") in {"unauthorized", "forbidden"}:
+            raise RuntimeError(
+                f"Permission denied reading transition dedupe comments for #{issue_number} (status {existing_notice.get('status_code')})."
+            )
         return _record_transport_failure(
             bot,
             review_data,
@@ -125,6 +129,10 @@ You may still continue this review, or use `{bot.BOT_MENTION} /pass`, `{bot.BOT_
 _If you believe this is in error or have extenuating circumstances, please reach out to the subcommittee._"""
     post_result = bot.github.post_comment_result(issue_number, notice_message)
     if not post_result.ok:
+        if post_result.failure_kind in {"unauthorized", "forbidden"}:
+            raise RuntimeError(
+                f"Permission denied posting transition notice for #{issue_number} (status {post_result.status_code})."
+            )
         if (
             post_result.failure_kind in {"invalid_payload", "server_error", "transport_error", "rate_limited"}
             or (post_result.status_code is not None and post_result.status_code < 400)
@@ -192,7 +200,11 @@ def _reconcile_lifecycle_reviewer_authority(
             emit_failure_comment=False,
             pr_head_sha=request.pr_head_sha,
         )
-        return bool(result.get("confirmed") or result.get("cleared_current_reviewer"))
+        return bool(
+            result.get("confirmed")
+            or result.get("cleared_current_reviewer")
+            or result.get("diagnostic_changed")
+        )
     if len(current_assignees) > 1:
         return assignment_flow.clear_reviewer_authority(bot, state, issue_number, reason="multiple_live_assignees")
     if not allow_auto_assign:
@@ -220,7 +232,11 @@ def _reconcile_lifecycle_reviewer_authority(
         emit_failure_comment=True,
         pr_head_sha=request.pr_head_sha,
     )
-    return bool(result.get("confirmed") or result.get("cleared_current_reviewer"))
+    return bool(
+        result.get("confirmed")
+        or result.get("cleared_current_reviewer")
+        or result.get("diagnostic_changed")
+    )
 
 
 def _clear_completion(review_data: dict) -> bool:

--- a/scripts/reviewer_bot_lib/lifecycle.py
+++ b/scripts/reviewer_bot_lib/lifecycle.py
@@ -9,19 +9,13 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-from .config import TRANSITION_NOTICE_MARKER_PREFIX
-from .guidance import (
-    get_assignment_failure_comment,
-    get_fls_audit_guidance,
-    get_issue_guidance,
-    get_pr_guidance,
-)
+from . import assignment_flow
+from .config import CODING_GUIDELINE_LABEL, TRANSITION_NOTICE_MARKER_PREFIX
 from .review_state import (
     accept_channel_event,
     ensure_review_entry,
     mark_review_complete,
     record_transition_notice_sent,
-    set_current_reviewer,
 )
 from .reviews import rebuild_pr_approval_state
 
@@ -78,11 +72,46 @@ def _write_transition_notice_marker_cutover(bot) -> None:
 
 
 def handle_transition_notice(bot, state: dict, issue_number: int, reviewer: str) -> bool:
+    from .overdue import (
+        _clear_transport_failure,
+        _record_transport_failure,
+        find_existing_transition_notice_result,
+    )
+
     review_data = ensure_review_entry(state, issue_number, create=True)
     if review_data is None:
         return False
     if review_data.get("transition_notice_sent_at"):
         return False
+    existing_notice = find_existing_transition_notice_result(
+        bot,
+        issue_number,
+        review_data.get("transition_warning_sent"),
+        reviewer,
+    )
+    if existing_notice.get("status") == "unavailable":
+        return _record_transport_failure(
+            bot,
+            review_data,
+            issue_number,
+            phase="transition_dedupe_read",
+            result=bot.GitHubApiResult(
+                existing_notice.get("status_code"),
+                None,
+                {},
+                "",
+                False,
+                existing_notice.get("failure_kind"),
+                existing_notice.get("retry_attempts", 0),
+                None,
+            ),
+        )
+    changed = _clear_transport_failure(bot, review_data, issue_number, phase="transition_dedupe_read")
+    timestamp = existing_notice.get("timestamp") if existing_notice.get("status") == "found" else None
+    if isinstance(timestamp, str) and timestamp:
+        record_transition_notice_sent(review_data, timestamp)
+        bot.collect_touched_item(issue_number)
+        return True
     notice_message = f"""<!-- {TRANSITION_NOTICE_MARKER_PREFIX} issue={issue_number} reviewer={reviewer} -->
 
 🔔 **Transition Period Ended**
@@ -94,14 +123,121 @@ Per our [contribution guidelines](CONTRIBUTING.md#review-deadlines), this may re
 You may still continue this review, or use `{bot.BOT_MENTION} /pass`, `{bot.BOT_MENTION} /release`, or `{bot.BOT_MENTION} /away` if you need to step back.
 
 _If you believe this is in error or have extenuating circumstances, please reach out to the subcommittee._"""
-    if not bot.github.post_comment(issue_number, notice_message):
-        return False
+    post_result = bot.github.post_comment_result(issue_number, notice_message)
+    if not post_result.ok:
+        if (
+            post_result.failure_kind in {"invalid_payload", "server_error", "transport_error", "rate_limited"}
+            or (post_result.status_code is not None and post_result.status_code < 400)
+        ):
+            existing_notice = find_existing_transition_notice_result(
+                bot,
+                issue_number,
+                review_data.get("transition_warning_sent"),
+                reviewer,
+            )
+            timestamp = existing_notice.get("timestamp") if existing_notice.get("status") == "found" else None
+            if isinstance(timestamp, str) and timestamp:
+                record_transition_notice_sent(review_data, timestamp)
+                _clear_transport_failure(bot, review_data, issue_number, phase="transition_post")
+                bot.collect_touched_item(issue_number)
+                return True
+        return _record_transport_failure(bot, review_data, issue_number, phase="transition_post", result=post_result)
+    changed = _clear_transport_failure(bot, review_data, issue_number, phase="transition_post") or changed
     _write_transition_notice_marker_cutover(bot)
     record_transition_notice_sent(
         review_data,
         bot.datetime.now(bot.timezone.utc).isoformat(),
     )
+    bot.collect_touched_item(issue_number)
     return True
+
+
+def _tracked_review_issue(bot, labels: list[str]) -> bool:
+    return any(label in bot.REVIEW_LABELS for label in labels)
+
+
+def _reconcile_lifecycle_reviewer_authority(
+    bot,
+    state: dict,
+    request,
+    *,
+    assignment_method: str,
+    allow_auto_assign: bool,
+) -> bool:
+    issue_number = request.issue_number
+    if not issue_number:
+        return False
+    bot.collect_touched_item(issue_number)
+    labels = list(request.issue_labels)
+    if not _tracked_review_issue(bot, labels):
+        return False
+    current_assignees = bot.github.get_issue_assignees(issue_number)
+    if current_assignees is None:
+        raise RuntimeError(f"Unable to determine assignees for #{issue_number}")
+    cycle_started_at = request.event_created_at or request.updated_at or _now_iso()
+    if len(current_assignees) == 1:
+        reviewer = current_assignees[0]
+        if request.issue_author and reviewer.lower() == request.issue_author.lower():
+            return assignment_flow.clear_reviewer_authority(bot, state, issue_number, reason="self_review_not_allowed")
+        result = assignment_flow.confirm_reviewer_assignment(
+            bot,
+            state,
+            request,
+            reviewer=reviewer,
+            assignment_method=assignment_method,
+            cycle_started_at=cycle_started_at,
+            current_assignees=current_assignees,
+            record_assignment=False,
+            emit_guidance=False,
+            emit_failure_comment=False,
+            pr_head_sha=request.pr_head_sha,
+        )
+        return bool(result.get("confirmed") or result.get("cleared_current_reviewer"))
+    if len(current_assignees) > 1:
+        return assignment_flow.clear_reviewer_authority(bot, state, issue_number, reason="multiple_live_assignees")
+    if not allow_auto_assign:
+        return assignment_flow.clear_reviewer_authority(bot, state, issue_number, reason="no_live_assignees")
+    reviewer = bot.adapters.queue.get_next_reviewer(
+        state,
+        skip_usernames={request.issue_author} if request.issue_author else set(),
+    )
+    if not reviewer:
+        bot.github.post_comment(
+            issue_number,
+            f"⚠️ No reviewers available in the queue. Please use `{bot.BOT_MENTION} /sync-members` to update the queue.",
+        )
+        return False
+    result = assignment_flow.confirm_reviewer_assignment(
+        bot,
+        state,
+        request,
+        reviewer=reviewer,
+        assignment_method="round-robin",
+        cycle_started_at=cycle_started_at,
+        current_assignees=current_assignees,
+        record_assignment=True,
+        emit_guidance=True,
+        emit_failure_comment=True,
+        pr_head_sha=request.pr_head_sha,
+    )
+    return bool(result.get("confirmed") or result.get("cleared_current_reviewer"))
+
+
+def _clear_completion(review_data: dict) -> bool:
+    changed = False
+    if review_data.get("review_completed_at") is not None:
+        review_data["review_completed_at"] = None
+        changed = True
+    if review_data.get("review_completed_by") is not None:
+        review_data["review_completed_by"] = None
+        changed = True
+    if review_data.get("review_completion_source") is not None:
+        review_data["review_completion_source"] = None
+        changed = True
+    if review_data.get("current_cycle_completion"):
+        review_data["current_cycle_completion"] = {}
+        changed = True
+    return changed
 
 
 def handle_issue_or_pr_opened(bot, state: dict) -> bool:
@@ -109,11 +245,7 @@ def handle_issue_or_pr_opened(bot, state: dict) -> bool:
     from .event_inputs import build_issue_lifecycle_request
 
     request = build_issue_lifecycle_request(bot)
-    issue_number = request.issue_number
-    if not issue_number:
-        return False
-    bot.collect_touched_item(issue_number)
-    issue_key = str(issue_number)
+    issue_key = str(request.issue_number)
     tracked_reviewer = None
     if isinstance(state.get("active_reviews"), dict) and issue_key in state["active_reviews"]:
         review_data = state["active_reviews"][issue_key]
@@ -121,44 +253,13 @@ def handle_issue_or_pr_opened(bot, state: dict) -> bool:
             tracked_reviewer = review_data.get("current_reviewer")
     if tracked_reviewer:
         return False
-    current_assignees = bot.github.get_issue_assignees(issue_number)
-    if current_assignees is None:
-        raise RuntimeError(f"Unable to determine assignees for #{issue_number}")
-    if current_assignees:
-        return False
-    labels = list(request.issue_labels)
-    if not any(label in bot.REVIEW_LABELS for label in labels):
-        return False
-    issue_author = request.issue_author
-    reviewer = bot.adapters.queue.get_next_reviewer(state, skip_usernames={issue_author} if issue_author else set())
-    if not reviewer:
-        bot.github.post_comment(issue_number, f"⚠️ No reviewers available in the queue. Please use `{bot.BOT_MENTION} /sync-members` to update the queue.")
-        return False
-    is_pr = request.is_pull_request
-    if is_pr:
-        assignment_attempt = bot.github.request_pr_reviewer_assignment(issue_number, reviewer)
-    else:
-        assignment_attempt = bot.github.assign_issue_assignee(issue_number, reviewer)
-    set_current_reviewer(state, issue_number, reviewer)
-    review_data = ensure_review_entry(state, issue_number, create=True)
-    if is_pr and isinstance(review_data, dict):
-        head_sha = request.pr_head_sha
-        if head_sha:
-            review_data["active_head_sha"] = head_sha
-    bot.adapters.queue.record_assignment(state, reviewer, issue_number, "pr" if is_pr else "issue")
-    failure_comment = get_assignment_failure_comment(
-        reviewer,
-        assignment_attempt,
-        is_pull_request=is_pr,
+    return _reconcile_lifecycle_reviewer_authority(
+        bot,
+        state,
+        request,
+        assignment_method="lifecycle-opened",
+        allow_auto_assign=True,
     )
-    if failure_comment:
-        bot.github.post_comment(issue_number, failure_comment)
-    if is_pr and assignment_attempt.success:
-        bot.github.post_comment(issue_number, get_pr_guidance(reviewer, issue_author))
-    if not is_pr:
-        guidance = get_fls_audit_guidance(reviewer, issue_author) if bot.FLS_AUDIT_LABEL in labels else get_issue_guidance(reviewer, issue_author)
-        bot.github.post_comment(issue_number, guidance)
-    return True
 
 
 def handle_issue_edited_event(bot, state: dict) -> bool:
@@ -206,9 +307,9 @@ def handle_issue_edited_event(bot, state: dict) -> bool:
 
 def handle_labeled_event(bot, state: dict) -> bool:
     bot.assert_lock_held("handle_labeled_event")
-    from .event_inputs import build_label_event_request
+    from .event_inputs import build_issue_lifecycle_request
 
-    request = build_label_event_request(bot)
+    request = build_issue_lifecycle_request(bot)
     issue_number = request.issue_number
     if not issue_number:
         return False
@@ -218,12 +319,81 @@ def handle_labeled_event(bot, state: dict) -> bool:
     if label_name == "sign-off: create pr":
         if is_pr:
             return False
+        if CODING_GUIDELINE_LABEL not in set(request.issue_labels):
+            return False
         review_data = ensure_review_entry(state, issue_number)
         reviewer = review_data.get("current_reviewer") if review_data else None
         return mark_review_complete(state, issue_number, reviewer, "issue_label: sign-off: create pr")
     if label_name not in bot.REVIEW_LABELS:
         return False
     return handle_issue_or_pr_opened(bot, state)
+
+
+def handle_unlabeled_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_unlabeled_event")
+    from .event_inputs import build_issue_lifecycle_request
+
+    request = build_issue_lifecycle_request(bot)
+    if not request.issue_number:
+        return False
+    bot.collect_touched_item(request.issue_number)
+    changed = False
+    review_data = ensure_review_entry(state, request.issue_number)
+    if (
+        request.label_name == "sign-off: create pr"
+        and isinstance(review_data, dict)
+        and review_data.get("review_completion_source") == "issue_label: sign-off: create pr"
+    ):
+        changed = _clear_completion(review_data) or changed
+    if request.label_name in bot.REVIEW_LABELS and not _tracked_review_issue(bot, list(request.issue_labels)):
+        changed = assignment_flow.clear_reviewer_authority(bot, state, request.issue_number, reason="review_label_removed") or changed
+    return changed
+
+
+def handle_assigned_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_assigned_event")
+    from .event_inputs import build_issue_lifecycle_request
+
+    request = build_issue_lifecycle_request(bot)
+    return _reconcile_lifecycle_reviewer_authority(
+        bot,
+        state,
+        request,
+        assignment_method="lifecycle-assigned",
+        allow_auto_assign=False,
+    )
+
+
+def handle_unassigned_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_unassigned_event")
+    from .event_inputs import build_issue_lifecycle_request
+
+    request = build_issue_lifecycle_request(bot)
+    return _reconcile_lifecycle_reviewer_authority(
+        bot,
+        state,
+        request,
+        assignment_method="lifecycle-unassigned",
+        allow_auto_assign=False,
+    )
+
+
+def handle_reopened_event(bot, state: dict) -> bool:
+    bot.assert_lock_held("handle_reopened_event")
+    from .event_inputs import build_issue_lifecycle_request
+
+    request = build_issue_lifecycle_request(bot)
+    changed = _reconcile_lifecycle_reviewer_authority(
+        bot,
+        state,
+        request,
+        assignment_method="lifecycle-reopened",
+        allow_auto_assign=False,
+    )
+    review_data = ensure_review_entry(state, request.issue_number)
+    if isinstance(review_data, dict) and review_data.get("review_completion_source") != "issue_label: sign-off: create pr":
+        changed = _clear_completion(review_data) or changed
+    return changed
 
 
 def handle_pull_request_target_synchronize(bot, state: dict) -> bool:

--- a/scripts/reviewer_bot_lib/maintenance_privileged.py
+++ b/scripts/reviewer_bot_lib/maintenance_privileged.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from scripts.reviewer_bot_core import privileged_command_policy
 
-from . import automation
+from . import automation, review_state
 
 
 def _now_iso(bot) -> str:
@@ -51,6 +51,7 @@ def execute_pending_privileged_command(bot, state: dict, source_event_key: str) 
         execution_plan=revalidation,
     )
     if execution.status == "executed":
+        review_state.mark_review_complete(state, issue_number, actor, "command: accept-no-fls-changes")
         privileged_command_policy.mark_pending_accept_no_fls_changes_executed(
             review_data,
             source_event_key,

--- a/scripts/reviewer_bot_lib/maintenance_schedule.py
+++ b/scripts/reviewer_bot_lib/maintenance_schedule.py
@@ -132,6 +132,7 @@ def _run_overdue_pass(bot, state: dict) -> bool:
                 issue_number,
                 reviewer,
                 anchor_reason=review.get("anchor_reason"),
+                anchor_timestamp=review.get("anchor_timestamp"),
             ):
                 changed = True
         elif review["needs_transition"]:

--- a/scripts/reviewer_bot_lib/maintenance_schedule.py
+++ b/scripts/reviewer_bot_lib/maintenance_schedule.py
@@ -126,7 +126,13 @@ def _run_overdue_pass(bot, state: dict) -> bool:
         issue_number = review["issue_number"]
         reviewer = review["reviewer"]
         if review["needs_warning"]:
-            if handle_overdue_review_warning(bot, state, issue_number, reviewer):
+            if handle_overdue_review_warning(
+                bot,
+                state,
+                issue_number,
+                reviewer,
+                anchor_reason=review.get("anchor_reason"),
+            ):
                 changed = True
         elif review["needs_transition"]:
             if backfill_transition_notice_if_present(bot, state, issue_number):

--- a/scripts/reviewer_bot_lib/overdue.py
+++ b/scripts/reviewer_bot_lib/overdue.py
@@ -2,13 +2,128 @@
 
 from __future__ import annotations
 
-from .config import TRANSITION_NOTICE_MARKER_PREFIX
+from .config import TRANSITION_NOTICE_MARKER_PREFIX, TRANSITION_WARNING_MARKER_PREFIX
+from .repair_records import clear_repair_marker, store_repair_marker
 
 _TRANSITION_NOTICE_AUTHORS = {"github-actions[bot]", "guidelines-bot"}
 
 
 def _log(bot, level: str, message: str, **fields) -> None:
     bot.logger.event(level, message, **fields)
+
+
+def _warning_anchor_sentence(bot, reviewer: str, anchor_reason: str | None) -> str:
+    if anchor_reason in {"contributor_comment_newer", "contributor_revision_newer"}:
+        return (
+            f"Hey @{reviewer}, it's been more than {bot.REVIEW_DEADLINE_DAYS} days since the latest "
+            "contributor follow-up returned this review to you."
+        )
+    return f"Hey @{reviewer}, it's been more than {bot.REVIEW_DEADLINE_DAYS} days since you were assigned to review this."
+
+
+def _transport_marker(*, phase: str, result, recorded_at: str) -> dict:
+    return {
+        "kind": "reminder_transport_failure",
+        "phase": phase,
+        "status_code": result.status_code,
+        "failure_kind": result.failure_kind,
+        "retry_attempts": result.retry_attempts,
+        "recorded_at": recorded_at,
+    }
+
+
+def _record_transport_failure(bot, review_data: dict, issue_number: int, *, phase: str, result) -> bool:
+    changed = store_repair_marker(
+        review_data,
+        phase,
+        _transport_marker(phase=phase, result=result, recorded_at=bot.clock.now().isoformat()),
+    )
+    if changed:
+        bot.collect_touched_item(issue_number)
+    return changed
+
+
+def _clear_transport_failure(bot, review_data: dict, issue_number: int, *, phase: str) -> bool:
+    changed = clear_repair_marker(review_data, phase)
+    if changed:
+        bot.collect_touched_item(issue_number)
+    return changed
+
+
+def _warning_marker(issue_number: int, reviewer: str, anchor_timestamp: str | None) -> str:
+    return (
+        f"<!-- {TRANSITION_WARNING_MARKER_PREFIX} issue={issue_number} reviewer={reviewer} "
+        f"anchor={anchor_timestamp or ''} -->"
+    )
+
+
+def _find_existing_marker_comment(
+    bot,
+    issue_number: int,
+    marker: str,
+    *,
+    authors: set[str],
+    not_before: str | None = None,
+) -> dict[str, object]:
+    earliest = None
+    if isinstance(not_before, str) and not_before:
+        try:
+            earliest = bot.datetime.fromisoformat(not_before.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            earliest = None
+    page = 1
+    while True:
+        response = bot.github.list_issue_comments_result(issue_number, page=page)
+        if not response.ok or not isinstance(response.payload, list):
+            return {
+                "status": "unavailable",
+                "status_code": response.status_code,
+                "failure_kind": response.failure_kind,
+                "retry_attempts": response.retry_attempts,
+            }
+        first_match = None
+        for comment in response.payload:
+            if not isinstance(comment, dict):
+                continue
+            user = comment.get("user")
+            login = user.get("login") if isinstance(user, dict) else None
+            created_at = comment.get("created_at")
+            body = comment.get("body")
+            if not isinstance(login, str) or not isinstance(created_at, str) or not isinstance(body, str):
+                continue
+            if login not in authors:
+                continue
+            try:
+                created_dt = bot.datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                continue
+            if earliest is not None and created_dt < earliest:
+                continue
+            lines = body.splitlines()
+            first_line = lines[0].strip() if lines else ""
+            if first_line == marker:
+                if first_match is None or created_dt < first_match[0]:
+                    first_match = (created_dt, created_at)
+        if first_match is not None:
+            return {"status": "found", "timestamp": first_match[1]}
+        if len(response.payload) < 100:
+            break
+        page += 1
+    return {"status": "missing"}
+
+
+def _warning_scan_result(bot, issue_number: int, reviewer: str, anchor_timestamp: str | None) -> dict[str, object]:
+    return _find_existing_marker_comment(
+        bot,
+        issue_number,
+        _warning_marker(issue_number, reviewer, anchor_timestamp),
+        authors=_TRANSITION_NOTICE_AUTHORS,
+    )
+
+
+def check_overdue_reviews_result(bot, state: dict) -> tuple[list[dict], bool]:
+    overdue = check_overdue_reviews(bot, state)
+    return overdue, False
 
 
 def check_overdue_reviews(bot, state: dict) -> list[dict]:
@@ -34,23 +149,22 @@ def check_overdue_reviews(bot, state: dict) -> list[dict]:
             continue
 
         issue_number = int(issue_key)
-        issue_snapshot = bot.github.get_issue_or_pr_snapshot(issue_number)
+        issue_snapshot_result = bot.github.get_issue_or_pr_snapshot_result(issue_number)
+        issue_snapshot = issue_snapshot_result.payload if issue_snapshot_result.ok else None
         if not isinstance(issue_snapshot, dict):
             _log(bot, "warning", f"Skipping overdue evaluation for #{issue_number}; issue/PR snapshot unavailable", issue_number=issue_number)
             continue
-        if isinstance(issue_snapshot.get("pull_request"), dict):
-            response_state = bot.adapters.review_state.compute_reviewer_response_state(
-                issue_number,
-                review_data,
-                issue_snapshot=issue_snapshot,
-            )
-            if response_state.get("state") != "awaiting_reviewer_response":
-                continue
-            last_activity = response_state.get("anchor_timestamp")
-        else:
-            last_activity = review_data.get("last_reviewer_activity")
-            if not last_activity:
-                last_activity = review_data.get("assigned_at")
+        if str(issue_snapshot.get("state", "")).lower() == "closed":
+            continue
+        response_state = bot.adapters.review_state.compute_reviewer_response_state(
+            issue_number,
+            review_data,
+            issue_snapshot=issue_snapshot,
+        )
+        if response_state.get("state") != "awaiting_reviewer_response":
+            continue
+        last_activity = response_state.get("anchor_timestamp")
+        anchor_reason = response_state.get("reason") if isinstance(response_state.get("reason"), str) else None
 
         if not last_activity:
             continue
@@ -80,6 +194,8 @@ def check_overdue_reviews(bot, state: dict) -> list[dict]:
                             "days_since_warning": days_since_warning,
                             "needs_warning": False,
                             "needs_transition": True,
+                            "anchor_reason": anchor_reason,
+                            "anchor_timestamp": last_activity,
                         }
                     )
             except (ValueError, AttributeError):
@@ -93,52 +209,24 @@ def check_overdue_reviews(bot, state: dict) -> list[dict]:
                     "days_since_warning": 0,
                     "needs_warning": True,
                     "needs_transition": False,
+                    "anchor_reason": anchor_reason,
+                    "anchor_timestamp": last_activity,
                 }
             )
 
     return overdue
 
 
-def find_existing_transition_notice(bot, issue_number: int, transition_warning_sent: str | None, reviewer: str | None = None) -> str | None:
+def find_existing_transition_notice_result(bot, issue_number: int, transition_warning_sent: str | None, reviewer: str | None = None) -> dict[str, object]:
     if not isinstance(transition_warning_sent, str) or not transition_warning_sent:
-        return None
-    try:
-        warning_dt = bot.datetime.fromisoformat(transition_warning_sent.replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
-        return None
-    first_match = None
-    marker = f"<!-- {TRANSITION_NOTICE_MARKER_PREFIX} issue={issue_number} reviewer={reviewer or ''} -->"
-    page = 1
-    while True:
-        response = bot.github_api("GET", f"issues/{issue_number}/comments?per_page=100&page={page}")
-        if not isinstance(response, list):
-            return None
-        for comment in response:
-            if not isinstance(comment, dict):
-                continue
-            user = comment.get("user")
-            login = user.get("login") if isinstance(user, dict) else None
-            created_at = comment.get("created_at")
-            body = comment.get("body")
-            if not isinstance(login, str) or not isinstance(created_at, str) or not isinstance(body, str):
-                continue
-            if login not in _TRANSITION_NOTICE_AUTHORS:
-                continue
-            try:
-                created_dt = bot.datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-            except (ValueError, AttributeError):
-                continue
-            if created_dt < warning_dt:
-                continue
-            lines = body.splitlines()
-            first_line = lines[0].strip() if lines else ""
-            if first_line == marker:
-                if first_match is None or created_dt < first_match[0]:
-                    first_match = (created_dt, created_at)
-        if len(response) < 100:
-            break
-        page += 1
-    return first_match[1] if first_match else None
+        return {"status": "missing"}
+    return _find_existing_marker_comment(
+        bot,
+        issue_number,
+        f"<!-- {TRANSITION_NOTICE_MARKER_PREFIX} issue={issue_number} reviewer={reviewer or ''} -->",
+        authors=_TRANSITION_NOTICE_AUTHORS,
+        not_before=transition_warning_sent,
+    )
 
 
 def backfill_transition_notice_if_present(bot, state: dict, issue_number: int) -> bool:
@@ -151,19 +239,46 @@ def backfill_transition_notice_if_present(bot, state: dict, issue_number: int) -
         return False
     if review_data.get("transition_notice_sent_at"):
         return False
-    existing_notice = find_existing_transition_notice(
+    existing_notice = find_existing_transition_notice_result(
         bot,
         issue_number,
         review_data.get("transition_warning_sent"),
         review_data.get("current_reviewer"),
     )
-    if not existing_notice:
-        return False
-    review_data["transition_notice_sent_at"] = existing_notice
+    if existing_notice.get("status") == "unavailable":
+        return _record_transport_failure(
+            bot,
+            review_data,
+            issue_number,
+            phase="transition_dedupe_read",
+            result=bot.GitHubApiResult(
+                existing_notice.get("status_code"),
+                None,
+                {},
+                "",
+                False,
+                existing_notice.get("failure_kind"),
+                existing_notice.get("retry_attempts", 0),
+                None,
+            ),
+        )
+    changed = _clear_transport_failure(bot, review_data, issue_number, phase="transition_dedupe_read")
+    timestamp = existing_notice.get("timestamp") if existing_notice.get("status") == "found" else None
+    if not isinstance(timestamp, str) or not timestamp:
+        return changed
+    review_data["transition_notice_sent_at"] = timestamp
+    bot.collect_touched_item(issue_number)
     return True
 
 
-def handle_overdue_review_warning(bot, state: dict, issue_number: int, reviewer: str) -> bool:
+def handle_overdue_review_warning(
+    bot,
+    state: dict,
+    issue_number: int,
+    reviewer: str,
+    *,
+    anchor_reason: str | None = None,
+) -> bool:
     """Post a warning comment and record that we've warned the reviewer."""
     issue_key = str(issue_number)
 
@@ -173,10 +288,36 @@ def handle_overdue_review_warning(bot, state: dict, issue_number: int, reviewer:
     review_data = state["active_reviews"][issue_key]
     if not isinstance(review_data, dict):
         return False
+    anchor_timestamp = review_data.get("transition_warning_sent") if isinstance(review_data.get("transition_warning_sent"), str) else None
+    existing_warning = _warning_scan_result(bot, issue_number, reviewer, anchor_timestamp)
+    if existing_warning.get("status") == "unavailable":
+        return _record_transport_failure(
+            bot,
+            review_data,
+            issue_number,
+            phase="warning_dedupe_read",
+            result=bot.GitHubApiResult(
+                existing_warning.get("status_code"),
+                None,
+                {},
+                "",
+                False,
+                existing_warning.get("failure_kind"),
+                existing_warning.get("retry_attempts", 0),
+                None,
+            ),
+        )
+    changed = _clear_transport_failure(bot, review_data, issue_number, phase="warning_dedupe_read")
+    if existing_warning.get("status") == "found":
+        review_data["transition_warning_sent"] = existing_warning.get("timestamp")
+        bot.collect_touched_item(issue_number)
+        return True
 
     warning_message = f"""⚠️ **Review Reminder**
 
-Hey @{reviewer}, it's been more than {bot.REVIEW_DEADLINE_DAYS} days since you were assigned to review this.
+{_warning_marker(issue_number, reviewer, anchor_timestamp)}
+
+{_warning_anchor_sentence(bot, reviewer, anchor_reason)}
 
 **Please take one of the following actions:**
 
@@ -188,11 +329,26 @@ If no action is taken within {bot.TRANSITION_PERIOD_DAYS} days, you may be trans
 
 _Life happens! If you're dealing with something, just let us know._"""
 
-    if not bot.github.post_comment(issue_number, warning_message):
-        return False
+    post_result = bot.github.post_comment_result(issue_number, warning_message)
+    if not post_result.ok:
+        if (
+            post_result.failure_kind in {"invalid_payload", "server_error", "transport_error", "rate_limited"}
+            or (post_result.status_code is not None and post_result.status_code < 400)
+        ):
+            existing_warning = _warning_scan_result(bot, issue_number, reviewer, anchor_timestamp)
+            if existing_warning.get("status") == "found":
+                review_data["transition_warning_sent"] = existing_warning.get("timestamp")
+                _clear_transport_failure(bot, review_data, issue_number, phase="warning_post")
+                bot.collect_touched_item(issue_number)
+                return True
+        changed = _record_transport_failure(bot, review_data, issue_number, phase="warning_post", result=post_result)
+        return changed or changed
+
+    changed = _clear_transport_failure(bot, review_data, issue_number, phase="warning_post") or changed
 
     now = bot.datetime.now(bot.timezone.utc).isoformat()
     review_data["transition_warning_sent"] = now
+    bot.collect_touched_item(issue_number)
 
     _log(bot, "info", f"Posted overdue warning for #{issue_number} to @{reviewer}", issue_number=issue_number, reviewer=reviewer)
     return True

--- a/scripts/reviewer_bot_lib/overdue.py
+++ b/scripts/reviewer_bot_lib/overdue.py
@@ -57,6 +57,19 @@ def _warning_marker(issue_number: int, reviewer: str, anchor_timestamp: str | No
     )
 
 
+def _authority_marker(*, phase: str, live_assignees: list[str], reason: str, recorded_at: str) -> dict:
+    return {
+        "kind": "reviewer_authority_mismatch",
+        "phase": phase,
+        "status_code": None,
+        "failure_kind": "reviewer_authority_mismatch",
+        "retry_attempts": 0,
+        "recorded_at": recorded_at,
+        "reason": reason,
+        "live_assignees": list(live_assignees),
+    }
+
+
 def _find_existing_marker_comment(
     bot,
     issue_number: int,
@@ -152,10 +165,70 @@ def check_overdue_reviews(bot, state: dict) -> list[dict]:
         issue_snapshot_result = bot.github.get_issue_or_pr_snapshot_result(issue_number)
         issue_snapshot = issue_snapshot_result.payload if issue_snapshot_result.ok else None
         if not isinstance(issue_snapshot, dict):
+            if issue_snapshot_result.failure_kind in {"unauthorized", "forbidden"}:
+                raise RuntimeError(
+                    f"Permission denied reading issue snapshot for #{issue_number} (status {issue_snapshot_result.status_code})."
+                )
+            _record_transport_failure(
+                bot,
+                review_data,
+                issue_number,
+                phase="issue_snapshot_read",
+                result=issue_snapshot_result,
+            )
             _log(bot, "warning", f"Skipping overdue evaluation for #{issue_number}; issue/PR snapshot unavailable", issue_number=issue_number)
             continue
+        _clear_transport_failure(bot, review_data, issue_number, phase="issue_snapshot_read")
         if str(issue_snapshot.get("state", "")).lower() == "closed":
             continue
+        assignee_result = bot.github.get_issue_assignees_result(
+            issue_number,
+            is_pull_request=isinstance(issue_snapshot.get("pull_request"), dict),
+        )
+        if assignee_result.failure_kind in {"unauthorized", "forbidden"}:
+            raise RuntimeError(
+                f"Permission denied reading reviewer authority for #{issue_number} (status {assignee_result.status_code})."
+            )
+        if not assignee_result.ok or not isinstance(assignee_result.payload, list):
+            _record_transport_failure(
+                bot,
+                review_data,
+                issue_number,
+                phase="assignment_confirm_read",
+                result=assignee_result,
+            )
+            continue
+        live_assignees = assignee_result.payload
+        live_assignees_normalized = [assignee.lower() for assignee in live_assignees]
+        if len(live_assignees) != 1:
+            _store_assignment_marker = store_repair_marker(
+                review_data,
+                "assignment_confirm_read",
+                _authority_marker(
+                    phase="assignment_confirm_read",
+                    live_assignees=live_assignees,
+                    reason="invalid_live_assignee_count",
+                    recorded_at=bot.clock.now().isoformat(),
+                ),
+            )
+            if _store_assignment_marker:
+                bot.collect_touched_item(issue_number)
+            continue
+        if current_reviewer.lower() != live_assignees_normalized[0]:
+            _store_assignment_marker = store_repair_marker(
+                review_data,
+                "assignment_confirm_read",
+                _authority_marker(
+                    phase="assignment_confirm_read",
+                    live_assignees=live_assignees,
+                    reason="stored_reviewer_mismatch",
+                    recorded_at=bot.clock.now().isoformat(),
+                ),
+            )
+            if _store_assignment_marker:
+                bot.collect_touched_item(issue_number)
+            continue
+        _clear_transport_failure(bot, review_data, issue_number, phase="assignment_confirm_read")
         response_state = bot.adapters.review_state.compute_reviewer_response_state(
             issue_number,
             review_data,
@@ -246,6 +319,10 @@ def backfill_transition_notice_if_present(bot, state: dict, issue_number: int) -
         review_data.get("current_reviewer"),
     )
     if existing_notice.get("status") == "unavailable":
+        if existing_notice.get("failure_kind") in {"unauthorized", "forbidden"}:
+            raise RuntimeError(
+                f"Permission denied reading transition dedupe comments for #{issue_number} (status {existing_notice.get('status_code')})."
+            )
         return _record_transport_failure(
             bot,
             review_data,
@@ -278,6 +355,7 @@ def handle_overdue_review_warning(
     reviewer: str,
     *,
     anchor_reason: str | None = None,
+    anchor_timestamp: str | None = None,
 ) -> bool:
     """Post a warning comment and record that we've warned the reviewer."""
     issue_key = str(issue_number)
@@ -288,9 +366,12 @@ def handle_overdue_review_warning(
     review_data = state["active_reviews"][issue_key]
     if not isinstance(review_data, dict):
         return False
-    anchor_timestamp = review_data.get("transition_warning_sent") if isinstance(review_data.get("transition_warning_sent"), str) else None
     existing_warning = _warning_scan_result(bot, issue_number, reviewer, anchor_timestamp)
     if existing_warning.get("status") == "unavailable":
+        if existing_warning.get("failure_kind") in {"unauthorized", "forbidden"}:
+            raise RuntimeError(
+                f"Permission denied reading warning dedupe comments for #{issue_number} (status {existing_warning.get('status_code')})."
+            )
         return _record_transport_failure(
             bot,
             review_data,
@@ -313,9 +394,9 @@ def handle_overdue_review_warning(
         bot.collect_touched_item(issue_number)
         return True
 
-    warning_message = f"""⚠️ **Review Reminder**
+    warning_message = f"""{_warning_marker(issue_number, reviewer, anchor_timestamp)}
 
-{_warning_marker(issue_number, reviewer, anchor_timestamp)}
+⚠️ **Review Reminder**
 
 {_warning_anchor_sentence(bot, reviewer, anchor_reason)}
 
@@ -331,6 +412,10 @@ _Life happens! If you're dealing with something, just let us know._"""
 
     post_result = bot.github.post_comment_result(issue_number, warning_message)
     if not post_result.ok:
+        if post_result.failure_kind in {"unauthorized", "forbidden"}:
+            raise RuntimeError(
+                f"Permission denied posting overdue warning for #{issue_number} (status {post_result.status_code})."
+            )
         if (
             post_result.failure_kind in {"invalid_payload", "server_error", "transport_error", "rate_limited"}
             or (post_result.status_code is not None and post_result.status_code < 400)

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -188,8 +188,14 @@ def handle_rectify_command(
     issue_number: int,
     comment_author: str,
 ) -> tuple[str, bool, bool]:
-    review_data = ensure_review_entry(state, issue_number)
-    current_reviewer = review_data.get("current_reviewer") if review_data else None
+    current_assignees = bot.github.get_issue_assignees(issue_number)
+    if current_assignees is None:
+        return (
+            "❌ Unable to determine current assignees/reviewers from GitHub; refusing to continue.",
+            False,
+            False,
+        )
+    current_reviewer = current_assignees[0] if len(current_assignees) == 1 else None
 
     is_current_reviewer = (
         isinstance(current_reviewer, str)
@@ -216,7 +222,7 @@ def handle_rectify_command(
                 False,
             )
         return (
-            "❌ Only maintainers with triage+ permission can run `/rectify` when no assigned "
+            "❌ Only maintainers with triage+ permission can run `/rectify` when no confirmed assigned "
             "reviewer is tracked.",
             False,
             False,

--- a/scripts/reviewer_bot_lib/repair_records.py
+++ b/scripts/reviewer_bot_lib/repair_records.py
@@ -80,5 +80,7 @@ def clear_repair_marker(review_data: dict, key: str) -> bool:
     markers = repair_markers(review_data)
     if key not in markers:
         return False
+    if not isinstance(markers.get(key), dict):
+        return False
     markers[key] = None
     return True

--- a/scripts/reviewer_bot_lib/repair_records.py
+++ b/scripts/reviewer_bot_lib/repair_records.py
@@ -8,6 +8,14 @@ _REPAIR_MARKER_KEYS = (
     "review_repair",
     "head_observation_repair",
     "status_label_projection",
+    "issue_snapshot_read",
+    "warning_dedupe_read",
+    "warning_post",
+    "transition_dedupe_read",
+    "transition_post",
+    "assignment_add_write",
+    "assignment_remove_write",
+    "assignment_confirm_read",
 )
 
 

--- a/scripts/reviewer_bot_lib/retrying.py
+++ b/scripts/reviewer_bot_lib/retrying.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Protocol
 
 RETRY_POLICY_NONE = "none"
@@ -23,6 +24,63 @@ class RetrySpec:
 
 def is_retryable_status(status_code: int | None) -> bool:
     return status_code == 429 or (status_code is not None and status_code >= 500)
+
+
+def is_rate_limited_response(
+    status_code: int | None,
+    *,
+    headers: dict[str, str] | None = None,
+    text: str = "",
+) -> bool:
+    if status_code == 429:
+        return True
+    if status_code != 403:
+        return False
+    normalized_headers = {str(key).lower(): str(value) for key, value in (headers or {}).items()}
+    if "retry-after" in normalized_headers:
+        return True
+    if normalized_headers.get("x-ratelimit-remaining", "").strip() == "0":
+        return True
+    return "rate limit" in text.lower()
+
+
+def retry_delay_seconds(
+    base_delay_seconds: float,
+    retry_attempt: int,
+    *,
+    jitter: JitterSource,
+    status_code: int | None = None,
+    headers: dict[str, str] | None = None,
+    text: str = "",
+    now: datetime | None = None,
+    max_delay_seconds: float = 8.0,
+) -> float:
+    normalized_headers = {str(key).lower(): str(value) for key, value in (headers or {}).items()}
+    retry_after = normalized_headers.get("retry-after", "").strip()
+    if is_rate_limited_response(status_code, headers=normalized_headers, text=text) and retry_after:
+        try:
+            return max(float(retry_after), 0.0)
+        except ValueError:
+            pass
+    if (
+        is_rate_limited_response(status_code, headers=normalized_headers, text=text)
+        and normalized_headers.get("x-ratelimit-remaining", "").strip() == "0"
+    ):
+        reset_at = normalized_headers.get("x-ratelimit-reset", "").strip()
+        if reset_at:
+            try:
+                reset_epoch = float(reset_at)
+            except ValueError:
+                pass
+            else:
+                reference_now = now or datetime.now(timezone.utc)
+                return max(reset_epoch - reference_now.timestamp(), 0.0)
+    return bounded_exponential_delay(
+        base_delay_seconds,
+        retry_attempt,
+        jitter=jitter,
+        max_delay_seconds=max_delay_seconds,
+    )
 
 
 def additional_attempts_for_policy(retry_policy: str, retry_limit: int) -> int:

--- a/scripts/reviewer_bot_lib/review_state.py
+++ b/scripts/reviewer_bot_lib/review_state.py
@@ -36,14 +36,19 @@ def set_current_reviewer(
     issue_number: int,
     reviewer: str,
     assignment_method: str = "round-robin",
+    at: str | None = None,
 ) -> None:
     review_state_machine.set_current_reviewer(
         state,
         issue_number,
         reviewer,
-        now=_now_iso(),
+        now=at or _now_iso(),
         assignment_method=assignment_method,
     )
+
+
+def clear_current_reviewer(state: dict, issue_number: int) -> bool:
+    return review_state_machine.clear_current_reviewer(state, issue_number)
 
 
 def semantic_key_seen(review_data: dict, channel_name: str, semantic_key: str) -> bool:

--- a/scripts/reviewer_bot_lib/runtime_protocols.py
+++ b/scripts/reviewer_bot_lib/runtime_protocols.py
@@ -137,6 +137,7 @@ class GitHubApiContext(Protocol):
     AssignmentAttempt: type[AssignmentAttempt]
     GitHubApiResult: type[GitHubApiResult]
     logger: Logger
+    clock: Clock
     sleeper: Sleeper
     jitter: JitterSource
     rest_transport: RestTransport
@@ -196,9 +197,9 @@ class GitHubTransportContext(GitHubApiContext, Protocol):
 
     def get_user_permission_status(self, username: str, required_permission: str = "triage") -> str: ...
 
-    def remove_issue_assignee(self, issue_number: int, username: str) -> bool: ...
+    def remove_issue_assignee(self, issue_number: int, username: str) -> AssignmentAttempt: ...
 
-    def remove_pr_reviewer(self, issue_number: int, username: str) -> bool: ...
+    def remove_pr_reviewer(self, issue_number: int, username: str) -> AssignmentAttempt: ...
 
 
 @runtime_checkable
@@ -378,6 +379,16 @@ class SweeperContext(Protocol):
 
     def get_issue_or_pr_snapshot(self, issue_number: int) -> dict | None: ...
 
+    def get_issue_or_pr_snapshot_result(self, issue_number: int) -> GitHubApiResult: ...
+
+    def list_issue_comments_result(
+        self,
+        issue_number: int,
+        *,
+        page: int = 1,
+        per_page: int = 100,
+    ) -> GitHubApiResult: ...
+
     def maybe_record_head_observation_repair(
         self, issue_number: int, review_data: dict
     ) -> HeadObservationRepairResult: ...
@@ -466,6 +477,8 @@ class CommentGitHubWriteContext(Protocol):
     def get_user_permission_status(self, username: str, required_permission: str = "triage") -> str: ...
 
     def post_comment(self, issue_number: int, body: str) -> bool: ...
+
+    def post_comment_result(self, issue_number: int, body: str) -> GitHubApiResult: ...
 
     def add_reaction(self, comment_id: int, reaction: str) -> bool: ...
 

--- a/scripts/reviewer_bot_lib/runtime_protocols.py
+++ b/scripts/reviewer_bot_lib/runtime_protocols.py
@@ -381,6 +381,13 @@ class SweeperContext(Protocol):
 
     def get_issue_or_pr_snapshot_result(self, issue_number: int) -> GitHubApiResult: ...
 
+    def get_issue_assignees_result(
+        self,
+        issue_number: int,
+        *,
+        is_pull_request: bool | None = None,
+    ) -> GitHubApiResult: ...
+
     def list_issue_comments_result(
         self,
         issue_number: int,

--- a/tests/contract/reviewer_bot/test_adapter_contract.py
+++ b/tests/contract/reviewer_bot/test_adapter_contract.py
@@ -369,9 +369,12 @@ def test_event_inputs_parse_labels_from_runtime_config(monkeypatch):
 
 def test_event_inputs_build_issue_lifecycle_request_from_runtime_config(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("EVENT_ACTION", "assigned")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("IS_PULL_REQUEST", "true")
+    runtime.set_config_value("ISSUE_STATE", "open")
     runtime.set_config_value("ISSUE_LABELS", '["coding guideline"]')
+    runtime.set_config_value("LABEL_NAME", "coding guideline")
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("SENDER_LOGIN", "alice")
     runtime.set_config_value("ISSUE_UPDATED_AT", "2026-03-17T10:00:00Z")
@@ -384,9 +387,12 @@ def test_event_inputs_build_issue_lifecycle_request_from_runtime_config(monkeypa
 
     request = event_inputs.build_issue_lifecycle_request(runtime)
 
+    assert request.event_action == "assigned"
     assert request.issue_number == 42
     assert request.is_pull_request is True
+    assert request.issue_state == "open"
     assert request.issue_labels == ("coding guideline",)
+    assert request.label_name == "coding guideline"
     assert request.issue_author == "dana"
     assert request.sender_login == "alice"
     assert request.updated_at == "2026-03-17T10:00:00Z"
@@ -415,6 +421,37 @@ def test_event_inputs_build_label_and_sync_requests_from_runtime_config(monkeypa
     assert sync_request.issue_number == 42
     assert sync_request.head_sha == "head-2"
     assert sync_request.event_created_at == "2026-03-17T10:05:00Z"
+
+
+def test_bootstrap_runtime_github_exposes_typed_reminder_helpers(monkeypatch):
+    runtime = reviewer_bot._runtime_bot()
+
+    def fake_request(method, endpoint, data=None, suppress_error_log=True, retry_policy="none", **kwargs):
+        del suppress_error_log, kwargs
+        if endpoint == "issues/42":
+            assert method == "GET"
+            assert retry_policy == "idempotent_read"
+            return GitHubApiResult(200, {"number": 42}, {}, "ok", True, None, 0, None)
+        if endpoint == "issues/42/comments?per_page=100&page=2":
+            assert method == "GET"
+            assert retry_policy == "idempotent_read"
+            return GitHubApiResult(200, [], {}, "ok", True, None, 0, None)
+        if endpoint == "issues/42/comments":
+            assert method == "POST"
+            assert data == {"body": "hello"}
+            return GitHubApiResult(201, {"id": 100}, {}, "created", True, None, 0, None)
+        raise AssertionError((method, endpoint, data, retry_policy))
+
+    runtime.github_api_request = fake_request
+
+    snapshot_result = runtime.github.get_issue_or_pr_snapshot_result(42)
+    comments_result = runtime.github.list_issue_comments_result(42, page=2)
+    post_result = runtime.github.post_comment_result(42, "hello")
+
+    assert snapshot_result.payload == {"number": 42}
+    assert comments_result.payload == []
+    assert post_result.status_code == 201
+    assert post_result.failure_kind is None
 
 
 def test_runtime_typed_config_accessors_read_runtime_config(monkeypatch):
@@ -524,7 +561,14 @@ def test_bootstrap_runtime_wires_explicit_handler_services():
     runtime = reviewer_bot._runtime_bot()
 
     assert hasattr(runtime.handlers, "handle_issue_or_pr_opened")
+    assert hasattr(runtime.handlers, "handle_assigned_event")
+    assert hasattr(runtime.handlers, "handle_unassigned_event")
     assert hasattr(runtime.handlers, "handle_comment_event")
+    assert hasattr(runtime.handlers, "handle_labeled_event")
+    assert hasattr(runtime.handlers, "handle_unlabeled_event")
+    assert hasattr(runtime.handlers, "handle_issue_edited_event")
+    assert hasattr(runtime.handlers, "handle_reopened_event")
+    assert hasattr(runtime.handlers, "handle_closed_event")
     assert hasattr(runtime.handlers, "handle_workflow_run_event") is False
 
 

--- a/tests/contract/reviewer_bot/test_comment_application_contract.py
+++ b/tests/contract/reviewer_bot/test_comment_application_contract.py
@@ -195,8 +195,8 @@ def test_comment_application_no_longer_owns_privileged_handoff_validation_or_met
 def test_comment_application_no_longer_owns_direct_comment_freshness_decision_branching():
     module_text = Path("scripts/reviewer_bot_lib/comment_application.py").read_text(encoding="utf-8")
 
-    assert "comment_freshness_policy.decide_comment_freshness(review_data, request)" in module_text
-    assert "if request.issue_author and request.issue_author.lower() == comment_author.lower():" not in module_text
+    assert "comment_freshness_policy.decide_comment_freshness(effective_review_data, request)" in module_text
+    assert 'bot.github.get_issue_assignees(' in module_text
     assert "if isinstance(current_reviewer, str) and current_reviewer.lower() == comment_author.lower():" not in module_text
 
 

--- a/tests/contract/reviewer_bot/test_fake_runtime_contract.py
+++ b/tests/contract/reviewer_bot/test_fake_runtime_contract.py
@@ -233,6 +233,25 @@ def test_fake_runtime_github_api_mode_delegates_to_shared_route_fake(monkeypatch
     assert runtime.github_api("GET", "pulls/42") == {"head": {"sha": "head-1"}}
 
 
+def test_fake_runtime_github_exposes_typed_reminder_results(monkeypatch):
+    github = (
+        RouteGitHubApi()
+        .add_request("GET", "issues/42", status_code=200, payload={"number": 42})
+        .add_request("GET", "issues/42/comments?per_page=100&page=2", status_code=200, payload=[])
+        .add_request("POST", "issues/42/comments", status_code=201, payload={"id": 100})
+    )
+    runtime = FakeReviewerBotRuntime(monkeypatch, github=github)
+
+    snapshot_result = runtime.github.get_issue_or_pr_snapshot_result(42)
+    comments_result = runtime.github.list_issue_comments_result(42, page=2)
+    post_result = runtime.github.post_comment_result(42, "hello")
+
+    assert snapshot_result.ok is True
+    assert snapshot_result.payload == {"number": 42}
+    assert comments_result.payload == []
+    assert post_result.status_code == 201
+
+
 def test_focused_fake_service_types_are_exposed_for_direct_fixture_composition(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
 

--- a/tests/contract/reviewer_bot/test_review_state_contract.py
+++ b/tests/contract/reviewer_bot/test_review_state_contract.py
@@ -43,6 +43,22 @@ def _read_review_state_inventory() -> str:
     return _read("tests/fixtures/equivalence/review_state/api_inventory.md")
 
 
+def _expected_repair_markers() -> dict[str, None]:
+    return {
+        "review_repair": None,
+        "head_observation_repair": None,
+        "status_label_projection": None,
+        "issue_snapshot_read": None,
+        "warning_dedupe_read": None,
+        "warning_post": None,
+        "transition_dedupe_read": None,
+        "transition_post": None,
+        "assignment_add_write": None,
+        "assignment_remove_write": None,
+        "assignment_confirm_read": None,
+    }
+
+
 def test_ensure_review_entry_initializes_tracked_review_shape():
     state = make_state()
 
@@ -51,11 +67,7 @@ def test_ensure_review_entry_initializes_tracked_review_shape():
     assert review is not None
     assert review["current_reviewer"] is None
     assert review["reviewer_comment"]["accepted"] is None
-    assert review["sidecars"]["repair_markers"] == {
-        "review_repair": None,
-        "head_observation_repair": None,
-        "status_label_projection": None,
-    }
+    assert review["sidecars"]["repair_markers"] == _expected_repair_markers()
     assert review["sidecars"]["pending_privileged_commands"] == {}
     assert review["sidecars"]["deferred_gaps"] == {}
     assert review["sidecars"]["observer_discovery_watermarks"] == {}
@@ -100,11 +112,7 @@ def test_ensure_review_entry_lazily_upgrades_sparse_legacy_review_entries():
     assert review is state["active_reviews"]["42"]
     assert review["skipped"] == ["alice", "bob"]
     assert review["reviewer_comment"] == {"accepted": None, "seen_keys": []}
-    assert review["sidecars"]["repair_markers"] == {
-        "review_repair": None,
-        "head_observation_repair": None,
-        "status_label_projection": None,
-    }
+    assert review["sidecars"]["repair_markers"] == _expected_repair_markers()
     assert review["sidecars"]["pending_privileged_commands"] == {}
     assert review["sidecars"]["reconciled_source_events"] == {}
 
@@ -126,11 +134,7 @@ def test_ensure_review_entry_repairs_missing_nested_maps_and_legacy_list_fields(
     assert review["sidecars"]["deferred_gaps"] == {}
     assert review["sidecars"]["observer_discovery_watermarks"] == {}
     assert review["sidecars"]["pending_privileged_commands"] == {}
-    assert review["sidecars"]["repair_markers"] == {
-        "review_repair": None,
-        "head_observation_repair": None,
-        "status_label_projection": None,
-    }
+    assert review["sidecars"]["repair_markers"] == _expected_repair_markers()
     assert review["current_cycle_completion"] == {}
     assert review["current_cycle_write_approval"] == {}
     assert review["sidecars"]["reconciled_source_events"] == {}

--- a/tests/contract/reviewer_bot/test_runtime_protocols.py
+++ b/tests/contract/reviewer_bot/test_runtime_protocols.py
@@ -1,20 +1,25 @@
 import json
 from pathlib import Path
+from typing import get_type_hints
 
 import pytest
 
 pytestmark = pytest.mark.contract
 
 from scripts import reviewer_bot
+from scripts.reviewer_bot_lib.config import AssignmentAttempt, GitHubApiResult
 from scripts.reviewer_bot_lib.runtime import ReviewerBotRuntime
 from scripts.reviewer_bot_lib.runtime_protocols import (
     AppEventContextRuntime,
     AppExecutionRuntime,
+    CommentGitHubWriteContext,
     EventInputsContext,
+    GitHubTransportContext,
     ProjectBoardMetadataContext,
     ProjectBoardProjectionContext,
     ReconcileRectifyRuntimeContext,
     ReconcileWorkflowRuntimeContext,
+    SweeperContext,
 )
 from tests.fixtures.fake_runtime import FakeReviewerBotRuntime
 
@@ -84,6 +89,14 @@ def test_fake_runtime_satisfies_app_execution_runtime_protocol(monkeypatch):
     assert isinstance(runtime, ReconcileWorkflowRuntimeContext)
     assert isinstance(runtime, ReconcileRectifyRuntimeContext)
     _assert_core_runtime_surface(runtime)
+
+
+def test_runtime_protocol_annotations_preserve_typed_reminder_transport_surfaces():
+    assert get_type_hints(GitHubTransportContext.remove_issue_assignee)["return"] is AssignmentAttempt
+    assert get_type_hints(GitHubTransportContext.remove_pr_reviewer)["return"] is AssignmentAttempt
+    assert get_type_hints(SweeperContext.get_issue_or_pr_snapshot_result)["return"] is GitHubApiResult
+    assert get_type_hints(SweeperContext.list_issue_comments_result)["return"] is GitHubApiResult
+    assert get_type_hints(CommentGitHubWriteContext.post_comment_result)["return"] is GitHubApiResult
 
 def test_o3_runtime_deletion_manifest_forbids_dead_workflow_run_handler_compatibility_surface():
     manifest = json.loads(

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -42,6 +42,31 @@ def test_pr_metadata_workflow_exports_label_name_for_labeled_path():
     )
     assert "LABEL_NAME: ${{ github.event.label.name }}" in workflow_text
 
+
+def test_issue_lifecycle_workflow_covers_retained_event_matrix():
+    workflow = yaml.safe_load(Path(".github/workflows/reviewer-bot-issues.yml").read_text(encoding="utf-8"))
+    on_block = workflow.get("on", workflow.get(True))
+
+    assert on_block["issues"]["types"] == [
+        "opened",
+        "edited",
+        "labeled",
+        "unlabeled",
+        "assigned",
+        "unassigned",
+        "reopened",
+        "closed",
+    ]
+
+
+def test_issue_lifecycle_workflow_exports_retained_request_boundary_fields():
+    workflow_text = Path(".github/workflows/reviewer-bot-issues.yml").read_text(encoding="utf-8")
+
+    assert "IS_PULL_REQUEST: 'false'" in workflow_text
+    assert "ISSUE_STATE: ${{ github.event.issue.state }}" in workflow_text
+    assert "LABEL_NAME: ${{ github.event.label.name }}" in workflow_text
+    assert "EVENT_CREATED_AT: ${{ github.event.issue.updated_at }}" in workflow_text
+
 def test_pr_comment_router_workflow_builds_payload_inline_without_bot_src_root():
     workflow = Path(".github/workflows/reviewer-bot-pr-comment-router.yml").read_text(encoding="utf-8")
     assert "build_pr_comment_observer_payload" not in workflow

--- a/tests/fixtures/commands_harness.py
+++ b/tests/fixtures/commands_harness.py
@@ -51,6 +51,7 @@ class CommandHarness:
         self.config = self.runtime.config
         self.github = self.runtime.github
         self.handlers = self.runtime.handlers
+        self._live_assignees: list[str] = []
 
     def wrapper_set_comment_command(
         self,
@@ -118,10 +119,21 @@ class CommandHarness:
         return record_comment_side_effects(self.runtime)
 
     def stub_assignees(self, assignees):
-        self.runtime.github.get_issue_assignees = lambda issue_number: assignees
+        self._live_assignees = list(assignees)
+        self.runtime.github.get_issue_assignees = lambda issue_number: list(self._live_assignees)
+        self.runtime.github.remove_pr_reviewer = self._remove_live_assignee
+        self.runtime.github.remove_issue_assignee = self._remove_live_assignee
+
+    def _remove_live_assignee(self, issue_number, username):
+        del issue_number
+        self._live_assignees = [assignee for assignee in self._live_assignees if assignee.lower() != username.lower()]
+        return True
 
     def stub_assignment(self, *, success: bool = True, status_code: int = 201):
         def attempt(issue_number, username):
+            del issue_number
+            if success:
+                self._live_assignees = [username]
             return AssignmentAttempt(success=success, status_code=status_code)
 
         self.runtime.github.request_pr_reviewer_assignment = attempt

--- a/tests/fixtures/commands_harness.py
+++ b/tests/fixtures/commands_harness.py
@@ -121,6 +121,16 @@ class CommandHarness:
     def stub_assignees(self, assignees):
         self._live_assignees = list(assignees)
         self.runtime.github.get_issue_assignees = lambda issue_number: list(self._live_assignees)
+        self.runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: self.runtime.GitHubApiResult(
+            200,
+            list(self._live_assignees),
+            {},
+            "ok",
+            True,
+            None,
+            0,
+            None,
+        )
         self.runtime.github.remove_pr_reviewer = self._remove_live_assignee
         self.runtime.github.remove_issue_assignee = self._remove_live_assignee
 
@@ -260,36 +270,43 @@ class CommandHarness:
     def typed_trust_context(self, **kwargs):
         return self.typed_pr_admission(**kwargs)
 
+    @staticmethod
+    def _normalize_command_result(result):
+        if isinstance(result, tuple) and len(result) == 3:
+            response, success, _state_changed = result
+            return response, success
+        return result
+
     def handle_assign(self, state: dict, issue_number: int, username: str, *, request=None):
-        return commands_module.handle_assign_command(
+        return self._normalize_command_result(commands_module.handle_assign_command(
             self.runtime,
             state,
             issue_number,
             username,
             request=request or self.assignment_request(issue_number=issue_number),
-        )
+        ))
 
     def handle_claim(self, state: dict, issue_number: int, comment_author: str, *, request=None):
-        return commands_module.handle_claim_command(
+        return self._normalize_command_result(commands_module.handle_claim_command(
             self.runtime,
             state,
             issue_number,
             comment_author,
             request=request or self.assignment_request(issue_number=issue_number),
-        )
+        ))
 
     def handle_pass(self, state: dict, issue_number: int, comment_author: str, reason: str | None, *, request=None):
-        return commands_module.handle_pass_command(
+        return self._normalize_command_result(commands_module.handle_pass_command(
             self.runtime,
             state,
             issue_number,
             comment_author,
             reason,
             request=request or self.assignment_request(issue_number=issue_number),
-        )
+        ))
 
     def handle_pass_until(self, state: dict, issue_number: int, comment_author: str, return_date: str, reason: str | None, *, request=None):
-        return commands_module.handle_pass_until_command(
+        return self._normalize_command_result(commands_module.handle_pass_until_command(
             self.runtime,
             state,
             issue_number,
@@ -297,25 +314,25 @@ class CommandHarness:
             return_date,
             reason,
             request=request or self.assignment_request(issue_number=issue_number),
-        )
+        ))
 
     def handle_release(self, state: dict, issue_number: int, comment_author: str, args=None, *, request=None):
-        return commands_module.handle_release_command(
+        return self._normalize_command_result(commands_module.handle_release_command(
             self.runtime,
             state,
             issue_number,
             comment_author,
             args,
             request=request or self.assignment_request(issue_number=issue_number),
-        )
+        ))
 
     def handle_assign_from_queue(self, state: dict, issue_number: int, *, request=None):
-        return commands_module.handle_assign_from_queue_command(
+        return self._normalize_command_result(commands_module.handle_assign_from_queue_command(
             self.runtime,
             state,
             issue_number,
             request=request or self.assignment_request(issue_number=issue_number),
-        )
+        ))
 
     def handle_rectify(self, state: dict, issue_number: int, comment_author: str):
         return reconcile_module.handle_rectify_command(

--- a/tests/fixtures/fake_runtime.py
+++ b/tests/fixtures/fake_runtime.py
@@ -255,6 +255,9 @@ class FakeRuntimeGitHubCompatibility:
     def post_comment(self, issue_number: int, body: str) -> bool:
         return github_api_module.post_comment(self._runtime, issue_number, body)
 
+    def post_comment_result(self, issue_number: int, body: str):
+        return github_api_module.post_comment_result(self._runtime, issue_number, body)
+
     def add_reaction(self, comment_id: int, reaction: str) -> bool:
         return github_api_module.add_reaction(self._runtime, comment_id, reaction)
 
@@ -280,8 +283,18 @@ class FakeRuntimeGitHubCompatibility:
         return github_api_module.remove_pr_reviewer(self._runtime, issue_number, username)
 
     def get_issue_or_pr_snapshot(self, issue_number: int) -> dict | None:
-        payload = self._runtime.github_api("GET", f"issues/{issue_number}")
-        return payload if isinstance(payload, dict) else None
+        return github_api_module.get_issue_or_pr_snapshot(self._runtime, issue_number)
+
+    def get_issue_or_pr_snapshot_result(self, issue_number: int):
+        return github_api_module.get_issue_or_pr_snapshot_result(self._runtime, issue_number)
+
+    def list_issue_comments_result(self, issue_number: int, *, page: int = 1, per_page: int = 100):
+        return github_api_module.list_issue_comments_result(
+            self._runtime,
+            issue_number,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_pull_request_reviews(self, issue_number: int):
         return reviews_module.get_pull_request_reviews(self._runtime, issue_number)
@@ -702,6 +715,9 @@ class FakeReviewerBotRuntime:
     def post_comment(self, issue_number: int, body: str) -> bool:
         return self.compat.github.post_comment(issue_number, body)
 
+    def post_comment_result(self, issue_number: int, body: str):
+        return self.compat.github.post_comment_result(issue_number, body)
+
     def add_reaction(self, comment_id: int, reaction: str) -> bool:
         return self.compat.github.add_reaction(comment_id, reaction)
 
@@ -728,6 +744,16 @@ class FakeReviewerBotRuntime:
 
     def get_issue_or_pr_snapshot(self, issue_number: int) -> dict | None:
         return self.compat.github.get_issue_or_pr_snapshot(issue_number)
+
+    def get_issue_or_pr_snapshot_result(self, issue_number: int):
+        return self.compat.github.get_issue_or_pr_snapshot_result(issue_number)
+
+    def list_issue_comments_result(self, issue_number: int, *, page: int = 1, per_page: int = 100):
+        return self.compat.github.list_issue_comments_result(
+            issue_number,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_pull_request_reviews(self, issue_number: int):
         return self.compat.github.get_pull_request_reviews(issue_number)
@@ -894,11 +920,23 @@ class FakeReviewerBotRuntime:
     def handle_issue_or_pr_opened(self, state: dict) -> bool:
         return self.handlers.call("handle_issue_or_pr_opened", state)
 
+    def handle_assigned_event(self, state: dict) -> bool:
+        return self.handlers.call("handle_assigned_event", state)
+
+    def handle_unassigned_event(self, state: dict) -> bool:
+        return self.handlers.call("handle_unassigned_event", state)
+
     def handle_labeled_event(self, state: dict) -> bool:
         return self.handlers.call("handle_labeled_event", state)
 
+    def handle_unlabeled_event(self, state: dict) -> bool:
+        return self.handlers.call("handle_unlabeled_event", state)
+
     def handle_issue_edited_event(self, state: dict) -> bool:
         return self.handlers.call("handle_issue_edited_event", state)
+
+    def handle_reopened_event(self, state: dict) -> bool:
+        return self.handlers.call("handle_reopened_event", state)
 
     def handle_closed_event(self, state: dict) -> bool:
         return self.handlers.call("handle_closed_event", state)

--- a/tests/fixtures/fake_runtime.py
+++ b/tests/fixtures/fake_runtime.py
@@ -703,8 +703,11 @@ class FakeReviewerBotRuntime:
     def ensure_review_entry(self, state: dict, issue_number: int, create: bool = False):
         return review_state_module.ensure_review_entry(state, issue_number, create=create)
 
-    def get_issue_assignees(self, issue_number: int):
-        return self.compat.github.get_issue_assignees(issue_number)
+    def get_issue_assignees(self, issue_number: int, *, is_pull_request=None):
+        return self.compat.github.get_issue_assignees(issue_number, is_pull_request=is_pull_request)
+
+    def get_issue_assignees_result(self, issue_number: int, *, is_pull_request=None):
+        return self.compat.github.get_issue_assignees_result(issue_number, is_pull_request=is_pull_request)
 
     def request_pr_reviewer_assignment(self, issue_number: int, username: str):
         return self.compat.github.request_pr_reviewer_assignment(issue_number, username)

--- a/tests/fixtures/focused_fake_services.py
+++ b/tests/fixtures/focused_fake_services.py
@@ -167,6 +167,11 @@ class GitHubStub:
 
         return github_api_module.post_comment(self._runtime_required(), issue_number, body)
 
+    def post_comment_result(self, issue_number: int, body: str):
+        from scripts.reviewer_bot_lib import github_api as github_api_module
+
+        return github_api_module.post_comment_result(self._runtime_required(), issue_number, body)
+
     def get_repo_labels(self):
         from scripts.reviewer_bot_lib import github_api as github_api_module
 
@@ -231,7 +236,24 @@ class GitHubStub:
         return github_api_module.check_user_permission(self._runtime_required(), username, required_permission)
 
     def get_issue_or_pr_snapshot(self, issue_number: int):
-        return self.github_api("GET", f"issues/{issue_number}")
+        from scripts.reviewer_bot_lib import github_api as github_api_module
+
+        return github_api_module.get_issue_or_pr_snapshot(self._runtime_required(), issue_number)
+
+    def get_issue_or_pr_snapshot_result(self, issue_number: int):
+        from scripts.reviewer_bot_lib import github_api as github_api_module
+
+        return github_api_module.get_issue_or_pr_snapshot_result(self._runtime_required(), issue_number)
+
+    def list_issue_comments_result(self, issue_number: int, *, page: int = 1, per_page: int = 100):
+        from scripts.reviewer_bot_lib import github_api as github_api_module
+
+        return github_api_module.list_issue_comments_result(
+            self._runtime_required(),
+            issue_number,
+            page=page,
+            per_page=per_page,
+        )
 
     def get_pull_request_reviews(self, issue_number: int):
         from scripts.reviewer_bot_lib import reviews as reviews_module
@@ -364,8 +386,12 @@ class ArtifactDownloadTransportStub:
 class HandlerStub:
     ALLOWED = {
         "handle_issue_or_pr_opened",
+        "handle_assigned_event",
+        "handle_unassigned_event",
         "handle_labeled_event",
+        "handle_unlabeled_event",
         "handle_issue_edited_event",
+        "handle_reopened_event",
         "handle_closed_event",
         "handle_pull_request_target_synchronize",
         "handle_comment_event",
@@ -449,8 +475,12 @@ def build_default_handler_map(runtime) -> dict[str, Callable[[dict], bool]]:
 
     return {
         "handle_issue_or_pr_opened": lambda state: lifecycle_module.handle_issue_or_pr_opened(runtime, state),
+        "handle_assigned_event": lambda state: lifecycle_module.handle_assigned_event(runtime, state),
+        "handle_unassigned_event": lambda state: lifecycle_module.handle_unassigned_event(runtime, state),
         "handle_labeled_event": lambda state: lifecycle_module.handle_labeled_event(runtime, state),
+        "handle_unlabeled_event": lambda state: lifecycle_module.handle_unlabeled_event(runtime, state),
         "handle_issue_edited_event": lambda state: lifecycle_module.handle_issue_edited_event(runtime, state),
+        "handle_reopened_event": lambda state: lifecycle_module.handle_reopened_event(runtime, state),
         "handle_closed_event": lambda state: lifecycle_module.handle_closed_event(runtime, state),
         "handle_pull_request_target_synchronize": lambda state: lifecycle_module.handle_pull_request_target_synchronize(runtime, state),
         "handle_comment_event": lambda state: comment_routing_module.handle_comment_event(runtime, state),

--- a/tests/fixtures/focused_fake_services.py
+++ b/tests/fixtures/focused_fake_services.py
@@ -192,10 +192,30 @@ class GitHubStub:
 
         return github_api_module.ensure_label_exists(self._runtime_required(), label, color=color, description=description)
 
-    def get_issue_assignees(self, issue_number: int):
+    def get_issue_assignees(self, issue_number: int, *, is_pull_request=None):
         from scripts.reviewer_bot_lib import github_api as github_api_module
 
-        return github_api_module.get_issue_assignees(self._runtime_required(), issue_number)
+        return github_api_module.get_issue_assignees(
+            self._runtime_required(),
+            issue_number,
+            is_pull_request=is_pull_request,
+        )
+
+    def get_issue_assignees_result(self, issue_number: int, *, is_pull_request=None):
+        from scripts.reviewer_bot_lib import github_api as github_api_module
+
+        override = self.__dict__.get("get_issue_assignees")
+        if callable(override):
+            assignees = override(issue_number)
+            runtime = self._runtime_required()
+            if assignees is None:
+                return runtime.GitHubApiResult(None, None, {}, "", False, "transport_error", 0, None)
+            return runtime.GitHubApiResult(200, list(assignees), {}, "ok", True, None, 0, None)
+        return github_api_module.get_issue_assignees_result(
+            self._runtime_required(),
+            issue_number,
+            is_pull_request=is_pull_request,
+        )
 
     def request_pr_reviewer_assignment(self, issue_number: int, username: str):
         from scripts.reviewer_bot_lib import github_api as github_api_module

--- a/tests/fixtures/reviewer_bot_fakes.py
+++ b/tests/fixtures/reviewer_bot_fakes.py
@@ -123,11 +123,22 @@ class RouteGitHubApi:
         return self
 
     def add_pull_request_snapshot(self, issue_number: int, payload: Any) -> "RouteGitHubApi":
+        issue_payload = {
+            "number": issue_number,
+            "state": payload.get("state", "open") if isinstance(payload, dict) else "open",
+            "pull_request": {},
+            "labels": payload.get("labels", []) if isinstance(payload, dict) else [],
+        }
         return self.add_api("GET", f"pulls/{issue_number}", payload).add_request(
             "GET",
             f"pulls/{issue_number}",
             status_code=200,
             payload=payload,
+        ).add_request(
+            "GET",
+            f"issues/{issue_number}",
+            status_code=200,
+            payload=issue_payload,
         )
 
     def add_pull_request_reviews(self, issue_number: int, reviews: Any, *, page: int = 1) -> "RouteGitHubApi":

--- a/tests/integration/reviewer_bot/test_app_execution.py
+++ b/tests/integration/reviewer_bot/test_app_execution.py
@@ -149,6 +149,77 @@ def test_execute_run_reloads_state_before_syncing_status_labels(monkeypatch):
     }
     assert release_calls == ["released"]
 
+
+def test_execute_run_opened_issue_assignment_failure_does_not_persist_reviewer_state(monkeypatch):
+    runtime = reviewer_bot._runtime_bot()
+    state = make_state()
+    saved = []
+
+    monkeypatch.setattr(runtime.locks, "acquire", lambda: setattr(runtime, "ACTIVE_LEASE_CONTEXT", object()) or runtime.ACTIVE_LEASE_CONTEXT)
+    monkeypatch.setattr(runtime.locks, "release", lambda: setattr(runtime, "ACTIVE_LEASE_CONTEXT", None) or True)
+    monkeypatch.setattr(runtime.state_store, "load_state", lambda *, fail_on_unavailable=False: state)
+    monkeypatch.setattr(runtime.state_store, "save_state", lambda current_state: saved.append(current_state.copy()) or True)
+    monkeypatch.setattr(runtime.adapters.workflow, "process_pass_until_expirations", lambda current_state: (current_state, []))
+    monkeypatch.setattr(runtime.adapters.workflow, "sync_members_with_queue", lambda current_state: (current_state, []))
+    monkeypatch.setattr(runtime.adapters.workflow, "sync_status_labels_for_items", lambda current_state, issue_numbers: False)
+    monkeypatch.setattr(runtime.github, "get_issue_assignees", lambda issue_number: [])
+    monkeypatch.setattr(runtime.adapters.queue, "get_next_reviewer", lambda current_state, skip_usernames=None: "alice")
+    monkeypatch.setattr(
+        runtime.github,
+        "assign_issue_assignee",
+        lambda issue_number, username: runtime.AssignmentAttempt(
+            success=False,
+            status_code=502,
+            exhausted_retryable_failure=True,
+            failure_kind="server_error",
+        ),
+    )
+    monkeypatch.setattr(runtime.github, "post_comment", lambda issue_number, body: True)
+    monkeypatch.setenv("EVENT_NAME", "issues")
+    monkeypatch.setenv("EVENT_ACTION", "opened")
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("ISSUE_LABELS", '["coding guideline"]')
+    monkeypatch.setenv("ISSUE_STATE", "open")
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("EVENT_CREATED_AT", "2026-03-17T10:00:00Z")
+
+    result = reviewer_bot.execute_run(reviewer_bot.build_event_context(runtime), runtime)
+
+    assert result.exit_code == 0
+    assert result.state_changed is False
+    assert saved == []
+    assert state.get("active_reviews", {}).get("42") is None
+
+
+def test_execute_run_opened_issue_adopts_existing_single_live_assignee(monkeypatch):
+    runtime = reviewer_bot._runtime_bot()
+    state = make_state()
+    saved = []
+
+    monkeypatch.setattr(runtime.locks, "acquire", lambda: setattr(runtime, "ACTIVE_LEASE_CONTEXT", object()) or runtime.ACTIVE_LEASE_CONTEXT)
+    monkeypatch.setattr(runtime.locks, "release", lambda: setattr(runtime, "ACTIVE_LEASE_CONTEXT", None) or True)
+    monkeypatch.setattr(runtime.state_store, "load_state", lambda *, fail_on_unavailable=False: state)
+    monkeypatch.setattr(runtime.state_store, "save_state", lambda current_state: saved.append(current_state.copy()) or True)
+    monkeypatch.setattr(runtime.adapters.workflow, "process_pass_until_expirations", lambda current_state: (current_state, []))
+    monkeypatch.setattr(runtime.adapters.workflow, "sync_members_with_queue", lambda current_state: (current_state, []))
+    monkeypatch.setattr(runtime.adapters.workflow, "sync_status_labels_for_items", lambda current_state, issue_numbers: False)
+    monkeypatch.setattr(runtime.github, "get_issue_assignees", lambda issue_number: ["alice"])
+    monkeypatch.setenv("EVENT_NAME", "issues")
+    monkeypatch.setenv("EVENT_ACTION", "opened")
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("ISSUE_LABELS", '["coding guideline"]')
+    monkeypatch.setenv("ISSUE_STATE", "open")
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("EVENT_CREATED_AT", "2026-03-17T10:00:00Z")
+
+    result = reviewer_bot.execute_run(reviewer_bot.build_event_context(runtime), runtime)
+
+    assert result.exit_code == 0
+    assert result.state_changed is True
+    assert saved[-1]["active_reviews"]["42"]["current_reviewer"] == "alice"
+
 def test_execute_run_returns_failure_when_save_state_fails(monkeypatch):
     harness = AppHarness(monkeypatch)
     harness.set_event(EVENT_NAME="issue_comment", EVENT_ACTION="created")
@@ -354,6 +425,68 @@ def test_bootstrapped_runtime_executes_pr_metadata_closed_dispatch_path(monkeypa
 
     assert context.event_name == "pull_request_target"
     assert context.event_action == "closed"
+    assert calls == [state]
+    assert result.exit_code == 0
+    assert result.state_changed is True
+    assert runtime.ACTIVE_LEASE_CONTEXT is None
+
+
+@pytest.mark.parametrize(
+    ("event_action", "handler_name", "issue_state", "label_name"),
+    [
+        ("opened", "handle_issue_or_pr_opened", "open", ""),
+        ("assigned", "handle_assigned_event", "open", ""),
+        ("unassigned", "handle_unassigned_event", "open", ""),
+        ("labeled", "handle_labeled_event", "open", "coding guideline"),
+        ("unlabeled", "handle_unlabeled_event", "open", "coding guideline"),
+        ("edited", "handle_issue_edited_event", "open", ""),
+        ("reopened", "handle_reopened_event", "open", ""),
+        ("closed", "handle_closed_event", "closed", ""),
+    ],
+)
+def test_bootstrapped_runtime_executes_issue_lifecycle_dispatch_matrix(
+    monkeypatch, event_action, handler_name, issue_state, label_name
+):
+    runtime = reviewer_bot._runtime_bot()
+    state = make_state()
+    calls = []
+
+    def acquire_lock():
+        runtime.ACTIVE_LEASE_CONTEXT = object()
+        return runtime.ACTIVE_LEASE_CONTEXT
+
+    def release_lock():
+        runtime.ACTIVE_LEASE_CONTEXT = None
+        return True
+
+    def handler(current_state):
+        calls.append(current_state)
+        return True
+
+    monkeypatch.setattr(runtime.locks, "acquire", acquire_lock)
+    monkeypatch.setattr(runtime.locks, "release", release_lock)
+    monkeypatch.setattr(runtime.state_store, "load_state", lambda *, fail_on_unavailable=False: state)
+    monkeypatch.setattr(runtime.state_store, "save_state", lambda current_state: True)
+    monkeypatch.setattr(runtime.adapters.workflow, "process_pass_until_expirations", lambda current_state: (current_state, []))
+    monkeypatch.setattr(runtime.adapters.workflow, "sync_members_with_queue", lambda current_state: (current_state, []))
+    monkeypatch.setattr(runtime.adapters.workflow, "sync_status_labels_for_items", lambda current_state, issue_numbers: False)
+    monkeypatch.setattr(runtime.handlers, handler_name, handler)
+    monkeypatch.setenv("EVENT_NAME", "issues")
+    monkeypatch.setenv("EVENT_ACTION", event_action)
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("IS_PULL_REQUEST", "false")
+    monkeypatch.setenv("ISSUE_STATE", issue_state)
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("ISSUE_LABELS", '["coding guideline"]')
+    monkeypatch.setenv("LABEL_NAME", label_name)
+    monkeypatch.setenv("ISSUE_UPDATED_AT", "2026-04-13T04:31:00Z")
+    monkeypatch.setenv("EVENT_CREATED_AT", "2026-04-13T04:31:00Z")
+
+    context = reviewer_bot.build_event_context(runtime)
+    result = reviewer_bot.execute_run(context, runtime)
+
+    assert context.event_name == "issues"
+    assert context.event_action == event_action
     assert calls == [state]
     assert result.exit_code == 0
     assert result.state_changed is True

--- a/tests/integration/reviewer_bot/test_app_execution.py
+++ b/tests/integration/reviewer_bot/test_app_execution.py
@@ -163,6 +163,11 @@ def test_execute_run_opened_issue_assignment_failure_does_not_persist_reviewer_s
     monkeypatch.setattr(runtime.adapters.workflow, "sync_members_with_queue", lambda current_state: (current_state, []))
     monkeypatch.setattr(runtime.adapters.workflow, "sync_status_labels_for_items", lambda current_state, issue_numbers: False)
     monkeypatch.setattr(runtime.github, "get_issue_assignees", lambda issue_number: [])
+    monkeypatch.setattr(
+        runtime.github,
+        "get_issue_assignees_result",
+        lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(200, [], {}, "ok", True, None, 0, None),
+    )
     monkeypatch.setattr(runtime.adapters.queue, "get_next_reviewer", lambda current_state, skip_usernames=None: "alice")
     monkeypatch.setattr(
         runtime.github,
@@ -187,9 +192,11 @@ def test_execute_run_opened_issue_assignment_failure_does_not_persist_reviewer_s
     result = reviewer_bot.execute_run(reviewer_bot.build_event_context(runtime), runtime)
 
     assert result.exit_code == 0
-    assert result.state_changed is False
-    assert saved == []
-    assert state.get("active_reviews", {}).get("42") is None
+    assert result.state_changed is True
+    assert saved
+    saved_review = saved[-1]["active_reviews"]["42"]
+    assert saved_review["current_reviewer"] is None
+    assert saved_review["sidecars"]["repair_markers"]["assignment_confirm_read"]["reason"] == "final_assignee_mismatch"
 
 
 def test_execute_run_opened_issue_adopts_existing_single_live_assignee(monkeypatch):
@@ -205,6 +212,11 @@ def test_execute_run_opened_issue_adopts_existing_single_live_assignee(monkeypat
     monkeypatch.setattr(runtime.adapters.workflow, "sync_members_with_queue", lambda current_state: (current_state, []))
     monkeypatch.setattr(runtime.adapters.workflow, "sync_status_labels_for_items", lambda current_state, issue_numbers: False)
     monkeypatch.setattr(runtime.github, "get_issue_assignees", lambda issue_number: ["alice"])
+    monkeypatch.setattr(
+        runtime.github,
+        "get_issue_assignees_result",
+        lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(200, ["alice"], {}, "ok", True, None, 0, None),
+    )
     monkeypatch.setenv("EVENT_NAME", "issues")
     monkeypatch.setenv("EVENT_ACTION", "opened")
     monkeypatch.setenv("ISSUE_NUMBER", "42")

--- a/tests/integration/reviewer_bot/test_app_schedule_bookkeeping.py
+++ b/tests/integration/reviewer_bot/test_app_schedule_bookkeeping.py
@@ -1,6 +1,11 @@
 import pytest
 
-from scripts.reviewer_bot_lib import maintenance, maintenance_schedule, review_state
+from scripts.reviewer_bot_lib import (
+    lifecycle,
+    maintenance,
+    maintenance_schedule,
+    review_state,
+)
 from scripts.reviewer_bot_lib.config import GitHubApiResult
 from tests.fixtures.app_harness import AppHarness
 from tests.fixtures.reviewer_bot import make_state
@@ -145,3 +150,72 @@ def test_m2_schedule_handler_exposes_typed_result_shape():
 
     fields = maintenance_schedule.ScheduleHandlerResult.__dataclass_fields__
     assert list(fields) == ["state_changed", "touched_items"]
+
+
+def test_execute_run_schedule_warning_diagnostic_mutation_projects_touched_item(monkeypatch):
+    harness = AppHarness(monkeypatch)
+    harness.set_event(EVENT_NAME="schedule", EVENT_ACTION="")
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    saved_states = []
+    synced = []
+
+    harness.stub_lock(acquire=lambda: None, release=lambda: True)
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_pass_until(lambda current: (current, []))
+    harness.stub_sync_members(lambda current: (current, []))
+    harness.runtime.github.get_issue_or_pr_snapshot = lambda issue_number: {"number": issue_number, "state": "open", "pull_request": {}, "labels": []}
+    harness.runtime.github.list_issue_comments_result = lambda issue_number, page=1, per_page=100: GitHubApiResult(
+        200,
+        [],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+    harness.runtime.github.post_comment_result = lambda issue_number, body: GitHubApiResult(
+        502,
+        None,
+        {},
+        "bad gateway",
+        False,
+        "server_error",
+        1,
+        None,
+    )
+    harness.stub_save_state(lambda current: saved_states.append(current.copy()) or True)
+    harness.stub_sync_status_labels(lambda current, issue_numbers: synced.append(list(issue_numbers)) or True)
+    monkeypatch.setattr(maintenance_schedule, "sweep_deferred_gaps", lambda bot, state: False)
+    monkeypatch.setattr(maintenance_schedule, "repair_missing_reviewer_review_state", lambda bot, issue_number, review_data: False)
+    monkeypatch.setattr(
+        maintenance_schedule,
+        "maybe_record_head_observation_repair",
+        lambda bot, issue_number, review_data: lifecycle.HeadObservationRepairResult(changed=False, outcome="unchanged"),
+    )
+    monkeypatch.setattr(
+        maintenance_schedule,
+        "check_overdue_reviews",
+        lambda bot, state: [
+            {
+                "issue_number": 42,
+                "reviewer": "alice",
+                "days_overdue": 1,
+                "days_since_warning": 0,
+                "needs_warning": True,
+                "needs_transition": False,
+                "anchor_reason": None,
+                "anchor_timestamp": "2026-03-17T10:00:00Z",
+            }
+        ],
+    )
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    assert result.state_changed is True
+    assert saved_states
+    assert synced == [[42]]

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -178,7 +178,7 @@ def test_deferred_comment_missing_live_object_preserves_source_time_freshness(mo
             source_run_attempt=1,
         ),
     )
-    harness.add_pull_request(pr_number=42, author="dana")
+    harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
     harness.add_request_failure(
         endpoint="issues/comments/99",
         status_code=404,
@@ -331,7 +331,7 @@ def test_deferred_review_comment_reconcile_records_contributor_freshness(monkeyp
             source_run_attempt=1,
         ),
     )
-    harness.add_pull_request(pr_number=42, author="dana")
+    harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
     harness.add_review_comment(
         comment_id=301,
         body=live_body,
@@ -370,7 +370,7 @@ def test_deferred_review_comment_reconcile_records_reviewer_freshness(monkeypatc
             source_run_attempt=1,
         ),
     )
-    harness.add_pull_request(pr_number=42, author="dana")
+    harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
     harness.add_review_comment(
         comment_id=302,
         body=live_body,
@@ -406,7 +406,7 @@ def test_deferred_review_comment_missing_live_object_preserves_source_time_fresh
             source_run_attempt=1,
         ),
     )
-    harness.add_pull_request(pr_number=42, author="dana")
+    harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
     harness.add_request_failure(
         endpoint="pulls/comments/303",
         status_code=404,

--- a/tests/unit/reviewer_bot/test_commands.py
+++ b/tests/unit/reviewer_bot/test_commands.py
@@ -333,6 +333,27 @@ def test_release_command_does_not_clear_reviewer_state_when_remove_fails(monkeyp
     assert review["current_reviewer"] == "alice"
 
 
+def test_away_command_does_not_mutate_queue_when_reassignment_is_unconfirmed(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    state["queue"] = [
+        {"github": "alice", "name": "Alice"},
+        {"github": "bob", "name": "Bob"},
+    ]
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    harness.stub_assignees(["alice"])
+    harness.runtime.github.remove_issue_assignee = lambda issue_number, username: False
+
+    response, success = harness.handle_pass_until(state, 42, "alice", "2099-01-01", None)
+
+    assert success is False
+    assert "could not confirm @bob as reviewer" in response
+    assert [member["github"] for member in state["queue"]] == ["alice", "bob"]
+    assert state["pass_until"] == []
+
+
 def test_handle_accept_no_fls_changes_command_fails_closed_when_permission_unavailable(monkeypatch):
     harness = CommandHarness(monkeypatch)
     request = harness.typed_privileged_request(
@@ -444,6 +465,7 @@ def test_handle_rectify_command_reports_permission_unavailable(monkeypatch):
     state = make_state()
     harness = CommandHarness(monkeypatch)
     monkeypatch.setattr(reconcile, "ensure_review_entry", lambda current, issue_number, create=False: None)
+    harness.runtime.github.get_issue_assignees = lambda issue_number: []
     harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": "unavailable"
 
     message, success, changed = harness.handle_rectify(state, 42, "alice")
@@ -457,6 +479,7 @@ def test_handle_rectify_command_reports_permission_denied(monkeypatch):
     state = make_state()
     harness = CommandHarness(monkeypatch)
     monkeypatch.setattr(reconcile, "ensure_review_entry", lambda current, issue_number, create=False: None)
+    harness.runtime.github.get_issue_assignees = lambda issue_number: []
     harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": "denied"
 
     message, success, changed = harness.handle_rectify(state, 42, "alice")
@@ -464,6 +487,22 @@ def test_handle_rectify_command_reports_permission_denied(monkeypatch):
     assert success is False
     assert changed is False
     assert "Only maintainers with triage+ permission" in message
+
+
+def test_handle_rectify_command_uses_live_assignee_truth_over_stored_reviewer(monkeypatch):
+    state = make_state()
+    harness = CommandHarness(monkeypatch)
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    harness.runtime.github.get_issue_assignees = lambda issue_number: ["bob"]
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": "denied"
+
+    message, success, changed = harness.handle_rectify(state, 42, "alice")
+
+    assert success is False
+    assert changed is False
+    assert "@bob" in message
 
 
 def test_validate_accept_no_fls_changes_handoff_distinguishes_permission_unavailable(monkeypatch):

--- a/tests/unit/reviewer_bot/test_commands.py
+++ b/tests/unit/reviewer_bot/test_commands.py
@@ -32,6 +32,7 @@ def test_label_signoff_create_pr_marks_issue_review_complete_without_inline_stat
         body="@guidelines-bot /label +sign-off: create pr",
         issue_author="dana",
         is_pull_request=False,
+        issue_labels=("coding guideline",),
     )
     harness.runtime.github.get_repo_labels = lambda: ["sign-off: create pr"]
     harness.runtime.github.add_label = lambda issue_number, label: True
@@ -45,6 +46,29 @@ def test_label_signoff_create_pr_marks_issue_review_complete_without_inline_stat
     assert review["review_completion_source"] == "issue_label: sign-off: create pr"
     assert review["current_cycle_completion"]["completed"] is True
     assert posted == [(42, "✅ Added label `sign-off: create pr`")]
+
+
+def test_label_signoff_create_pr_on_generic_issue_does_not_mark_issue_complete(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="alice",
+        body="@guidelines-bot /label +sign-off: create pr",
+        issue_author="dana",
+        is_pull_request=False,
+        issue_labels=(),
+    )
+    harness.runtime.github.get_repo_labels = lambda: ["sign-off: create pr"]
+    harness.runtime.github.add_label = lambda issue_number, label: True
+    harness.runtime.github.add_reaction = lambda *args, **kwargs: True
+    harness.runtime.github.post_comment = lambda *args, **kwargs: True
+
+    assert harness.handle_comment_event(state, request=request) is False
+    assert review["review_completion_source"] is None
 
 
 def test_label_signoff_create_pr_on_pr_does_not_mark_issue_complete(monkeypatch):
@@ -182,7 +206,6 @@ def test_pass_command_posts_pr_guidance_for_new_reviewer(monkeypatch):
     request = harness.typed_assignment_request(issue_number=42, issue_author="PLeVasseur", is_pull_request=True)
     harness.stub_assignees(["alice"])
     harness.stub_assignment()
-    harness.runtime.github.remove_pr_reviewer = lambda issue_number, username: True
     posted = []
     harness.runtime.github.post_comment = lambda issue_number, body: posted.append(body) or True
 
@@ -208,6 +231,106 @@ def test_assign_from_queue_posts_guidance_only_once(monkeypatch):
     assert success is True
     assert response == "✅ @felix91gr (next in queue) has been assigned as reviewer."
     assert posted == [guidance.get_pr_guidance("felix91gr", "PLeVasseur")]
+
+
+def test_done_command_marks_generic_issue_review_complete_for_current_reviewer(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    request = harness.typed_assignment_request(issue_number=42, issue_author="dana", is_pull_request=False, issue_labels=())
+    harness.stub_assignees(["alice"])
+
+    response, success = commands.handle_done_command(harness.runtime, state, 42, "alice", request=request)
+
+    assert success is True
+    assert response == "✅ Review marked complete."
+    assert review["review_completion_source"] == "command: /done"
+
+
+def test_done_command_rejects_pull_requests(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    request = harness.typed_assignment_request(issue_number=42, issue_author="dana", is_pull_request=True, issue_labels=())
+
+    response, success = commands.handle_done_command(harness.runtime, state, 42, "alice", request=request)
+
+    assert success is False
+    assert "not supported on pull requests" in response
+
+
+def test_done_command_rejects_coding_guideline_issues(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    request = harness.typed_assignment_request(
+        issue_number=42,
+        issue_author="dana",
+        is_pull_request=False,
+        issue_labels=("coding guideline",),
+    )
+
+    response, success = commands.handle_done_command(harness.runtime, state, 42, "alice", request=request)
+
+    assert success is False
+    assert "Use `sign-off: create pr`" in response
+
+
+def test_done_command_allows_triage_maintainer_when_current_reviewer_differs(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    request = harness.typed_assignment_request(issue_number=42, issue_author="dana", is_pull_request=False, issue_labels=(FLS_AUDIT_LABEL,))
+    harness.stub_assignees(["alice"])
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": "granted"
+
+    response, success = commands.handle_done_command(harness.runtime, state, 42, "bob", request=request)
+
+    assert success is True
+    assert response == "✅ Review marked complete."
+    assert review["review_completed_by"] == "bob"
+
+
+def test_pass_command_does_not_mutate_reviewer_state_when_remove_fails(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    state["queue"] = [
+        {"github": "alice", "name": "Alice"},
+        {"github": "bob", "name": "Bob"},
+    ]
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["skipped"] = []
+    harness.stub_assignees(["alice"])
+    harness.runtime.github.remove_issue_assignee = lambda issue_number, username: False
+
+    response, success = harness.handle_pass(state, 42, "alice", None)
+
+    assert success is False
+    assert "could not confirm @bob as reviewer" in response
+    assert review["current_reviewer"] == "alice"
+    assert review["skipped"] == []
+
+
+def test_release_command_does_not_clear_reviewer_state_when_remove_fails(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    harness.stub_assignees(["alice"])
+    harness.runtime.github.remove_issue_assignee = lambda issue_number, username: False
+
+    response, success = harness.handle_release(state, 42, "alice")
+
+    assert success is False
+    assert "could not confirm @alice as reviewer" in response
+    assert review["current_reviewer"] == "alice"
 
 
 def test_handle_accept_no_fls_changes_command_fails_closed_when_permission_unavailable(monkeypatch):

--- a/tests/unit/reviewer_bot/test_comment_freshness_equivalence.py
+++ b/tests/unit/reviewer_bot/test_comment_freshness_equivalence.py
@@ -109,11 +109,13 @@ def test_comment_freshness_equivalence_matches_legacy_mutation_and_activity_beha
             "contributor_plain_text_freshness",
             lambda state: harness.request(issue_number=42, is_pull_request=False, issue_author="dana", comment_author="dana", comment_body="hello"),
             lambda review: None,
+            [],
         ),
         (
             "reviewer_plain_text_freshness",
             lambda state: harness.request(issue_number=42, is_pull_request=False, issue_author="dana", comment_author="alice", comment_body="hello", comment_created_at="2026-03-17T10:00:00Z"),
             lambda review: review.__setitem__("current_reviewer", "alice"),
+            ["alice"],
         ),
         (
             "reviewer_activity_only_when_semantic_key_exists",
@@ -125,22 +127,25 @@ def test_comment_freshness_equivalence_matches_legacy_mutation_and_activity_beha
                 review.__setitem__("transition_notice_sent_at", "2026-03-25T00:00:00Z"),
                 review_state.accept_channel_event(review, "reviewer_comment", semantic_key="issue_comment:100", timestamp="2026-03-17T09:00:00Z", actor="alice"),
             ),
+            ["alice"],
         ),
         (
             "non_contributor_non_reviewer_noop",
             lambda state: harness.request(issue_number=42, is_pull_request=False, issue_author="dana", comment_author="zoe", comment_body="hello"),
             lambda review: review.__setitem__("current_reviewer", "alice"),
+            ["alice"],
         ),
         (
             "command_plus_text_freshness",
             lambda state: harness.request(issue_number=42, is_pull_request=False, issue_author="dana", comment_author="dana", comment_body="hello\n@guidelines-bot /queue"),
             lambda review: None,
+            [],
         ),
     ]
 
-    assert matrix["scenarios"] == [name for name, _req, _prep in scenarios]
+    assert matrix["scenarios"] == [name for name, _req, _prep, _assignees in scenarios]
 
-    for scenario_name, make_request, prepare_review in scenarios:
+    for scenario_name, make_request, prepare_review, live_assignees in scenarios:
         legacy_state = make_state()
         new_state = make_state()
         legacy_review = review_state.ensure_review_entry(legacy_state, 42, create=True)
@@ -150,6 +155,7 @@ def test_comment_freshness_equivalence_matches_legacy_mutation_and_activity_beha
             prepare_review(legacy_review)
             prepare_review(new_review)
         request = make_request(new_state)
+        harness.runtime.github.get_issue_assignees = lambda issue_number, is_pull_request=None, assignees=live_assignees: list(assignees)
 
         legacy_changed = _legacy_record_conversation_freshness(legacy_state, request)
         new_changed = comment_application.record_conversation_freshness(harness.runtime, new_state, request)

--- a/tests/unit/reviewer_bot/test_comment_routing.py
+++ b/tests/unit/reviewer_bot/test_comment_routing.py
@@ -36,6 +36,7 @@ def test_record_conversation_freshness_returns_true_when_only_reviewer_activity_
         comment_created_at="2026-03-17T10:00:00Z",
         comment_source_event_key="issue_comment:100",
     )
+    harness.runtime.github.get_issue_assignees = lambda issue_number, is_pull_request=None: ["alice"]
 
     changed = comment_application.record_conversation_freshness(
         harness.runtime,
@@ -144,7 +145,7 @@ def test_comment_application_delegates_freshness_decision_to_core_policy():
         module_text = handle.read()
 
     assert "comment_freshness_policy" in module_text
-    assert "decision = comment_freshness_policy.decide_comment_freshness(review_data, request)" in module_text
+    assert "decision = comment_freshness_policy.decide_comment_freshness(effective_review_data, request)" in module_text
 
 
 def test_k2_comment_routing_entrypoints_use_narrow_comment_runtime_protocol():

--- a/tests/unit/reviewer_bot/test_github_api.py
+++ b/tests/unit/reviewer_bot/test_github_api.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 
 from scripts.reviewer_bot_lib import automation, github_api, guidance
@@ -79,6 +81,47 @@ def test_github_api_request_classifies_forbidden_without_retry(monkeypatch):
     assert result.failure_kind == "forbidden"
     assert result.retry_attempts == 0
     assert github.requested_endpoints() == ["issues/42"]
+
+
+def test_github_api_request_retries_403_retry_after_rate_limit(monkeypatch):
+    github = RouteGitHubApi().add_request_sequence(
+        "GET",
+        "issues/42",
+        [
+            github_result(403, {"message": "secondary rate limit"}, headers={"Retry-After": "7"}),
+            github_result(200, {"ok": True}),
+        ],
+    )
+    bot = _bot(monkeypatch, github=github)
+
+    result = github_api.github_api_request(bot, "GET", "issues/42", retry_policy="idempotent_read")
+
+    assert result.ok is True
+    assert result.retry_attempts == 1
+    assert bot.sleeper.calls == [7.0]
+
+
+def test_github_api_request_retries_403_ratelimit_remaining_zero(monkeypatch):
+    github = RouteGitHubApi().add_request_sequence(
+        "GET",
+        "issues/42",
+        [
+            github_result(
+                403,
+                {"message": "forbidden"},
+                headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1767225605"},
+            ),
+            github_result(200, {"ok": True}),
+        ],
+    )
+    bot = _bot(monkeypatch, github=github)
+    bot.clock.set(datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    result = github_api.github_api_request(bot, "GET", "issues/42", retry_policy="idempotent_read")
+
+    assert result.ok is True
+    assert result.retry_attempts == 1
+    assert bot.sleeper.calls == [5.0]
 
 
 def test_github_graphql_request_retries_idempotent_query_on_502(monkeypatch):
@@ -203,6 +246,8 @@ def test_request_pr_reviewer_assignment_targets_pr_reviewers_endpoint(monkeypatc
     result = github_api.request_pr_reviewer_assignment(bot, 42, "alice")
 
     assert result.success is True
+    assert result.failure_kind is None
+    assert result.retry_attempts == 0
     assert recorded == {
         "method": "POST",
         "endpoint": "pulls/42/requested_reviewers",
@@ -222,6 +267,8 @@ def test_assign_issue_assignee_targets_issue_assignees_endpoint(monkeypatch):
     result = github_api.assign_issue_assignee(bot, 42, "alice")
 
     assert result.success is True
+    assert result.failure_kind is None
+    assert result.retry_attempts == 0
     assert recorded == {
         "method": "POST",
         "endpoint": "issues/42/assignees",
@@ -248,20 +295,26 @@ def test_get_assignment_failure_comment_formats_retry_exhaustion_message(monkeyp
 
 def test_remove_pr_reviewer_calls_pr_reviewers_delete(monkeypatch):
     github = RouteGitHubApi()
-    github.add_api("DELETE", "pulls/42/requested_reviewers", {})
+    github.add_request("DELETE", "pulls/42/requested_reviewers", status_code=204, payload={})
     bot = _bot(monkeypatch, github=github)
 
-    assert github_api.remove_pr_reviewer(bot, 42, "alice") is True
-    assert [call.endpoint for call in github.api_calls] == ["pulls/42/requested_reviewers"]
+    result = github_api.remove_pr_reviewer(bot, 42, "alice")
+
+    assert result.success is True
+    assert result.status_code == 204
+    assert [call.endpoint for call in github.request_calls] == ["pulls/42/requested_reviewers"]
 
 
 def test_remove_issue_assignee_calls_issue_assignees_delete(monkeypatch):
     github = RouteGitHubApi()
-    github.add_api("DELETE", "issues/42/assignees", {})
+    github.add_request("DELETE", "issues/42/assignees", status_code=204, payload={})
     bot = _bot(monkeypatch, github=github)
 
-    assert github_api.remove_issue_assignee(bot, 42, "alice") is True
-    assert [call.endpoint for call in github.api_calls] == ["issues/42/assignees"]
+    result = github_api.remove_issue_assignee(bot, 42, "alice")
+
+    assert result.success is True
+    assert result.status_code == 204
+    assert [call.endpoint for call in github.request_calls] == ["issues/42/assignees"]
 
 
 def test_find_open_pr_for_branch_status_reports_unavailable_for_malformed_payload(monkeypatch):
@@ -281,6 +334,35 @@ def test_github_api_request_reports_invalid_payload_for_malformed_json(monkeypat
     result = github_api.github_api_request(_bot(monkeypatch, github=github), "GET", "issues/42")
 
     assert result.ok is False
+    assert result.failure_kind == "invalid_payload"
+
+
+def test_github_api_request_classifies_other_4xx_as_http_error(monkeypatch):
+    github = RouteGitHubApi().add_request("GET", "issues/42", result=github_result(418, {"message": "teapot"}))
+
+    result = github_api.github_api_request(_bot(monkeypatch, github=github), "GET", "issues/42", suppress_error_log=True)
+
+    assert result.ok is False
+    assert result.failure_kind == "http_error"
+
+
+def test_post_comment_result_preserves_ambiguous_invalid_payload(monkeypatch):
+    bot = _bot(monkeypatch)
+    bot.github_api_request = lambda *args, **kwargs: GitHubApiResult(
+        201,
+        None,
+        {},
+        "bad json",
+        False,
+        "invalid_payload",
+        0,
+        None,
+    )
+
+    result = github_api.post_comment_result(bot, 42, "hello")
+
+    assert result.ok is False
+    assert result.status_code == 201
     assert result.failure_kind == "invalid_payload"
 
 

--- a/tests/unit/reviewer_bot/test_lifecycle.py
+++ b/tests/unit/reviewer_bot/test_lifecycle.py
@@ -86,7 +86,10 @@ def test_handle_transition_notice_records_transition_notice_sent_at_once(monkeyp
     assert review is not None
     review["current_reviewer"] = "alice"
     posted = []
-    runtime.github.post_comment = lambda issue_number, body: posted.append((issue_number, body)) or True
+    runtime.github.post_comment_result = (
+        lambda issue_number, body: posted.append((issue_number, body))
+        or runtime.GitHubApiResult(201, {}, {}, "created", True, None, 0, None)
+    )
 
     assert lifecycle.handle_transition_notice(runtime, state, 42, "alice") is True
     assert review["transition_notice_sent_at"] is not None
@@ -99,7 +102,10 @@ def test_handle_transition_notice_message_does_not_claim_reassignment(monkeypatc
     state = make_state()
     review_state.ensure_review_entry(state, 42, create=True)
     posted = []
-    runtime.github.post_comment = lambda issue_number, body: posted.append(body) or True
+    runtime.github.post_comment_result = (
+        lambda issue_number, body: posted.append(body)
+        or runtime.GitHubApiResult(201, {}, {}, "created", True, None, 0, None)
+    )
 
     assert lifecycle.handle_transition_notice(runtime, state, 42, "alice") is True
     assert "reassigned to the next person in the queue" not in posted[0]
@@ -114,7 +120,16 @@ def test_handle_transition_notice_skips_cutover_artifact_write_when_opencode_con
     runtime = FakeReviewerBotRuntime(monkeypatch)
     state = make_state()
     review_state.ensure_review_entry(state, 42, create=True)
-    runtime.github.post_comment = lambda issue_number, body: True
+    runtime.github.post_comment_result = lambda issue_number, body: runtime.GitHubApiResult(
+        201,
+        {},
+        {},
+        "created",
+        True,
+        None,
+        0,
+        None,
+    )
     if config_value is not None:
         runtime.set_config_value("OPENCODE_CONFIG_DIR", config_value)
 
@@ -196,15 +211,27 @@ def test_scheduled_check_backfills_markerized_transition_notice_without_repostin
     runtime.get_pull_request_reviews = lambda issue_number: []
     runtime.github.get_issue_or_pr_snapshot = lambda issue_number: {"pull_request": {}}
     posted = []
-    runtime.github.post_comment = lambda issue_number, body: posted.append(body) or True
-    runtime.github_api = lambda method, endpoint, data=None: [
-        {
-            "id": 99,
-            "created_at": "2026-03-25T15:22:42Z",
-            "body": "<!-- reviewer-bot:transition-notice:v1 issue=42 reviewer=alice -->\n\n🔔 **Transition Period Ended**\n\nExisting notice",
-            "user": {"login": "github-actions[bot]"},
-        }
-    ]
+    runtime.github.post_comment_result = (
+        lambda issue_number, body: posted.append(body)
+        or runtime.GitHubApiResult(201, {}, {}, "created", True, None, 0, None)
+    )
+    runtime.github.list_issue_comments_result = lambda issue_number, page=1, per_page=100: runtime.GitHubApiResult(
+        200,
+        [
+            {
+                "id": 99,
+                "created_at": "2026-03-25T15:22:42Z",
+                "body": "<!-- reviewer-bot:transition-notice:v1 issue=42 reviewer=alice -->\n\n🔔 **Transition Period Ended**\n\nExisting notice",
+                "user": {"login": "github-actions[bot]"},
+            }
+        ],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
 
     assert maintenance.handle_scheduled_check_result(runtime, state).state_changed is True
     assert review["transition_notice_sent_at"] == "2026-03-25T15:22:42Z"
@@ -343,6 +370,77 @@ def test_handle_issue_or_pr_opened_fails_closed_when_assignees_unavailable(monke
         lifecycle.handle_issue_or_pr_opened(runtime, state)
 
 
+def test_handle_issue_or_pr_opened_does_not_mutate_reviewer_state_on_assignment_failure(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("ISSUE_AUTHOR", "dana")
+    runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+    runtime.github.get_issue_assignees = lambda issue_number: []
+    runtime.adapters.queue.get_next_reviewer = lambda state, skip_usernames=None: "alice"
+    runtime.github.assign_issue_assignee = lambda issue_number, username: runtime.AssignmentAttempt(
+        success=False,
+        status_code=502,
+        exhausted_retryable_failure=True,
+        failure_kind="server_error",
+    )
+    runtime.github.post_comment = lambda issue_number, body: True
+
+    assert lifecycle.handle_issue_or_pr_opened(runtime, state) is False
+    review = review_state.ensure_review_entry(state, 42)
+    assert review is None or review.get("current_reviewer") is None
+
+
+def test_handle_issue_or_pr_opened_adopts_existing_single_live_assignee(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("ISSUE_AUTHOR", "dana")
+    runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+    runtime.set_config_value("EVENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    runtime.github.get_issue_assignees = lambda issue_number: ["alice"]
+
+    assert lifecycle.handle_issue_or_pr_opened(runtime, state) is True
+    review = review_state.ensure_review_entry(state, 42)
+    assert review is not None
+    assert review["current_reviewer"] == "alice"
+    assert review["assigned_at"] == "2026-03-17T10:00:00Z"
+
+
+def test_handle_assigned_event_clears_reviewer_authority_on_multiple_live_assignees(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("ISSUE_AUTHOR", "dana")
+    runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+    runtime.github.get_issue_assignees = lambda issue_number: ["alice", "bob"]
+
+    assert lifecycle.handle_assigned_event(runtime, state) is True
+    assert review["current_reviewer"] is None
+
+
+def test_handle_unassigned_event_clears_reviewer_authority_when_live_assignee_missing(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("ISSUE_AUTHOR", "dana")
+    runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+    runtime.github.get_issue_assignees = lambda issue_number: []
+
+    assert lifecycle.handle_unassigned_event(runtime, state) is True
+    assert review["current_reviewer"] is None
+
+
 def test_issue_edit_by_author_records_contributor_freshness(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.ACTIVE_LEASE_CONTEXT = object()
@@ -363,6 +461,60 @@ def test_issue_edit_by_author_records_contributor_freshness(monkeypatch):
     assert lifecycle.handle_issue_edited_event(runtime, state) is True
     accepted = review["contributor_comment"]["accepted"]
     assert accepted["semantic_key"].startswith("issues_edit_title:42:")
+
+
+def test_handle_labeled_event_signoff_only_completes_coding_guideline_issue(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("LABEL_NAME", "sign-off: create pr")
+    runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline", "sign-off: create pr"]))
+
+    assert lifecycle.handle_labeled_event(runtime, state) is True
+    assert review["review_completion_source"] == "issue_label: sign-off: create pr"
+
+
+def test_handle_unlabeled_event_reopens_signoff_completion(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["review_completed_at"] = "2026-03-17T10:00:00Z"
+    review["review_completed_by"] = "alice"
+    review["review_completion_source"] = "issue_label: sign-off: create pr"
+    review["current_cycle_completion"] = {"completed": True}
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("LABEL_NAME", "sign-off: create pr")
+    runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+
+    assert lifecycle.handle_unlabeled_event(runtime, state) is True
+    assert review["review_completed_at"] is None
+    assert review["review_completion_source"] is None
+
+
+def test_handle_reopened_event_reopens_done_completion(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["review_completed_at"] = "2026-03-17T10:00:00Z"
+    review["review_completed_by"] = "alice"
+    review["review_completion_source"] = "command: /done"
+    review["current_cycle_completion"] = {"completed": True}
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("ISSUE_LABELS", json.dumps(["fls-audit"]))
+    runtime.github.get_issue_assignees = lambda issue_number: []
+
+    assert lifecycle.handle_reopened_event(runtime, state) is True
+    assert review["review_completed_at"] is None
+    assert review["review_completion_source"] is None
 
 
 def test_maybe_record_head_observation_repair_uses_github_api_fallback_after_system_exit(monkeypatch):

--- a/tests/unit/reviewer_bot/test_lifecycle.py
+++ b/tests/unit/reviewer_bot/test_lifecycle.py
@@ -175,10 +175,44 @@ def test_reviewer_comment_clears_warning_and_transition_notice_markers(monkeypat
         head_repo_full_name="rustfoundation/safety-critical-rust-coding-guidelines",
         pr_author="dana",
     )
+    harness.runtime.github.get_issue_assignees = lambda issue_number, is_pull_request=None: ["alice"]
 
     assert comment_routing.handle_comment_event(harness.runtime, state, request, trust_context) is True
     assert review["transition_warning_sent"] is None
     assert review["transition_notice_sent_at"] is None
+
+
+def test_reviewer_comment_does_not_count_as_reviewer_activity_when_live_assignee_differs(monkeypatch):
+    harness = CommentRoutingHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["transition_warning_sent"] = "2026-03-10T00:00:00Z"
+    review["transition_notice_sent_at"] = "2026-03-25T00:00:00Z"
+    request = harness.request(
+        issue_number=42,
+        is_pull_request=True,
+        issue_author="dana",
+        comment_author="alice",
+        comment_body="hello",
+    )
+    trust_context = harness.trust_context(
+        github_repository="rustfoundation/safety-critical-rust-coding-guidelines",
+        comment_author_association="MEMBER",
+        current_workflow_file=".github/workflows/reviewer-bot-pr-comment-router.yml",
+        github_ref="refs/heads/main",
+    )
+    harness.add_pull_request_metadata(
+        issue_number=42,
+        head_repo_full_name="rustfoundation/safety-critical-rust-coding-guidelines",
+        pr_author="dana",
+    )
+    harness.runtime.github.get_issue_assignees = lambda issue_number, is_pull_request=None: ["bob"]
+
+    assert comment_routing.handle_comment_event(harness.runtime, state, request, trust_context) is False
+    assert review["transition_warning_sent"] == "2026-03-10T00:00:00Z"
+    assert review["transition_notice_sent_at"] == "2026-03-25T00:00:00Z"
 
 
 def test_scheduled_check_backfills_markerized_transition_notice_without_reposting(monkeypatch):
@@ -378,6 +412,16 @@ def test_handle_issue_or_pr_opened_does_not_mutate_reviewer_state_on_assignment_
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
     runtime.github.get_issue_assignees = lambda issue_number: []
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        [],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
     runtime.adapters.queue.get_next_reviewer = lambda state, skip_usernames=None: "alice"
     runtime.github.assign_issue_assignee = lambda issue_number, username: runtime.AssignmentAttempt(
         success=False,
@@ -387,9 +431,11 @@ def test_handle_issue_or_pr_opened_does_not_mutate_reviewer_state_on_assignment_
     )
     runtime.github.post_comment = lambda issue_number, body: True
 
-    assert lifecycle.handle_issue_or_pr_opened(runtime, state) is False
+    assert lifecycle.handle_issue_or_pr_opened(runtime, state) is True
     review = review_state.ensure_review_entry(state, 42)
-    assert review is None or review.get("current_reviewer") is None
+    assert review is not None
+    assert review.get("current_reviewer") is None
+    assert review["sidecars"]["repair_markers"]["assignment_confirm_read"]["reason"] == "final_assignee_mismatch"
 
 
 def test_handle_issue_or_pr_opened_adopts_existing_single_live_assignee(monkeypatch):
@@ -401,6 +447,16 @@ def test_handle_issue_or_pr_opened_adopts_existing_single_live_assignee(monkeypa
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
     runtime.set_config_value("EVENT_CREATED_AT", "2026-03-17T10:00:00Z")
     runtime.github.get_issue_assignees = lambda issue_number: ["alice"]
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        ["alice"],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
 
     assert lifecycle.handle_issue_or_pr_opened(runtime, state) is True
     review = review_state.ensure_review_entry(state, 42)
@@ -420,6 +476,16 @@ def test_handle_assigned_event_clears_reviewer_authority_on_multiple_live_assign
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
     runtime.github.get_issue_assignees = lambda issue_number: ["alice", "bob"]
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        ["alice", "bob"],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
 
     assert lifecycle.handle_assigned_event(runtime, state) is True
     assert review["current_reviewer"] is None
@@ -436,6 +502,16 @@ def test_handle_unassigned_event_clears_reviewer_authority_when_live_assignee_mi
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
     runtime.github.get_issue_assignees = lambda issue_number: []
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        [],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
 
     assert lifecycle.handle_unassigned_event(runtime, state) is True
     assert review["current_reviewer"] is None
@@ -511,6 +587,16 @@ def test_handle_reopened_event_reopens_done_completion(monkeypatch):
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["fls-audit"]))
     runtime.github.get_issue_assignees = lambda issue_number: []
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        [],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
 
     assert lifecycle.handle_reopened_event(runtime, state) is True
     assert review["review_completed_at"] is None

--- a/tests/unit/reviewer_bot/test_maintenance.py
+++ b/tests/unit/reviewer_bot/test_maintenance.py
@@ -170,6 +170,58 @@ def test_manual_dispatch_check_overdue_preserves_touched_items_for_projection_fo
     assert bot.drain_touched_items() == [42, 99]
 
 
+def test_scheduled_check_collects_touched_item_for_warning_diagnostic_mutation(monkeypatch):
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    bot = FakeReviewerBotRuntime(monkeypatch)
+    bot.ACTIVE_LEASE_CONTEXT = object()
+    bot.github.get_issue_or_pr_snapshot = lambda issue_number: {"number": issue_number, "state": "open", "pull_request": {}, "labels": []}
+    bot.github.list_issue_comments_result = lambda issue_number, page=1, per_page=100: GitHubApiResult(
+        200,
+        [],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+    bot.github.post_comment_result = lambda issue_number, body: GitHubApiResult(
+        502,
+        None,
+        {},
+        "bad gateway",
+        False,
+        "server_error",
+        1,
+        None,
+    )
+    monkeypatch.setattr(maintenance_schedule, "sweep_deferred_gaps", lambda bot, state: False)
+    monkeypatch.setattr(maintenance_schedule, "repair_missing_reviewer_review_state", lambda bot, issue_number, review_data: False)
+    monkeypatch.setattr(maintenance_schedule, "maybe_record_head_observation_repair", lambda bot, issue_number, review_data: lifecycle.HeadObservationRepairResult(changed=False, outcome="unchanged"))
+    monkeypatch.setattr(
+        maintenance_schedule,
+        "check_overdue_reviews",
+        lambda bot, state: [
+            {
+                "issue_number": 42,
+                "reviewer": "alice",
+                "days_overdue": 1,
+                "days_since_warning": 0,
+                "needs_warning": True,
+                "needs_transition": False,
+                "anchor_reason": None,
+                "anchor_timestamp": "2026-03-17T10:00:00Z",
+            }
+        ],
+    )
+
+    assert maintenance.handle_scheduled_check_result(bot, state).touched_items == [42]
+    assert repair_records.load_repair_marker(review, "warning_post")["failure_kind"] == "server_error"
+
+
 def test_scheduled_check_clears_head_observation_repair_marker_after_success(monkeypatch):
     state = make_state()
     review = review_state.ensure_review_entry(state, 42, create=True)

--- a/tests/unit/reviewer_bot/test_overdue.py
+++ b/tests/unit/reviewer_bot/test_overdue.py
@@ -71,6 +71,16 @@ def test_check_overdue_reviews_consumes_only_stable_reviewer_response_fields(mon
         "anchor_timestamp": anchor_timestamp,
         "ignored": {"reviewer_review": "not consumed"},
     }
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        ["alice"],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
 
     overdue = maintenance.check_overdue_reviews(runtime, state)
 
@@ -108,6 +118,49 @@ def test_check_overdue_reviews_skips_item_when_snapshot_unavailable(monkeypatch)
     )
 
     assert maintenance.check_overdue_reviews(runtime, state) == []
+
+
+def test_check_overdue_reviews_suppresses_stale_reviewer_authority_and_records_diagnostic(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    now = runtime.datetime.now(runtime.timezone.utc)
+    anchor_timestamp = iso_z(now - timedelta(days=runtime.REVIEW_DEADLINE_DAYS + 1))
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at=anchor_timestamp,
+        active_cycle_started_at=anchor_timestamp,
+    )
+    runtime.github.get_issue_or_pr_snapshot_result = lambda issue_number: runtime.GitHubApiResult(
+        200,
+        issue_snapshot(issue_number, state="open", is_pull_request=False),
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        ["bob"],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+    runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+        "state": "awaiting_reviewer_response",
+        "anchor_timestamp": anchor_timestamp,
+    }
+
+    assert maintenance.check_overdue_reviews(runtime, state) == []
+    marker = load_repair_marker(review, "assignment_confirm_read")
+    assert marker is not None
+    assert marker["reason"] == "stored_reviewer_mismatch"
 
 
 def test_handle_overdue_review_warning_only_records_successful_comment(monkeypatch):
@@ -171,6 +224,7 @@ def test_handle_overdue_review_warning_uses_contributor_handoff_text(monkeypatch
     ) is True
     assert "latest contributor follow-up returned this review to you" in posted[0]
     assert "since you were assigned" not in posted[0]
+    assert posted[0].splitlines()[0] == "<!-- reviewer-bot:transition-warning:v1 issue=42 reviewer=alice anchor= -->"
 
 
 def test_handle_overdue_review_warning_backfills_existing_marker_without_repost(monkeypatch):
@@ -260,6 +314,16 @@ def test_check_overdue_reviews_non_pr_contributor_followup_reanchors_to_contribu
         0,
         None,
     )
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        ["alice"],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
 
     overdue = maintenance.check_overdue_reviews(runtime, state)
 
@@ -289,6 +353,16 @@ def test_check_overdue_reviews_uses_contributor_comment_timestamp_when_turn_retu
     accept_contributor_comment(review, semantic_key="issue_comment:20", timestamp=contributor_comment_at, actor="bob")
     routes = RouteGitHubApi().add_pull_request_snapshot(42, pull_request_payload(42, head_sha="head-1"))
     runtime = _runtime(monkeypatch, routes)
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        ["alice"],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
     monkeypatch.setattr(approval_policy, "compute_pr_approval_state_result", _approval_incomplete_result)
 
     overdue = maintenance.check_overdue_reviews(runtime, state)
@@ -309,6 +383,16 @@ def test_check_overdue_reviews_uses_contributor_revision_timestamp_when_head_cha
     accept_contributor_revision(review, semantic_key="pull_request_sync:42:head-2", timestamp=contributor_revision_at, actor="alice", head_sha="head-2")
     routes = RouteGitHubApi().add_pull_request_snapshot(42, pull_request_payload(42, head_sha="head-2")).add_pull_request_reviews(42, [])
     runtime = _runtime(monkeypatch, routes)
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
+        200,
+        ["alice"],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
 
     overdue = maintenance.check_overdue_reviews(runtime, state)
     assert overdue[0]["issue_number"] == 42

--- a/tests/unit/reviewer_bot/test_overdue.py
+++ b/tests/unit/reviewer_bot/test_overdue.py
@@ -1,11 +1,15 @@
 from datetime import timedelta
 
+import pytest
+
 from scripts.reviewer_bot_core import approval_policy
 from scripts.reviewer_bot_lib import maintenance, review_state
+from scripts.reviewer_bot_lib.repair_records import load_repair_marker
 from tests.fixtures.fake_runtime import FakeReviewerBotRuntime
 from tests.fixtures.reviewer_bot import (
     accept_contributor_comment,
     accept_contributor_revision,
+    accept_reviewer_comment,
     accept_reviewer_review,
     iso_z,
     issue_snapshot,
@@ -52,7 +56,16 @@ def test_check_overdue_reviews_consumes_only_stable_reviewer_response_fields(mon
     anchor_timestamp = iso_z(now - timedelta(days=runtime.REVIEW_DEADLINE_DAYS + 1))
     state = make_state()
     make_tracked_review_state(state, 42, reviewer="alice", assigned_at=anchor_timestamp, active_cycle_started_at=anchor_timestamp)
-    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+    runtime.github.get_issue_or_pr_snapshot_result = lambda issue_number: runtime.GitHubApiResult(
+        200,
+        issue_snapshot(issue_number, state="open", is_pull_request=True),
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
     runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
         "state": "awaiting_reviewer_response",
         "anchor_timestamp": anchor_timestamp,
@@ -69,6 +82,8 @@ def test_check_overdue_reviews_consumes_only_stable_reviewer_response_fields(mon
             "days_since_warning": 0,
             "needs_warning": True,
             "needs_transition": False,
+            "anchor_reason": None,
+            "anchor_timestamp": anchor_timestamp,
         }
     ]
 
@@ -81,7 +96,16 @@ def test_check_overdue_reviews_skips_item_when_snapshot_unavailable(monkeypatch)
     review["assigned_at"] = "2026-03-01T00:00:00Z"
     review["last_reviewer_activity"] = "2026-03-01T00:00:00Z"
     runtime = FakeReviewerBotRuntime(monkeypatch)
-    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: None
+    runtime.github.get_issue_or_pr_snapshot_result = lambda issue_number: runtime.GitHubApiResult(
+        502,
+        None,
+        {},
+        "bad gateway",
+        False,
+        "server_error",
+        1,
+        None,
+    )
 
     assert maintenance.check_overdue_reviews(runtime, state) == []
 
@@ -91,10 +115,166 @@ def test_handle_overdue_review_warning_only_records_successful_comment(monkeypat
     review = review_state.ensure_review_entry(state, 42, create=True)
     assert review is not None
     runtime = FakeReviewerBotRuntime(monkeypatch)
-    runtime.github.post_comment = lambda issue_number, body: False
+    runtime.github.list_issue_comments_result = lambda issue_number, page=1, per_page=100: runtime.GitHubApiResult(
+        200,
+        [],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+    runtime.github.post_comment_result = lambda issue_number, body: runtime.GitHubApiResult(
+        502,
+        None,
+        {},
+        "bad gateway",
+        False,
+        "server_error",
+        1,
+        None,
+    )
 
-    assert maintenance.handle_overdue_review_warning(runtime, state, 42, "alice") is False
+    assert maintenance.handle_overdue_review_warning(runtime, state, 42, "alice") is True
     assert review["transition_warning_sent"] is None
+    assert load_repair_marker(review, "warning_post")["failure_kind"] == "server_error"
+
+
+def test_handle_overdue_review_warning_uses_contributor_handoff_text(monkeypatch):
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    posted = []
+    runtime.github.list_issue_comments_result = lambda issue_number, page=1, per_page=100: runtime.GitHubApiResult(
+        200,
+        [],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+    runtime.github.post_comment_result = (
+        lambda issue_number, body: posted.append(body)
+        or runtime.GitHubApiResult(201, {}, {}, "created", True, None, 0, None)
+    )
+
+    assert maintenance.handle_overdue_review_warning(
+        runtime,
+        state,
+        42,
+        "alice",
+        anchor_reason="contributor_comment_newer",
+    ) is True
+    assert "latest contributor follow-up returned this review to you" in posted[0]
+    assert "since you were assigned" not in posted[0]
+
+
+def test_handle_overdue_review_warning_backfills_existing_marker_without_repost(monkeypatch):
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.github.list_issue_comments_result = lambda issue_number, page=1, per_page=100: runtime.GitHubApiResult(
+        200,
+        [
+            {
+                "id": 99,
+                "created_at": "2026-03-25T15:22:42Z",
+                "body": "<!-- reviewer-bot:transition-warning:v1 issue=42 reviewer=alice anchor= -->\n\n⚠️ **Review Reminder**\n\nExisting warning",
+                "user": {"login": "guidelines-bot"},
+            }
+        ],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+    runtime.github.post_comment_result = lambda issue_number, body: pytest.fail("warning backfill must not repost")
+
+    assert maintenance.handle_overdue_review_warning(runtime, state, 42, "alice") is True
+    assert review["transition_warning_sent"] == "2026-03-25T15:22:42Z"
+
+
+def test_backfill_transition_notice_if_present_records_dedupe_failure_without_backfill(monkeypatch):
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["transition_warning_sent"] = "2026-03-10T00:00:00Z"
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.github.list_issue_comments_result = lambda issue_number, page=1, per_page=100: runtime.GitHubApiResult(
+        502,
+        None,
+        {},
+        "bad gateway",
+        False,
+        "server_error",
+        1,
+        None,
+    )
+
+    assert maintenance.backfill_transition_notice_if_present(runtime, state, 42) is True
+    assert review.get("transition_notice_sent_at") is None
+    assert load_repair_marker(review, "transition_dedupe_read")["failure_kind"] == "server_error"
+
+
+def test_check_overdue_reviews_non_pr_contributor_followup_reanchors_to_contributor_timestamp(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    now = runtime.datetime.now(runtime.timezone.utc)
+    assigned_at = iso_z(now - timedelta(days=runtime.REVIEW_DEADLINE_DAYS + 20))
+    reviewer_comment_at = iso_z(now - timedelta(days=runtime.REVIEW_DEADLINE_DAYS + 19))
+    contributor_comment_at = iso_z(now - timedelta(days=runtime.REVIEW_DEADLINE_DAYS + 1))
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at=assigned_at,
+        active_cycle_started_at=assigned_at,
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:10",
+        timestamp=reviewer_comment_at,
+        actor="alice",
+    )
+    accept_contributor_comment(
+        review,
+        semantic_key="issue_comment:11",
+        timestamp=contributor_comment_at,
+        actor="dana",
+    )
+    runtime.github.get_issue_or_pr_snapshot_result = lambda issue_number: runtime.GitHubApiResult(
+        200,
+        issue_snapshot(issue_number, state="open", is_pull_request=False),
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+
+    overdue = maintenance.check_overdue_reviews(runtime, state)
+
+    assert overdue == [
+        {
+            "issue_number": 42,
+            "reviewer": "alice",
+            "days_overdue": 1,
+            "days_since_warning": 0,
+            "needs_warning": True,
+            "needs_transition": False,
+            "anchor_reason": "contributor_comment_newer",
+            "anchor_timestamp": contributor_comment_at,
+        }
+    ]
 
 
 def test_check_overdue_reviews_uses_contributor_comment_timestamp_when_turn_returns_to_reviewer(monkeypatch):

--- a/tests/unit/reviewer_bot/test_project_board.py
+++ b/tests/unit/reviewer_bot/test_project_board.py
@@ -13,6 +13,7 @@ from tests.fixtures.fake_runtime import FakeReviewerBotRuntime
 from tests.fixtures.focused_fake_services import GraphQLTransportStub
 from tests.fixtures.http_responses import FakeGitHubResponse
 from tests.fixtures.reviewer_bot import (
+    accept_contributor_comment,
     accept_reviewer_comment,
     accept_reviewer_review,
     issue_snapshot,
@@ -159,6 +160,37 @@ def test_preview_board_projection_formats_dates_at_day_granularity(monkeypatch):
     assert preview.desired is not None
     assert preview.desired.assigned_at == "2026-03-20"
     assert preview.desired.waiting_since == "2026-03-21"
+
+
+def test_preview_board_projection_non_pr_contributor_followup_returns_to_reviewer(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-20T12:34:56Z",
+        active_cycle_started_at="2026-03-20T12:34:56Z",
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:10",
+        timestamp="2026-03-21T08:00:00Z",
+        actor="alice",
+    )
+    accept_contributor_comment(
+        review,
+        semantic_key="issue_comment:11",
+        timestamp="2026-03-22T09:00:00Z",
+        actor="dana",
+    )
+    runtime = _runtime(monkeypatch)
+    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open")
+
+    preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+    assert preview.desired is not None
+    assert preview.desired.review_state == "Awaiting Reviewer"
+    assert preview.desired.waiting_since == "2026-03-22"
 
 
 def test_preview_board_projection_keeps_parity_with_refreshed_live_review_state(monkeypatch):

--- a/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
+++ b/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
@@ -9,7 +9,9 @@ from scripts.reviewer_bot_core import (
 )
 from scripts.reviewer_bot_lib import reviews
 from tests.fixtures.reviewer_bot import (
+    accept_contributor_comment,
     accept_contributor_revision,
+    accept_reviewer_comment,
     accept_reviewer_review,
     make_state,
     make_tracked_review_state,
@@ -379,6 +381,60 @@ def test_reviewer_response_derivation_supports_pure_inputs_without_live_reads():
     assert result["state"] == "awaiting_contributor_response"
     assert result["reason"] == "completion_missing"
     assert result["reviewer_review"]["semantic_key"] == "pull_request_review:10"
+
+
+def test_issue_reviewer_response_returns_to_reviewer_after_contributor_followup():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:10",
+        timestamp="2026-03-17T10:00:00Z",
+        actor="alice",
+    )
+    accept_contributor_comment(
+        review,
+        semantic_key="issue_comment:11",
+        timestamp="2026-03-18T11:00:00Z",
+        actor="dana",
+    )
+
+    result = reviewer_response_policy.derive_reviewer_response_state(review, issue_is_pull_request=False)
+
+    assert result["state"] == "awaiting_reviewer_response"
+    assert result["reason"] == "contributor_comment_newer"
+    assert result["anchor_timestamp"] == "2026-03-18T11:00:00Z"
+
+
+def test_issue_reviewer_response_ignores_prior_reviewer_records_after_reviewer_change():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:10",
+        timestamp="2026-03-17T10:00:00Z",
+        actor="alice",
+    )
+    review["current_reviewer"] = "bob"
+
+    result = reviewer_response_policy.derive_reviewer_response_state(review, issue_is_pull_request=False)
+
+    assert result["state"] == "awaiting_reviewer_response"
+    assert result["reason"] == "no_reviewer_activity"
+    assert result["anchor_timestamp"] == "2026-03-17T09:00:00Z"
+    assert result["reviewer_comment"] is None
 
 
 def test_h1a_reviewer_response_scenario_matrix_matches_frozen_outputs(monkeypatch):


### PR DESCRIPTION
## Summary
- Route issue reminder eligibility through cyclical response-state derivation so contributor follow-up can return non-PR reviews to the reviewer without stale reminder spam.
- Gate reviewer authority transitions on the confirmed final live GitHub assignee set, add marker-based reminder idempotence and diagnostics, and converge touched-item projection in the same run.
- Add generic tracked-issue completion with `/done`, preserve coding-guideline signoff semantics, wire successful FLS no-change execution into completion, and expand proof across unit, integration, and contract seams.

## Testing
- uv run pytest tests/unit/reviewer_bot
- uv run pytest tests/integration/reviewer_bot
- uv run pytest tests/contract/reviewer_bot
- uv run ruff check