### PR TITLE
fix: close residual pr264 scope-key incident gap

### DIFF
--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from . import live_review_support, reviewer_review_helpers
 
 _UNSET = object()
+_ASSIGNMENT_GUIDANCE_AUTHORS = {"github-actions", "github-actions[bot]", "guidelines-bot"}
 
 
 def _record_timestamp(record: dict | None, *, parse_timestamp) -> datetime | None:
@@ -63,7 +64,43 @@ def _initial_cycle_boundary(review_data: dict) -> tuple[str | None, str | None]:
     return None, None
 
 
-def _alternate_current_head_cycle_boundary(review_data: dict, issue_snapshot: dict | None) -> str | None:
+def _claim_assignment_guidance_timestamp(bot, issue_number: int, current_reviewer: str | None) -> str | None:
+    if not isinstance(current_reviewer, str) or not current_reviewer.strip():
+        return None
+    expected_first_line = f"👋 Hey @{current_reviewer}! You've been assigned to review this coding guideline PR."
+    first_match: tuple[datetime, str] | None = None
+    page = 1
+    while True:
+        response = bot.github.list_issue_comments_result(issue_number, page=page)
+        if not response.ok or not isinstance(response.payload, list):
+            return None
+        for comment in response.payload:
+            if not isinstance(comment, dict):
+                continue
+            user = comment.get("user")
+            login = user.get("login") if isinstance(user, dict) else None
+            created_at = comment.get("created_at")
+            body = comment.get("body")
+            if not isinstance(login, str) or not isinstance(created_at, str) or not isinstance(body, str):
+                continue
+            if login.lower() not in _ASSIGNMENT_GUIDANCE_AUTHORS:
+                continue
+            lines = body.splitlines()
+            first_line = lines[0].strip() if lines else ""
+            if first_line != expected_first_line:
+                continue
+            created_dt = live_review_support.parse_github_timestamp(created_at)
+            if created_dt is None:
+                continue
+            if first_match is None or created_dt < first_match[0]:
+                first_match = (created_dt, created_at)
+        if len(response.payload) < 100:
+            break
+        page += 1
+    return first_match[1] if first_match is not None else None
+
+
+def _alternate_current_head_cycle_boundary(bot, issue_number: int, review_data: dict, issue_snapshot: dict | None) -> str | None:
     if not isinstance(issue_snapshot, dict) or not isinstance(issue_snapshot.get("pull_request"), dict):
         return None
     if review_data.get("assignment_method") != "claim":
@@ -72,8 +109,7 @@ def _alternate_current_head_cycle_boundary(review_data: dict, issue_snapshot: di
         value = review_data.get(field)
         if isinstance(value, str) and value:
             return None
-    created_at = issue_snapshot.get("created_at")
-    return created_at if isinstance(created_at, str) and created_at else None
+    return _claim_assignment_guidance_timestamp(bot, issue_number, review_data.get("current_reviewer"))
 
 
 def _scope_basis_and_anchor(review_data: dict, contributor_handoff: dict | None) -> tuple[str | None, str | None]:
@@ -591,7 +627,12 @@ def compute_reviewer_response_state(
         reviews,
         parse_timestamp=bot.parse_iso8601_timestamp,
     )
-    alternate_current_head_cycle_boundary = _alternate_current_head_cycle_boundary(review_data, issue_snapshot)
+    alternate_current_head_cycle_boundary = _alternate_current_head_cycle_boundary(
+        bot,
+        issue_number,
+        review_data,
+        issue_snapshot,
+    )
 
     return derive_reviewer_response_state(
         review_data,

--- a/tests/integration/reviewer_bot/test_app_preview_overdue.py
+++ b/tests/integration/reviewer_bot/test_app_preview_overdue.py
@@ -97,7 +97,7 @@ def test_execute_run_preview_check_overdue_uses_frozen_pr264_operational_project
     }
 
 
-def test_execute_run_preview_check_overdue_backfills_claim_cycle_from_pr_creation(monkeypatch, capsys):
+def test_execute_run_preview_check_overdue_backfills_claim_cycle_from_assignment_guidance(monkeypatch, capsys):
     harness = AppHarness(monkeypatch)
     harness.set_event(
         EVENT_NAME="workflow_dispatch",
@@ -133,7 +133,7 @@ def test_execute_run_preview_check_overdue_backfills_claim_cycle_from_pr_creatio
             "state": "open",
             "pull_request": {},
             "labels": [],
-            "created_at": "2026-02-10T17:20:07Z",
+            "created_at": "2025-12-08T04:16:34Z",
         },
     ).add_request(
         "GET",
@@ -147,6 +147,17 @@ def test_execute_run_preview_check_overdue_backfills_claim_cycle_from_pr_creatio
     ).add_pull_request_reviews(
         264,
         [review_payload(501, state="APPROVED", submitted_at="2026-03-18T12:10:42Z", commit_id="head-live", author="plaindocs")],
+    ).add_request(
+        "GET",
+        "issues/264/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[
+            {
+                "user": {"login": "github-actions"},
+                "created_at": "2026-02-10T17:20:07Z",
+                "body": "👋 Hey @iglesias! You've been assigned to review this coding guideline PR.\n\n## Your Role as Reviewer",
+            }
+        ],
     )
     harness.runtime.github.stub(routes)
     harness.stub_load_state(lambda *, fail_on_unavailable=False: state)

--- a/tests/unit/reviewer_bot/test_reviews_live_fetch.py
+++ b/tests/unit/reviewer_bot/test_reviews_live_fetch.py
@@ -241,7 +241,7 @@ def test_compute_reviewer_response_state_reports_awaiting_write_approval_after_c
     assert response_state["reason"] == "current_head_alternate_approval_present"
 
 
-def test_compute_reviewer_response_state_uses_issue_created_at_for_claim_alternate_approval_scope(monkeypatch):
+def test_compute_reviewer_response_state_uses_assignment_guidance_for_claim_alternate_approval_scope(monkeypatch):
     state = make_state()
     review = make_tracked_review_state(
         state,
@@ -261,11 +261,22 @@ def test_compute_reviewer_response_state_uses_issue_created_at_for_claim_alterna
     routes = RouteGitHubApi().add_pull_request_snapshot(42, pull_request_payload(42, head_sha="head-live")).add_pull_request_reviews(
         42,
         [review_payload(10, state="APPROVED", submitted_at="2026-03-18T12:10:42Z", commit_id="head-live", author="plaindocs")],
+    ).add_request(
+        "GET",
+        "issues/42/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[
+            {
+                "user": {"login": "github-actions"},
+                "created_at": "2026-02-10T17:20:07Z",
+                "body": "👋 Hey @iglesias! You've been assigned to review this coding guideline PR.\n\n## Your Role as Reviewer",
+            }
+        ],
     )
     runtime = _runtime(monkeypatch, routes)
     runtime.github.get_issue_or_pr_snapshot = lambda issue_number: {
         **issue_snapshot(issue_number, state="open", is_pull_request=True),
-        "created_at": "2026-02-10T17:20:07Z",
+        "created_at": "2025-12-08T04:16:34Z",
     }
 
     response_state = reviews.compute_reviewer_response_state(runtime, 42, review)


### PR DESCRIPTION
## Summary
- recover the PR264 claim-based alternate-approval scope boundary from the original reviewer assignment guidance comment instead of the PR creation timestamp
- keep the retained Window 3 closure projection unchanged while updating the live-shape regression coverage for the claim fallback path

## Verification
- uv run pytest tests/unit/reviewer_bot/test_reviews_live_fetch.py
- uv run pytest tests/integration/reviewer_bot/test_app_preview_overdue.py
- uv run pytest tests/unit/reviewer_bot/test_app_event_intent.py tests/unit/reviewer_bot/test_maintenance.py tests/unit/reviewer_bot/test_sweeper_logic.py tests/unit/reviewer_bot/test_project_board.py tests/unit/reviewer_bot/test_reconcile_unit.py tests/unit/reviewer_bot/test_commands.py
- uv run pytest tests/integration/reviewer_bot/test_cli_entrypoint.py tests/integration/reviewer_bot/test_app_execution.py tests/integration/reviewer_bot/test_app_reviewer_board_preview.py tests/integration/reviewer_bot/test_app_schedule_bookkeeping.py tests/integration/reviewer_bot/test_reconcile_workflow_run.py tests/integration/reviewer_bot/test_pr264_incident_replay_card.py
- uv run pytest tests/contract/reviewer_bot/test_workflow_files.py tests/contract/reviewer_bot/test_workflow_artifact_contracts.py tests/contract/reviewer_bot/test_review_state_contract.py tests/contract/reviewer_bot/test_adapter_contract.py tests/contract/reviewer_bot/test_preview_workflow_contracts.py tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
- uv run pytest tests/unit/reviewer_bot/test_overdue.py
- uv run pytest tests/unit/reviewer_bot/test_approval_policy_equivalence.py
- uv run ruff check --fix
