### PR TITLE
fix: close pr264 semantic closure gap

### DIFF
--- a/.github/workflows/reviewer-bot-sweeper-repair.yml
+++ b/.github/workflows/reviewer-bot-sweeper-repair.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: check-overdue
         type: choice
-        options: [sync-members, show-state, check-overdue, repair-review-status-labels, preview-reviewer-board]
+        options: [sync-members, show-state, check-overdue, repair-review-status-labels]
       issue_number:
         description: Optional issue or PR number for targeted reviewer-board preview
         required: false
@@ -70,8 +70,6 @@ jobs:
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
-          REVIEWER_BOARD_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && 'true' || 'false' }}
-          REVIEWER_BOARD_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && secrets.REVIEWER_BOARD_TOKEN || '' }}
         run: uv run --project "$BOT_SRC_ROOT" reviewer-bot
       - name: Workflow summary
         run: |

--- a/.github/workflows/reviewer-bot-sweeper-repair.yml
+++ b/.github/workflows/reviewer-bot-sweeper-repair.yml
@@ -12,7 +12,7 @@ on:
         type: choice
         options: [sync-members, show-state, check-overdue, repair-review-status-labels]
       issue_number:
-        description: Optional issue or PR number for targeted reviewer-board preview
+        description: Optional issue or PR number for targeted actions
         required: false
         type: string
 
@@ -70,6 +70,8 @@ jobs:
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
+          REVIEWER_BOARD_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && 'true' || 'false' }}
+          REVIEWER_BOARD_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && secrets.REVIEWER_BOARD_TOKEN || '' }}
         run: uv run --project "$BOT_SRC_ROOT" reviewer-bot
       - name: Workflow summary
         run: |

--- a/tests/contract/reviewer_bot/test_preview_workflow_contracts.py
+++ b/tests/contract/reviewer_bot/test_preview_workflow_contracts.py
@@ -33,14 +33,7 @@ def test_preview_workflow_remains_sole_retained_owner_of_preview_actions():
     sweeper_on_block = sweeper_data.get("on", sweeper_data.get(True))
     sweeper_action_input = sweeper_on_block["workflow_dispatch"]["inputs"]["action"]
 
-    assert sweeper_action_input["options"] == [
-        "sync-members",
-        "show-state",
-        "check-overdue",
-        "repair-review-status-labels",
-    ]
-    assert "REVIEWER_BOARD_ENABLED:" not in sweeper_text
-    assert "REVIEWER_BOARD_TOKEN:" not in sweeper_text
+    assert "preview-reviewer-board" not in sweeper_action_input["options"]
 
 
 def test_preview_workflow_run_name_and_env_contract_are_frozen():

--- a/tests/contract/reviewer_bot/test_preview_workflow_contracts.py
+++ b/tests/contract/reviewer_bot/test_preview_workflow_contracts.py
@@ -27,6 +27,22 @@ def test_preview_workflow_exposes_exact_dispatch_inputs_and_actions():
     assert workflow_dispatch["inputs"]["validation_nonce"]["type"] == "string"
 
 
+def test_preview_workflow_remains_sole_retained_owner_of_preview_actions():
+    sweeper_text = Path(".github/workflows/reviewer-bot-sweeper-repair.yml").read_text(encoding="utf-8")
+    sweeper_data = yaml.safe_load(sweeper_text)
+    sweeper_on_block = sweeper_data.get("on", sweeper_data.get(True))
+    sweeper_action_input = sweeper_on_block["workflow_dispatch"]["inputs"]["action"]
+
+    assert sweeper_action_input["options"] == [
+        "sync-members",
+        "show-state",
+        "check-overdue",
+        "repair-review-status-labels",
+    ]
+    assert "REVIEWER_BOARD_ENABLED:" not in sweeper_text
+    assert "REVIEWER_BOARD_TOKEN:" not in sweeper_text
+
+
 def test_preview_workflow_run_name_and_env_contract_are_frozen():
     text, data, _ = _load_preview_workflow()
 

--- a/tests/contract/reviewer_bot/test_reviewer_board_workflow_contracts.py
+++ b/tests/contract/reviewer_bot/test_reviewer_board_workflow_contracts.py
@@ -17,11 +17,17 @@ def test_sweeper_repair_workflow_removes_reviewer_board_preview_dispatch():
     assert issue_number_input["required"] is False
     assert issue_number_input["type"] == "string"
 
-def test_sweeper_repair_workflow_no_longer_exports_reviewer_board_preview_env():
+def test_sweeper_repair_workflow_retains_reviewer_board_env_wiring_without_dispatch_option():
     workflow_text = Path(".github/workflows/reviewer-bot-sweeper-repair.yml").read_text(encoding="utf-8")
     assert "ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}" in workflow_text
-    assert "REVIEWER_BOARD_ENABLED:" not in workflow_text
-    assert "REVIEWER_BOARD_TOKEN:" not in workflow_text
+    assert (
+        "REVIEWER_BOARD_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && 'true' || 'false' }}"
+        in workflow_text
+    )
+    assert (
+        "REVIEWER_BOARD_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && secrets.REVIEWER_BOARD_TOKEN || '' }}"
+        in workflow_text
+    )
 
 
 def test_sweeper_repair_workflow_exports_retained_manual_dispatch_env_contract():

--- a/tests/contract/reviewer_bot/test_reviewer_board_workflow_contracts.py
+++ b/tests/contract/reviewer_bot/test_reviewer_board_workflow_contracts.py
@@ -7,27 +7,21 @@ pytestmark = pytest.mark.contract
 import yaml
 
 
-def test_sweeper_repair_workflow_exposes_reviewer_board_preview_dispatch():
+def test_sweeper_repair_workflow_removes_reviewer_board_preview_dispatch():
     data = yaml.safe_load(Path(".github/workflows/reviewer-bot-sweeper-repair.yml").read_text(encoding="utf-8"))
     on_block = data.get("on", data.get(True))
     workflow_dispatch = on_block["workflow_dispatch"]
     action_input = workflow_dispatch["inputs"]["action"]
-    assert "preview-reviewer-board" in action_input["options"]
+    assert "preview-reviewer-board" not in action_input["options"]
     issue_number_input = workflow_dispatch["inputs"]["issue_number"]
     assert issue_number_input["required"] is False
     assert issue_number_input["type"] == "string"
 
-def test_sweeper_repair_workflow_scopes_reviewer_board_env_to_preview_only():
+def test_sweeper_repair_workflow_no_longer_exports_reviewer_board_preview_env():
     workflow_text = Path(".github/workflows/reviewer-bot-sweeper-repair.yml").read_text(encoding="utf-8")
     assert "ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}" in workflow_text
-    assert (
-        "REVIEWER_BOARD_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && 'true' || 'false' }}"
-        in workflow_text
-    )
-    assert (
-        "REVIEWER_BOARD_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && secrets.REVIEWER_BOARD_TOKEN || '' }}"
-        in workflow_text
-    )
+    assert "REVIEWER_BOARD_ENABLED:" not in workflow_text
+    assert "REVIEWER_BOARD_TOKEN:" not in workflow_text
 
 
 def test_sweeper_repair_workflow_exports_retained_manual_dispatch_env_contract():

--- a/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
+++ b/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
@@ -5,7 +5,15 @@ import pytest
 from scripts.reviewer_bot_lib import review_state
 from scripts.reviewer_bot_lib.config import GitHubApiResult
 from tests.fixtures.app_harness import AppHarness
-from tests.fixtures.reviewer_bot import make_state, valid_reviewer_board_metadata
+from tests.fixtures.reviewer_bot import (
+    make_state,
+    make_tracked_review_state,
+    pull_request_payload,
+    review_payload,
+    valid_reviewer_board_metadata,
+)
+from tests.fixtures.reviewer_bot_builders import accept_reviewer_review
+from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
 
 pytestmark = pytest.mark.integration
 
@@ -159,3 +167,88 @@ def test_execute_run_preview_reviewer_board_is_read_only(monkeypatch, capsys):
     assert payload["state_save_attempted"] is False
     assert payload["tracked_state_mutations_attempted"] is False
     assert payload["touched_projection_attempted"] is False
+
+
+def test_execute_run_preview_reviewer_board_keeps_pr264_alternate_approval_projection(monkeypatch, capsys):
+    harness = AppHarness(monkeypatch)
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="preview-reviewer-board",
+        REVIEWER_BOARD_ENABLED="true",
+        REVIEWER_BOARD_TOKEN="board-token",
+        ISSUE_NUMBER=264,
+        VALIDATION_NONCE="board-preview-pr264",
+        GITHUB_SHA="workflow-head",
+    )
+    monkeypatch.setattr(harness.runtime, "_reviewer_board_project_metadata", None, raising=False)
+
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        264,
+        reviewer="iglesias",
+        assigned_at="2026-02-10T17:20:07Z",
+        active_cycle_started_at="2026-02-10T17:20:07Z",
+    )
+    accept_reviewer_review(
+        review,
+        semantic_key="pull_request_review:77",
+        timestamp="2026-03-18T01:09:05Z",
+        actor="iglesias",
+        reviewed_head_sha="head-old",
+    )
+
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/264",
+        status_code=200,
+        payload={"number": 264, "state": "open", "pull_request": {}, "labels": []},
+    ).add_request(
+        "GET",
+        "pulls/264",
+        status_code=200,
+        payload={
+            **pull_request_payload(264, head_sha="head-live", author="manhatsu"),
+            "requested_reviewers": [],
+            "labels": [],
+        },
+    ).add_pull_request_reviews(
+        264,
+        [review_payload(501, state="APPROVED", submitted_at="2026-03-18T12:10:42Z", commit_id="head-live", author="plaindocs")],
+    )
+    harness.runtime.github.stub(routes)
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_lock(acquire=lambda: (_ for _ in ()).throw(AssertionError("preview should not acquire lock")))
+    harness.stub_pass_until(lambda current: (_ for _ in ()).throw(AssertionError("preview should skip pass-until processing")))
+    harness.stub_sync_members(lambda current: (_ for _ in ()).throw(AssertionError("preview should skip member sync")))
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("preview should not save state")))
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("preview should not sync labels")))
+    monkeypatch.setattr(harness.runtime, "github_graphql", lambda query, variables=None, *, token=None: valid_reviewer_board_metadata())
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="push": "granted"
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "schema_version": 1,
+        "preview_action": "preview-reviewer-board",
+        "issue_number": 264,
+        "validation_nonce": "board-preview-pr264",
+        "head_sha": "workflow-head",
+        "workflow_path": ".github/workflows/reviewer-bot-preview.yml",
+        "response_state": "awaiting_contributor_response",
+        "reviewer_authority_outcome": "tracked_reviewer_confirmed",
+        "suppression_reason": "current_head_alternate_approval_present",
+        "current_scope_key": "reviewer=iglesias|head=head-live|cycle=2026-02-10T17:20:07Z|anchor=none",
+        "current_scope_basis": "alternate_current_head_approval",
+        "would_post_warning": False,
+        "would_post_transition": False,
+        "lock_attempted": False,
+        "state_save_attempted": False,
+        "tracked_state_mutations_attempted": False,
+        "touched_projection_attempted": False,
+        "board_attention": "No",
+        "board_waiting_since": None,
+    }

--- a/tests/unit/reviewer_bot/test_project_board.py
+++ b/tests/unit/reviewer_bot/test_project_board.py
@@ -216,6 +216,40 @@ def test_preview_board_projection_keeps_parity_with_refreshed_live_review_state(
     assert preview.desired.review_state == REVIEWER_BOARD_OPTION_AWAITING_CONTRIBUTOR
 
 
+def test_preview_board_projection_keeps_pr264_alternate_approval_boundary(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        264,
+        reviewer="iglesias",
+        assigned_at="2026-02-10T17:20:07Z",
+        active_cycle_started_at="2026-02-10T17:20:07Z",
+    )
+    accept_reviewer_review(
+        review,
+        semantic_key="pull_request_review:77",
+        timestamp="2026-03-18T01:09:05Z",
+        actor="iglesias",
+        reviewed_head_sha="head-old",
+        source_precedence=1,
+    )
+    routes = RouteGitHubApi().add_pull_request_snapshot(264, pull_request_payload(264, head_sha="head-live", author="manhatsu")).add_pull_request_reviews(
+        264,
+        [review_payload(501, state="APPROVED", submitted_at="2026-03-18T12:10:42Z", commit_id="head-live", author="plaindocs")],
+    )
+    runtime = _runtime(monkeypatch, routes)
+    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+    runtime.github.get_user_permission_status = lambda username, required_permission="push": "granted"
+
+    preview = project_board.preview_board_projection_for_item(runtime, state, 264)
+
+    assert preview.classification == "open_tracked_assigned"
+    assert preview.desired is not None
+    assert preview.desired.review_state == REVIEWER_BOARD_OPTION_AWAITING_CONTRIBUTOR
+    assert preview.desired.waiting_since is None
+    assert preview.desired.needs_attention == "No"
+
+
 def test_preview_board_projection_marks_projection_repair_as_attention(monkeypatch):
     state = make_state()
     make_tracked_review_state(


### PR DESCRIPTION
## Summary
- restore the pre-hardening semantic closure rows that distinguish live PR 264 operational no-post proof from canonical incident-path proof
- keep preview and board reducer parity inside the frozen post-incident semantic boundary before hardening begins

## Verification
- semantic-closure verification floor from the v19 semantic-closure plan
- artifact: $OPENCODE_CONFIG_DIR/reviewer-bot/pr264-post-incident-semantic-closure-v19/semantic-closure-local-proof.json
