### PR TITLE
refactor: harden reviewer handoff command surface

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -74,6 +74,19 @@ Use this to release your assignment from an issue/PR without automatically assig
 @guidelines-bot /release Need to focus on other priorities
 ```
 
+### Record Feedback for Contributor Follow-Up
+
+```
+@guidelines-bot /feedback
+```
+
+Use this after you have provided reviewer feedback and are waiting for the contributor to respond. This keeps reviewer-bot's review state aligned without marking the review complete or changing the assigned reviewer.
+
+**Example:**
+```
+@guidelines-bot /feedback
+```
+
 ### Rectify Review State
 
 ```
@@ -200,6 +213,7 @@ Life happens! Any of these actions will reset the 14-day clock:
 - **Post a review comment** - Any substantive feedback counts
 - **Use `/pass [reason]`** - Pass the review to the next person if you can't review it
 - **Use `/away YYYY-MM-DD [reason]`** - Step away temporarily (e.g., "On vacation until 2025-02-15")
+- **Use `/feedback`** - Record that reviewer feedback is ready for contributor follow-up
 - **Use `/rectify`** - Reconcile PR review state when review activity happened but bot state is stale
 
 #### Before You Pass: Consider the Learning Opportunity

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -74,19 +74,6 @@ Use this to release your assignment from an issue/PR without automatically assig
 @guidelines-bot /release Need to focus on other priorities
 ```
 
-### Record Feedback for Contributor Follow-Up
-
-```
-@guidelines-bot /feedback
-```
-
-Use this after you have provided reviewer feedback and are waiting for the contributor to respond. This keeps reviewer-bot's review state aligned without marking the review complete or changing the assigned reviewer.
-
-**Example:**
-```
-@guidelines-bot /feedback
-```
-
 ### Rectify Review State
 
 ```
@@ -99,7 +86,6 @@ permission to persist reviewer-bot state.
 
 Who can run it:
 - The currently assigned reviewer
-- A maintainer with triage+ permission
 
 What it does (for the current PR only):
 - If the latest review by the assigned reviewer is `APPROVED`, it marks the review complete.
@@ -213,7 +199,6 @@ Life happens! Any of these actions will reset the 14-day clock:
 - **Post a review comment** - Any substantive feedback counts
 - **Use `/pass [reason]`** - Pass the review to the next person if you can't review it
 - **Use `/away YYYY-MM-DD [reason]`** - Step away temporarily (e.g., "On vacation until 2025-02-15")
-- **Use `/feedback`** - Record that reviewer feedback is ready for contributor follow-up
 - **Use `/rectify`** - Reconcile PR review state when review activity happened but bot state is stale
 
 #### Before You Pass: Consider the Learning Opportunity

--- a/scripts/reviewer_bot_core/comment_command_policy.py
+++ b/scripts/reviewer_bot_core/comment_command_policy.py
@@ -118,6 +118,12 @@ def decide_comment_command(bot, request, classified, *, actor_class: str, comman
             raw_args=(),
             needs_assignment_request=False,
         )
+    if command == "_malformed_feedback_args":
+        return InlineResponseDecision(
+            response=f"❌ `/feedback` does not accept arguments. Usage: `{bot.BOT_MENTION} /feedback`",
+            success=False,
+            react=True,
+        )
     if command == OrdinaryCommandId.DONE.value:
         return ExecuteOrdinaryCommandDecision(
             command_id=OrdinaryCommandId.DONE,

--- a/scripts/reviewer_bot_core/comment_command_policy.py
+++ b/scripts/reviewer_bot_core/comment_command_policy.py
@@ -11,6 +11,7 @@ from . import privileged_command_policy
 class OrdinaryCommandId(StrEnum):
     PASS = "pass"
     AWAY = "away"
+    FEEDBACK = "feedback"
     DONE = "done"
     LABEL = "label"
     SYNC_MEMBERS = "sync-members"
@@ -102,6 +103,20 @@ def decide_comment_command(bot, request, classified, *, actor_class: str, comman
             response=f"❌ Missing date. Usage: `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]`",
             success=False,
             react=True,
+        )
+    if command == OrdinaryCommandId.FEEDBACK.value:
+        if args:
+            return InlineResponseDecision(
+                response=f"❌ `/feedback` does not accept arguments. Usage: `{bot.BOT_MENTION} /feedback`",
+                success=False,
+                react=True,
+            )
+        return ExecuteOrdinaryCommandDecision(
+            command_id=OrdinaryCommandId.FEEDBACK,
+            issue_number=issue_number,
+            actor=comment_author,
+            raw_args=(),
+            needs_assignment_request=False,
         )
     if command == OrdinaryCommandId.DONE.value:
         return ExecuteOrdinaryCommandDecision(

--- a/scripts/reviewer_bot_core/review_state_machine.py
+++ b/scripts/reviewer_bot_core/review_state_machine.py
@@ -97,6 +97,18 @@ def _compare_records(left: dict | None, right: dict | None) -> int:
     return 0
 
 
+def _clear_handoff_after_newer_contributor_event(review_data: dict, timestamp: str) -> bool:
+    handoff = review_data.get("current_cycle_reviewer_handoff")
+    if not isinstance(handoff, dict):
+        return False
+    contributor_time = parse_github_timestamp(timestamp)
+    handoff_time = parse_github_timestamp(handoff.get("timestamp"))
+    if contributor_time is None or handoff_time is None or contributor_time <= handoff_time:
+        return False
+    review_data["current_cycle_reviewer_handoff"] = None
+    return True
+
+
 def semantic_key_seen(review_data: dict, channel_name: str, semantic_key: str) -> bool:
     channel = _ensure_channel_map(review_data, channel_name)
     return semantic_key in channel["seen_keys"]
@@ -135,6 +147,8 @@ def accept_channel_event(
     current = channel.get("accepted")
     if _compare_records(candidate, current) >= 0:
         channel["accepted"] = candidate
+    if channel_name in {"contributor_comment", "contributor_revision"}:
+        _clear_handoff_after_newer_contributor_event(review_data, timestamp)
     return True
 
 

--- a/scripts/reviewer_bot_core/review_state_machine.py
+++ b/scripts/reviewer_bot_core/review_state_machine.py
@@ -161,6 +161,7 @@ def _reset_cycle_state(review_data: dict) -> None:
         review_data[channel] = {"accepted": None, "seen_keys": []}
     review_data["current_cycle_completion"] = {}
     review_data["current_cycle_write_approval"] = {}
+    review_data["current_cycle_reviewer_handoff"] = None
     review_data["overdue_anchor"] = None
 
 
@@ -203,6 +204,9 @@ def clear_current_reviewer(state: dict, issue_number: int) -> bool:
         changed = True
     if review_data.get("assignment_method") is not None:
         review_data["assignment_method"] = None
+        changed = True
+    if review_data.get("current_cycle_reviewer_handoff") is not None:
+        review_data["current_cycle_reviewer_handoff"] = None
         changed = True
     clear_transition_timers(review_data)
     return changed

--- a/scripts/reviewer_bot_core/review_state_machine.py
+++ b/scripts/reviewer_bot_core/review_state_machine.py
@@ -165,6 +165,13 @@ def _reset_cycle_state(review_data: dict) -> None:
     review_data["overdue_anchor"] = None
 
 
+def clear_current_cycle_reviewer_handoff(review_data: dict) -> bool:
+    if review_data.get("current_cycle_reviewer_handoff") is None:
+        return False
+    review_data["current_cycle_reviewer_handoff"] = None
+    return True
+
+
 def set_current_reviewer(
     state: dict,
     issue_number: int,
@@ -205,9 +212,7 @@ def clear_current_reviewer(state: dict, issue_number: int) -> bool:
     if review_data.get("assignment_method") is not None:
         review_data["assignment_method"] = None
         changed = True
-    if review_data.get("current_cycle_reviewer_handoff") is not None:
-        review_data["current_cycle_reviewer_handoff"] = None
-        changed = True
+    changed = clear_current_cycle_reviewer_handoff(review_data) or changed
     clear_transition_timers(review_data)
     return changed
 

--- a/scripts/reviewer_bot_core/review_state_types.py
+++ b/scripts/reviewer_bot_core/review_state_types.py
@@ -46,6 +46,17 @@ class ReviewChannelState:
 
 
 @dataclass
+class CurrentCycleReviewerHandoff:
+    """Maps to the exact persisted `/feedback` reviewer handoff shape."""
+
+    source_event_key: str
+    timestamp: str
+    actor: str
+    command_name: str
+    reviewed_head_sha: str | None = None
+
+
+@dataclass
 class ReviewEntryState:
     """Maps to the persisted review entry fields used by the future C1 cutover.
 
@@ -79,4 +90,4 @@ class ReviewEntryState:
     review_dismissal: ReviewChannelState = field(default_factory=ReviewChannelState)
     current_cycle_completion: dict[str, Any] = field(default_factory=dict)
     current_cycle_write_approval: dict[str, Any] = field(default_factory=dict)
-    current_cycle_reviewer_handoff: dict[str, Any] | None = None
+    current_cycle_reviewer_handoff: CurrentCycleReviewerHandoff | None = None

--- a/scripts/reviewer_bot_core/review_state_types.py
+++ b/scripts/reviewer_bot_core/review_state_types.py
@@ -79,3 +79,4 @@ class ReviewEntryState:
     review_dismissal: ReviewChannelState = field(default_factory=ReviewChannelState)
     current_cycle_completion: dict[str, Any] = field(default_factory=dict)
     current_cycle_write_approval: dict[str, Any] = field(default_factory=dict)
+    current_cycle_reviewer_handoff: dict[str, Any] | None = None

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -333,6 +333,12 @@ def derive_reviewer_response_state(
             None,
             issue_is_pull_request=False,
         )
+        if _compare_cross_channel_conversation(
+            contributor_comment,
+            reviewer_handoff,
+            parse_timestamp=live_review_support.parse_github_timestamp,
+        ) > 0:
+            reviewer_handoff = None
         if reviewer_review_helpers.compare_records(
             reviewer_handoff,
             latest_reviewer_response,
@@ -446,6 +452,25 @@ def derive_reviewer_response_state(
         issue_is_pull_request=True,
     )
 
+    contributor_handoff = contributor_comment
+    contributor_revision = _contributor_revision_handoff_record(
+        review_data,
+        current_head,
+        reviewer_review if isinstance(reviewer_review, dict) else None,
+    )
+    if reviewer_review_helpers.compare_records(
+        contributor_revision,
+        contributor_handoff,
+        parse_timestamp=live_review_support.parse_github_timestamp,
+    ) > 0:
+        contributor_handoff = contributor_revision
+    if _compare_cross_channel_conversation(
+        contributor_handoff,
+        reviewer_handoff,
+        parse_timestamp=live_review_support.parse_github_timestamp,
+    ) > 0:
+        reviewer_handoff = None
+
     if not reviewer_comment and not reviewer_review and not reviewer_handoff:
         if not had_reviewer_review:
             return _decorate_response(
@@ -473,19 +498,6 @@ def derive_reviewer_response_state(
         parse_timestamp=live_review_support.parse_github_timestamp,
     ) > 0:
         latest_reviewer_response = reviewer_handoff
-
-    contributor_handoff = contributor_comment
-    contributor_revision = _contributor_revision_handoff_record(
-        review_data,
-        current_head,
-        reviewer_review if isinstance(reviewer_review, dict) else None,
-    )
-    if reviewer_review_helpers.compare_records(
-        contributor_revision,
-        contributor_handoff,
-        parse_timestamp=live_review_support.parse_github_timestamp,
-    ) > 0:
-        contributor_handoff = contributor_revision
 
     if _compare_cross_channel_conversation(
         contributor_handoff,

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -216,6 +216,13 @@ def _current_cycle_reviewer_handoff_record(
         return None
     if not isinstance(source_event_key, str) or not source_event_key.strip():
         return None
+    handoff_time = live_review_support.parse_github_timestamp(timestamp)
+    if handoff_time is None:
+        return None
+    _, cycle_boundary = _initial_cycle_boundary(review_data)
+    cycle_boundary_time = live_review_support.parse_github_timestamp(cycle_boundary)
+    if cycle_boundary_time is not None and handoff_time < cycle_boundary_time:
+        return None
     reviewed_head_sha = handoff.get("reviewed_head_sha")
     if issue_is_pull_request:
         if not isinstance(reviewed_head_sha, str) or reviewed_head_sha != current_head:
@@ -332,6 +339,34 @@ def derive_reviewer_response_state(
             parse_timestamp=live_review_support.parse_github_timestamp,
         ) > 0:
             latest_reviewer_response = reviewer_handoff
+        if reviewer_handoff is not None and latest_reviewer_response is reviewer_handoff:
+            if _compare_cross_channel_conversation(
+                contributor_comment,
+                reviewer_handoff,
+                parse_timestamp=live_review_support.parse_github_timestamp,
+            ) > 0:
+                return _decorate_response(
+                    state="awaiting_reviewer_response",
+                    reason="contributor_comment_newer",
+                    scope_fields=_current_scope_fields(review_data, current_reviewer, None, contributor_comment),
+                    anchor_timestamp=contributor_comment.get("timestamp") if isinstance(contributor_comment, dict) else None,
+                    reviewer_comment=reviewer_comment,
+                    reviewer_review=reviewer_review,
+                    current_cycle_reviewer_handoff=reviewer_handoff,
+                    contributor_comment=contributor_comment,
+                    contributor_handoff=contributor_comment,
+                )
+            return _decorate_response(
+                state="awaiting_contributor_response",
+                reason="completion_missing",
+                scope_fields=_current_scope_fields(review_data, current_reviewer, None, contributor_comment),
+                anchor_timestamp=reviewer_handoff.get("timestamp"),
+                reviewer_comment=reviewer_comment,
+                reviewer_review=reviewer_review,
+                current_cycle_reviewer_handoff=reviewer_handoff,
+                contributor_comment=contributor_comment,
+                contributor_handoff=contributor_comment,
+            )
         completion = review_data.get("current_cycle_completion")
         if isinstance(completion, dict) and completion.get("completed"):
             return _decorate_response(
@@ -467,6 +502,20 @@ def derive_reviewer_response_state(
             reason=reason,
             scope_fields=_current_scope_fields(review_data, current_reviewer, current_head, contributor_handoff),
             anchor_timestamp=contributor_handoff.get("timestamp") if isinstance(contributor_handoff, dict) else None,
+            current_head_sha=current_head,
+            reviewer_comment=reviewer_comment,
+            reviewer_review=reviewer_review,
+            current_cycle_reviewer_handoff=reviewer_handoff,
+            contributor_comment=contributor_comment,
+            contributor_handoff=contributor_handoff,
+        )
+
+    if reviewer_handoff is not None and latest_reviewer_response is reviewer_handoff:
+        return _decorate_response(
+            state="awaiting_contributor_response",
+            reason="accepted_same_scope_reviewer_activity",
+            scope_fields=_current_scope_fields(review_data, current_reviewer, current_head, contributor_handoff),
+            anchor_timestamp=reviewer_handoff.get("timestamp"),
             current_head_sha=current_head,
             reviewer_comment=reviewer_comment,
             reviewer_review=reviewer_review,

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -195,6 +195,43 @@ def _record_for_current_reviewer(record: dict | None | object, current_reviewer:
     return record
 
 
+def _current_cycle_reviewer_handoff_record(
+    review_data: dict,
+    current_reviewer: str,
+    current_head: str | None,
+    *,
+    issue_is_pull_request: bool,
+) -> dict | None:
+    handoff = review_data.get("current_cycle_reviewer_handoff")
+    if not isinstance(handoff, dict):
+        return None
+    if handoff.get("command_name") != "feedback":
+        return None
+    actor = handoff.get("actor")
+    timestamp = handoff.get("timestamp")
+    source_event_key = handoff.get("source_event_key")
+    if not isinstance(actor, str) or actor.lower() != current_reviewer.lower():
+        return None
+    if not isinstance(timestamp, str) or not timestamp.strip():
+        return None
+    if not isinstance(source_event_key, str) or not source_event_key.strip():
+        return None
+    reviewed_head_sha = handoff.get("reviewed_head_sha")
+    if issue_is_pull_request:
+        if not isinstance(reviewed_head_sha, str) or reviewed_head_sha != current_head:
+            return None
+    elif reviewed_head_sha is not None:
+        return None
+    return {
+        "semantic_key": source_event_key,
+        "timestamp": timestamp,
+        "actor": actor,
+        "reviewed_head_sha": reviewed_head_sha,
+        "source_precedence": 1,
+        "payload": {"command_name": "feedback"},
+    }
+
+
 def _contributor_revision_handoff_record(review_data: dict, current_head: str | None, reviewer_review: dict | None) -> dict | None:
     contributor_revision = review_data.get("contributor_revision", {}).get("accepted")
     if not isinstance(contributor_revision, dict):
@@ -283,6 +320,18 @@ def derive_reviewer_response_state(
             parse_timestamp=live_review_support.parse_github_timestamp,
         ) > 0:
             latest_reviewer_response = reviewer_review
+        reviewer_handoff = _current_cycle_reviewer_handoff_record(
+            review_data,
+            current_reviewer,
+            None,
+            issue_is_pull_request=False,
+        )
+        if reviewer_review_helpers.compare_records(
+            reviewer_handoff,
+            latest_reviewer_response,
+            parse_timestamp=live_review_support.parse_github_timestamp,
+        ) > 0:
+            latest_reviewer_response = reviewer_handoff
         completion = review_data.get("current_cycle_completion")
         if isinstance(completion, dict) and completion.get("completed"):
             return _decorate_response(
@@ -292,6 +341,7 @@ def derive_reviewer_response_state(
                 anchor_timestamp=latest_reviewer_response.get("timestamp") if isinstance(latest_reviewer_response, dict) else None,
                 reviewer_comment=reviewer_comment,
                 reviewer_review=reviewer_review,
+                current_cycle_reviewer_handoff=reviewer_handoff,
                 contributor_comment=contributor_comment,
                 contributor_handoff=contributor_comment,
             )
@@ -303,6 +353,7 @@ def derive_reviewer_response_state(
                 anchor_timestamp=latest_reviewer_response.get("timestamp") if isinstance(latest_reviewer_response, dict) else None,
                 reviewer_comment=reviewer_comment,
                 reviewer_review=reviewer_review,
+                current_cycle_reviewer_handoff=reviewer_handoff,
                 contributor_comment=contributor_comment,
                 contributor_handoff=contributor_comment,
             )
@@ -314,6 +365,7 @@ def derive_reviewer_response_state(
                 anchor_timestamp=_initial_reviewer_anchor(review_data),
                 reviewer_comment=reviewer_comment,
                 reviewer_review=reviewer_review,
+                current_cycle_reviewer_handoff=reviewer_handoff,
                 contributor_comment=contributor_comment,
                 contributor_handoff=contributor_comment,
             )
@@ -329,6 +381,7 @@ def derive_reviewer_response_state(
                 anchor_timestamp=contributor_comment.get("timestamp") if isinstance(contributor_comment, dict) else None,
                 reviewer_comment=reviewer_comment,
                 reviewer_review=reviewer_review,
+                current_cycle_reviewer_handoff=reviewer_handoff,
                 contributor_comment=contributor_comment,
                 contributor_handoff=contributor_comment,
             )
@@ -339,6 +392,7 @@ def derive_reviewer_response_state(
             anchor_timestamp=latest_reviewer_response.get("timestamp") if isinstance(latest_reviewer_response, dict) else None,
             reviewer_comment=reviewer_comment,
             reviewer_review=reviewer_review,
+            current_cycle_reviewer_handoff=reviewer_handoff,
             contributor_comment=contributor_comment,
             contributor_handoff=contributor_comment,
         )
@@ -350,7 +404,14 @@ def derive_reviewer_response_state(
             scope_fields={"current_scope_key": None, "current_scope_basis": None},
         )
 
-    if not reviewer_comment and not reviewer_review:
+    reviewer_handoff = _current_cycle_reviewer_handoff_record(
+        review_data,
+        current_reviewer,
+        current_head,
+        issue_is_pull_request=True,
+    )
+
+    if not reviewer_comment and not reviewer_review and not reviewer_handoff:
         if not had_reviewer_review:
             return _decorate_response(
                 state="awaiting_reviewer_response",
@@ -359,6 +420,7 @@ def derive_reviewer_response_state(
                 anchor_timestamp=_initial_reviewer_anchor(review_data),
                 reviewer_comment=reviewer_comment,
                 reviewer_review=reviewer_review,
+                current_cycle_reviewer_handoff=reviewer_handoff,
                 contributor_comment=contributor_comment,
                 contributor_handoff=None,
             )
@@ -370,6 +432,12 @@ def derive_reviewer_response_state(
         parse_timestamp=live_review_support.parse_github_timestamp,
     ) > 0:
         latest_reviewer_response = reviewer_review
+    if reviewer_review_helpers.compare_records(
+        reviewer_handoff,
+        latest_reviewer_response,
+        parse_timestamp=live_review_support.parse_github_timestamp,
+    ) > 0:
+        latest_reviewer_response = reviewer_handoff
 
     contributor_handoff = contributor_comment
     contributor_revision = _contributor_revision_handoff_record(
@@ -402,6 +470,7 @@ def derive_reviewer_response_state(
             current_head_sha=current_head,
             reviewer_comment=reviewer_comment,
             reviewer_review=reviewer_review,
+            current_cycle_reviewer_handoff=reviewer_handoff,
             contributor_comment=contributor_comment,
             contributor_handoff=contributor_handoff,
         )
@@ -419,6 +488,7 @@ def derive_reviewer_response_state(
                 current_head_sha=current_head,
                 reviewer_comment=reviewer_comment,
                 reviewer_review=reviewer_review,
+                current_cycle_reviewer_handoff=reviewer_handoff,
                 contributor_comment=contributor_comment,
                 contributor_handoff=contributor_handoff,
             )
@@ -438,21 +508,24 @@ def derive_reviewer_response_state(
             current_head_sha=current_head,
             reviewer_comment=reviewer_comment,
             reviewer_review=reviewer_review,
+            current_cycle_reviewer_handoff=reviewer_handoff,
             contributor_comment=contributor_comment,
             contributor_handoff=contributor_handoff,
         )
 
     latest_review_head = reviewer_review.get("reviewed_head_sha") if isinstance(reviewer_review, dict) else None
     if not isinstance(latest_review_head, str) or latest_review_head != current_head:
-        if isinstance(reviewer_comment, dict):
+        if isinstance(reviewer_comment, dict) or isinstance(reviewer_handoff, dict):
+            response_anchor = reviewer_comment if isinstance(reviewer_comment, dict) else reviewer_handoff
             return _decorate_response(
                 state="awaiting_contributor_response",
                 reason="accepted_same_scope_reviewer_activity",
                 scope_fields=_current_scope_fields(review_data, current_reviewer, current_head, contributor_handoff),
-                anchor_timestamp=reviewer_comment.get("timestamp") if isinstance(reviewer_comment.get("timestamp"), str) else None,
+                anchor_timestamp=response_anchor.get("timestamp") if isinstance(response_anchor.get("timestamp"), str) else None,
                 current_head_sha=current_head,
                 reviewer_comment=reviewer_comment,
                 reviewer_review=reviewer_review,
+                current_cycle_reviewer_handoff=reviewer_handoff,
                 contributor_comment=contributor_comment,
                 contributor_handoff=contributor_handoff,
             )
@@ -464,6 +537,7 @@ def derive_reviewer_response_state(
             current_head_sha=current_head,
             reviewer_comment=reviewer_comment,
             reviewer_review=reviewer_review,
+            current_cycle_reviewer_handoff=reviewer_handoff,
             contributor_comment=contributor_comment,
             contributor_handoff=contributor_handoff,
         )
@@ -486,6 +560,7 @@ def derive_reviewer_response_state(
             current_head_sha=current_head,
             reviewer_comment=reviewer_comment,
             reviewer_review=reviewer_review,
+            current_cycle_reviewer_handoff=reviewer_handoff,
             contributor_comment=contributor_comment,
             contributor_handoff=contributor_handoff,
         )
@@ -498,6 +573,7 @@ def derive_reviewer_response_state(
             current_head_sha=current_head,
             reviewer_comment=reviewer_comment,
             reviewer_review=reviewer_review,
+            current_cycle_reviewer_handoff=reviewer_handoff,
             contributor_comment=contributor_comment,
             contributor_handoff=contributor_handoff,
         )
@@ -509,6 +585,7 @@ def derive_reviewer_response_state(
         current_head_sha=current_head,
         reviewer_comment=reviewer_comment,
         reviewer_review=reviewer_review,
+        current_cycle_reviewer_handoff=reviewer_handoff,
         contributor_comment=contributor_comment,
         contributor_handoff=contributor_handoff,
     )

--- a/scripts/reviewer_bot_core/state_adapters.py
+++ b/scripts/reviewer_bot_core/state_adapters.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from .review_state_types import (
     AcceptedChannelRecord,
+    CurrentCycleReviewerHandoff,
     DismissalAcceptedRecord,
     ReviewChannelState,
     ReviewEntryState,
@@ -36,6 +37,14 @@ _DEFERRED_GAP_MIGRATION_DROP_KEYS = {
     "source_run_attempt",
     "source_workflow_file",
     "source_artifact_name",
+}
+
+_REVIEWER_HANDOFF_KEYS = {
+    "source_event_key",
+    "timestamp",
+    "actor",
+    "command_name",
+    "reviewed_head_sha",
 }
 
 
@@ -213,6 +222,45 @@ def _channel_to_persisted(channel: ReviewChannelState) -> dict[str, Any]:
     }
 
 
+def _reviewer_handoff_from_persisted(value: Any) -> CurrentCycleReviewerHandoff | None:
+    if not isinstance(value, dict) or set(value) != _REVIEWER_HANDOFF_KEYS:
+        return None
+    source_event_key = value.get("source_event_key")
+    timestamp = value.get("timestamp")
+    actor = value.get("actor")
+    command_name = value.get("command_name")
+    reviewed_head_sha = value.get("reviewed_head_sha")
+    if not isinstance(source_event_key, str) or not source_event_key.strip():
+        return None
+    if not isinstance(timestamp, str) or not timestamp.strip():
+        return None
+    if not isinstance(actor, str) or not actor.strip():
+        return None
+    if command_name != "feedback":
+        return None
+    if reviewed_head_sha is not None and (not isinstance(reviewed_head_sha, str) or not reviewed_head_sha.strip()):
+        return None
+    return CurrentCycleReviewerHandoff(
+        source_event_key=source_event_key,
+        timestamp=timestamp,
+        actor=actor,
+        command_name=command_name,
+        reviewed_head_sha=reviewed_head_sha,
+    )
+
+
+def _reviewer_handoff_to_persisted(handoff: CurrentCycleReviewerHandoff | None) -> dict[str, Any] | None:
+    if handoff is None:
+        return None
+    return {
+        "source_event_key": handoff.source_event_key,
+        "timestamp": handoff.timestamp,
+        "actor": handoff.actor,
+        "command_name": handoff.command_name,
+        "reviewed_head_sha": handoff.reviewed_head_sha,
+    }
+
+
 def review_entry_from_persisted(review_entry: dict[str, Any] | list[Any] | None) -> ReviewEntryState | None:
     if review_entry is None:
         return None
@@ -297,9 +345,9 @@ def review_entry_from_persisted(review_entry: dict[str, Any] | list[Any] | None)
         current_cycle_write_approval=deepcopy(review_entry.get("current_cycle_write_approval") or {})
         if isinstance(review_entry.get("current_cycle_write_approval"), dict)
         else {},
-        current_cycle_reviewer_handoff=deepcopy(review_entry.get("current_cycle_reviewer_handoff"))
-        if isinstance(review_entry.get("current_cycle_reviewer_handoff"), dict)
-        else None,
+        current_cycle_reviewer_handoff=_reviewer_handoff_from_persisted(
+            review_entry.get("current_cycle_reviewer_handoff")
+        ),
     )
 
 
@@ -331,7 +379,9 @@ def review_entry_to_persisted(review_entry: ReviewEntryState) -> dict[str, Any]:
         "review_dismissal": _channel_to_persisted(review_entry.review_dismissal),
         "current_cycle_completion": deepcopy(review_entry.current_cycle_completion),
         "current_cycle_write_approval": deepcopy(review_entry.current_cycle_write_approval),
-        "current_cycle_reviewer_handoff": deepcopy(review_entry.current_cycle_reviewer_handoff),
+        "current_cycle_reviewer_handoff": _reviewer_handoff_to_persisted(
+            review_entry.current_cycle_reviewer_handoff
+        ),
     }
 
 

--- a/scripts/reviewer_bot_core/state_adapters.py
+++ b/scripts/reviewer_bot_core/state_adapters.py
@@ -297,6 +297,9 @@ def review_entry_from_persisted(review_entry: dict[str, Any] | list[Any] | None)
         current_cycle_write_approval=deepcopy(review_entry.get("current_cycle_write_approval") or {})
         if isinstance(review_entry.get("current_cycle_write_approval"), dict)
         else {},
+        current_cycle_reviewer_handoff=deepcopy(review_entry.get("current_cycle_reviewer_handoff"))
+        if isinstance(review_entry.get("current_cycle_reviewer_handoff"), dict)
+        else None,
     )
 
 
@@ -328,6 +331,7 @@ def review_entry_to_persisted(review_entry: ReviewEntryState) -> dict[str, Any]:
         "review_dismissal": _channel_to_persisted(review_entry.review_dismissal),
         "current_cycle_completion": deepcopy(review_entry.current_cycle_completion),
         "current_cycle_write_approval": deepcopy(review_entry.current_cycle_write_approval),
+        "current_cycle_reviewer_handoff": deepcopy(review_entry.current_cycle_reviewer_handoff),
     }
 
 

--- a/scripts/reviewer_bot_lib/assignment_flow.py
+++ b/scripts/reviewer_bot_lib/assignment_flow.py
@@ -117,14 +117,6 @@ def resolve_reviewer_authority(
     is_pull_request: bool,
 ) -> dict[str, object]:
     tracked_reviewer = review_data.get("current_reviewer") if isinstance(review_data, dict) else None
-    if not isinstance(tracked_reviewer, str) or not tracked_reviewer.strip():
-        return {
-            "authority_status": "no_tracked_reviewer",
-            "tracked_reviewer": None,
-            "live_control_plane_reviewers": [],
-            "reason": "no_tracked_reviewer",
-        }
-
     result = bot.github.get_issue_assignees_result(issue_number, is_pull_request=is_pull_request)
     _hard_fail_if_permission_denied(result, action="reviewer authority read", issue_number=issue_number)
     if not result.ok or not isinstance(result.payload, list):
@@ -136,6 +128,13 @@ def resolve_reviewer_authority(
         }
 
     live_control_plane_reviewers = [value for value in result.payload if isinstance(value, str) and value.strip()]
+    if not isinstance(tracked_reviewer, str) or not tracked_reviewer.strip():
+        return {
+            "authority_status": "no_tracked_reviewer",
+            "tracked_reviewer": None,
+            "live_control_plane_reviewers": live_control_plane_reviewers,
+            "reason": "no_tracked_reviewer",
+        }
     normalized_reviewers = {value.lower() for value in live_control_plane_reviewers}
     tracked_key = tracked_reviewer.lower()
     if is_pull_request:
@@ -173,6 +172,80 @@ def resolve_reviewer_authority(
         "live_control_plane_reviewers": live_control_plane_reviewers,
         "reason": "tracked_reviewer_confirmed",
     }
+
+
+def resolve_reviewer_command_authority(
+    bot,
+    state: dict,
+    request,
+    *,
+    actor: str | None = None,
+) -> dict[str, object]:
+    issue_number = request.issue_number
+    review_data = ensure_review_entry(state, issue_number)
+    if review_data is None:
+        result = bot.github.get_issue_assignees_result(issue_number, is_pull_request=bool(request.is_pull_request))
+        _hard_fail_if_permission_denied(result, action="reviewer authority read", issue_number=issue_number)
+        if not result.ok or not isinstance(result.payload, list):
+            return {
+                "authorized": False,
+                "authorization_status": "live_read_unavailable",
+                "review_data": None,
+                "tracked_reviewer": None,
+                "live_control_plane_reviewers": [],
+                "reason": str(result.failure_kind or "live_control_plane_unavailable"),
+            }
+        return {
+            "authorized": False,
+            "authorization_status": "no_active_review",
+            "review_data": None,
+            "tracked_reviewer": None,
+            "live_control_plane_reviewers": [value for value in result.payload if isinstance(value, str) and value.strip()],
+            "reason": "no_active_review",
+        }
+    authority = resolve_reviewer_authority(
+        bot,
+        issue_number,
+        review_data,
+        is_pull_request=bool(request.is_pull_request),
+    )
+    status = str(authority.get("authority_status"))
+    resolution = {
+        "authorized": status == "tracked_reviewer_confirmed",
+        "authorization_status": status,
+        "review_data": review_data,
+        "tracked_reviewer": authority.get("tracked_reviewer"),
+        "live_control_plane_reviewers": list(authority.get("live_control_plane_reviewers") or []),
+        "reason": authority.get("reason"),
+    }
+    if not resolution["authorized"] or actor is None:
+        return resolution
+    tracked_reviewer = resolution.get("tracked_reviewer")
+    if not isinstance(tracked_reviewer, str) or tracked_reviewer.lower() != actor.lower():
+        resolution["authorized"] = False
+        resolution["authorization_status"] = "actor_not_current_reviewer"
+        resolution["reason"] = "actor_not_current_reviewer"
+    return resolution
+
+
+def reviewer_command_authority_failure_message(command_name: str, resolution: dict[str, object]) -> str:
+    status = str(resolution.get("authorization_status") or "")
+    tracked_reviewer = resolution.get("tracked_reviewer")
+    live_reviewers = [value for value in resolution.get("live_control_plane_reviewers") or [] if isinstance(value, str)]
+    if status == "live_read_unavailable":
+        return "❌ Unable to determine current assignees/reviewers from GitHub; refusing to continue."
+    if status in {"no_active_review", "no_tracked_reviewer"}:
+        return "❌ No active tracked review exists for this issue/PR."
+    if status == "actor_not_current_reviewer" and isinstance(tracked_reviewer, str) and tracked_reviewer:
+        return f"❌ Only the current reviewer (@{tracked_reviewer}) can use `/{command_name}`."
+    if status == "control_plane_mismatch":
+        if live_reviewers:
+            return (
+                f"❌ Unable to confirm @{tracked_reviewer} as the current reviewer from GitHub. "
+                f"Live reviewer(s): @{', @'.join(live_reviewers)}."
+            )
+        return f"❌ Unable to confirm @{tracked_reviewer} as the current reviewer from GitHub."
+    return f"❌ Unable to confirm current reviewer authority for `/{command_name}`."
 
 
 def _post_assignment_guidance(bot, request, reviewer: str) -> None:

--- a/scripts/reviewer_bot_lib/assignment_flow.py
+++ b/scripts/reviewer_bot_lib/assignment_flow.py
@@ -220,12 +220,20 @@ def resolve_reviewer_command_authority(
     }
     if not resolution["authorized"] or actor is None:
         return resolution
+    return require_reviewer_command_actor(resolution, actor)
+
+
+def require_reviewer_command_actor(resolution: dict[str, object], actor: str) -> dict[str, object]:
+    if not resolution.get("authorized"):
+        return resolution
     tracked_reviewer = resolution.get("tracked_reviewer")
-    if not isinstance(tracked_reviewer, str) or tracked_reviewer.lower() != actor.lower():
-        resolution["authorized"] = False
-        resolution["authorization_status"] = "actor_not_current_reviewer"
-        resolution["reason"] = "actor_not_current_reviewer"
-    return resolution
+    if isinstance(tracked_reviewer, str) and tracked_reviewer.lower() == actor.lower():
+        return resolution
+    denied = dict(resolution)
+    denied["authorized"] = False
+    denied["authorization_status"] = "actor_not_current_reviewer"
+    denied["reason"] = "actor_not_current_reviewer"
+    return denied
 
 
 def reviewer_command_authority_failure_message(command_name: str, resolution: dict[str, object]) -> str:

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -176,6 +176,7 @@ def handle_pass_command(
         assignment_request,
         actor=comment_author,
     )
+    authority = assignment_flow.require_reviewer_command_actor(authority, comment_author)
     if not authority.get("authorized"):
         return _reviewer_command_authority_error("pass", authority), False
     issue_data = authority.get("review_data")
@@ -426,7 +427,7 @@ def handle_queue_command(
 
 
 def handle_commands_command(bot) -> tuple[str, bool]:
-    return (f"ℹ️ **Available Commands**\n\n**Pass or step away:**\n- `{bot.BOT_MENTION} /pass [reason]` - Pass this review to next in queue (current reviewer only)\n- `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from queue until a date\n- `{bot.BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up\n- `{bot.BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)\n\n**Assign reviewers:**\n- `{bot.BOT_MENTION} /r? @username` - Assign a specific reviewer\n- `{bot.BOT_MENTION} /r? producers` - Request the next reviewer from the queue\n- `{bot.BOT_MENTION} /claim` - Claim this review for yourself\n\n**Other:**\n- `{bot.BOT_MENTION} /done` - Mark a tracked non-PR issue review complete\n- `{bot.BOT_MENTION} /label +label-name` - Add a label\n- `{bot.BOT_MENTION} /label -label-name` - Remove a label\n- `{bot.BOT_MENTION} /rectify` - Reconcile this issue/PR review state from GitHub\n- `{bot.BOT_MENTION} /accept-no-fls-changes` - Update spec.lock and open a PR when no guidelines are impacted\n- `{bot.BOT_MENTION} /queue` - Show current queue status\n- `{bot.BOT_MENTION} /sync-members` - Sync queue with members.md"), True
+    return (f"ℹ️ **Available Commands**\n\n**Pass or step away:**\n- `{bot.BOT_MENTION} /pass [reason]` - Pass this review to next in queue (current reviewer only)\n- `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from queue until a date\n- `{bot.BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up\n- `{bot.BOT_MENTION} /release [reason]` - Release your current reviewer assignment\n\n**Assign reviewers:**\n- `{bot.BOT_MENTION} /r? @username` - Assign a specific reviewer\n- `{bot.BOT_MENTION} /r? producers` - Request the next reviewer from the queue\n- `{bot.BOT_MENTION} /claim` - Claim this review for yourself\n\n**Other:**\n- `{bot.BOT_MENTION} /done` - Mark a tracked non-PR issue review complete\n- `{bot.BOT_MENTION} /label +label-name` - Add a label\n- `{bot.BOT_MENTION} /label -label-name` - Remove a label\n- `{bot.BOT_MENTION} /rectify` - Reconcile this issue/PR review state from GitHub (current reviewer only)\n- `{bot.BOT_MENTION} /accept-no-fls-changes` - Update spec.lock and open a PR when no guidelines are impacted\n- `{bot.BOT_MENTION} /queue` - Show current queue status\n- `{bot.BOT_MENTION} /sync-members` - Sync queue with members.md"), True
 
 
 def handle_claim_command(
@@ -475,11 +476,9 @@ def handle_release_command(
     request = request or build_assignment_request(bot, issue_number=issue_number)
     target_username = None
     reason = None
-    releasing_other = False
     if args and args[0].startswith("@"):
         target_username = args[0].lstrip("@")
         reason = " ".join(args[1:]) if len(args) > 1 else None
-        releasing_other = target_username.lower() != comment_author.lower()
     else:
         target_username = comment_author
         reason = " ".join(args) if args else None
@@ -489,22 +488,18 @@ def handle_release_command(
         issue_data = state["active_reviews"][issue_key]
         if isinstance(issue_data, dict):
             assignment_method = issue_data.get("assignment_method")
-    authority = reviewer_authority or assignment_flow.resolve_reviewer_command_authority(bot, state, request)
+    authority = reviewer_authority or assignment_flow.resolve_reviewer_command_authority(
+        bot,
+        state,
+        request,
+        actor=comment_author,
+    )
+    authority = assignment_flow.require_reviewer_command_actor(authority, comment_author)
     if not authority.get("authorized"):
         return _reviewer_command_authority_error("release", authority), False
     tracked_reviewer = str(authority["tracked_reviewer"])
     if target_username.lower() != tracked_reviewer.lower():
         return (f"❌ @{target_username} is not the current reviewer. Current reviewer: @{tracked_reviewer}"), False
-    if releasing_other:
-        permission_status = bot.github.get_user_permission_status(comment_author, "triage")
-        if permission_status == "unavailable":
-            return "❌ Unable to verify triage permissions right now; refusing to continue.", False
-        if permission_status != "granted":
-            return (f"❌ @{comment_author} does not have permission to release other reviewers. Triage access or higher is required."), False
-    if not releasing_other and comment_author.lower() != tracked_reviewer.lower():
-        return (
-            f"❌ Only the current reviewer (@{tracked_reviewer}) can use `/release` without triage+ permission."
-        ), False
     result = assignment_flow.confirm_reviewer_release(
         bot,
         state,
@@ -517,8 +512,6 @@ def handle_release_command(
             result.get("diagnostic_changed") or result.get("cleared_current_reviewer")
         )
     reason_text = f" Reason: {reason}" if reason else ""
-    if releasing_other:
-        return (f"✅ @{comment_author} has released @{target_username} from this review.{reason_text}\n\n_This issue/PR is now unassigned. Use `{bot.BOT_MENTION} /r? producers` to assign the next reviewer from the queue, or `{bot.BOT_MENTION} /claim` to claim it._"), True
     return (f"✅ @{target_username} has released this review.{reason_text}\n\n_This issue/PR is now unassigned. Use `{bot.BOT_MENTION} /r? producers` to assign the next reviewer from the queue, or `{bot.BOT_MENTION} /claim` to claim it._"), True
 
 

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -480,11 +480,6 @@ def handle_release_command(
         target_username = args[0].lstrip("@")
         reason = " ".join(args[1:]) if len(args) > 1 else None
         releasing_other = target_username.lower() != comment_author.lower()
-        permission_status = bot.github.get_user_permission_status(comment_author, "triage")
-        if permission_status == "unavailable":
-            return "❌ Unable to verify triage permissions right now; refusing to continue.", False
-        if releasing_other and permission_status != "granted":
-            return (f"❌ @{comment_author} does not have permission to release other reviewers. Triage access or higher is required."), False
     else:
         target_username = comment_author
         reason = " ".join(args) if args else None
@@ -500,6 +495,12 @@ def handle_release_command(
     tracked_reviewer = str(authority["tracked_reviewer"])
     if target_username.lower() != tracked_reviewer.lower():
         return (f"❌ @{target_username} is not the current reviewer. Current reviewer: @{tracked_reviewer}"), False
+    if releasing_other:
+        permission_status = bot.github.get_user_permission_status(comment_author, "triage")
+        if permission_status == "unavailable":
+            return "❌ Unable to verify triage permissions right now; refusing to continue.", False
+        if permission_status != "granted":
+            return (f"❌ @{comment_author} does not have permission to release other reviewers. Triage access or higher is required."), False
     if not releasing_other and comment_author.lower() != tracked_reviewer.lower():
         return (
             f"❌ Only the current reviewer (@{tracked_reviewer}) can use `/release` without triage+ permission."

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -85,7 +85,7 @@ def parse_command(bot, comment_body: str) -> tuple[str, list[str]] | None:
             return "r?-user", [f"@{username}"]
         return "r?", []
     if command == "feedback" and args_str:
-        return "feedback", args_str.split()
+        return "_malformed_feedback_args", []
     args = []
     if args_str:
         current_arg = ""
@@ -167,12 +167,13 @@ def handle_pass_command(
     comment_author: str,
     reason: str | None,
     request: AssignmentRequest | None = None,
+    reviewer_authority: dict[str, object] | None = None,
 ) -> tuple[str, bool]:
     assignment_request = request or build_assignment_request(bot, issue_number=issue_number)
     issue_data = review_state.ensure_review_entry(state, issue_number, create=True)
     if issue_data is None:
         return "❌ Unable to load review state.", False
-    authority = assignment_flow.resolve_reviewer_command_authority(
+    authority = reviewer_authority or assignment_flow.resolve_reviewer_command_authority(
         bot,
         state,
         assignment_request,
@@ -468,6 +469,7 @@ def handle_release_command(
     comment_author: str,
     args: list | None = None,
     request: AssignmentRequest | None = None,
+    reviewer_authority: dict[str, object] | None = None,
 ) -> tuple[str, bool]:
     args = args or []
     request = request or build_assignment_request(bot, issue_number=issue_number)
@@ -492,7 +494,7 @@ def handle_release_command(
         issue_data = state["active_reviews"][issue_key]
         if isinstance(issue_data, dict):
             assignment_method = issue_data.get("assignment_method")
-    authority = assignment_flow.resolve_reviewer_command_authority(bot, state, request)
+    authority = reviewer_authority or assignment_flow.resolve_reviewer_command_authority(bot, state, request)
     if not authority.get("authorized"):
         return _reviewer_command_authority_error("release", authority), False
     tracked_reviewer = str(authority["tracked_reviewer"])

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -170,9 +170,6 @@ def handle_pass_command(
     reviewer_authority: dict[str, object] | None = None,
 ) -> tuple[str, bool]:
     assignment_request = request or build_assignment_request(bot, issue_number=issue_number)
-    issue_data = review_state.ensure_review_entry(state, issue_number, create=True)
-    if issue_data is None:
-        return "❌ Unable to load review state.", False
     authority = reviewer_authority or assignment_flow.resolve_reviewer_command_authority(
         bot,
         state,
@@ -181,6 +178,9 @@ def handle_pass_command(
     )
     if not authority.get("authorized"):
         return _reviewer_command_authority_error("pass", authority), False
+    issue_data = authority.get("review_data")
+    if not isinstance(issue_data, dict):
+        return "❌ Unable to load review state.", False
     passed_reviewer = str(authority["tracked_reviewer"])
     current_assignees = list(authority.get("live_control_plane_reviewers") or [])
     skipped = list(issue_data["skipped"])

--- a/scripts/reviewer_bot_lib/commands.py
+++ b/scripts/reviewer_bot_lib/commands.py
@@ -84,6 +84,8 @@ def parse_command(bot, comment_body: str) -> tuple[str, list[str]] | None:
             username = target.lstrip("@")
             return "r?-user", [f"@{username}"]
         return "r?", []
+    if command == "feedback" and args_str:
+        return "feedback", args_str.split()
     args = []
     if args_str:
         current_arg = ""
@@ -154,6 +156,10 @@ def _single_current_assignee_or_error(current_assignees: list[str]) -> tuple[str
     return current_assignees[0], None
 
 
+def _reviewer_command_authority_error(command_name: str, resolution: dict[str, object]) -> str:
+    return assignment_flow.reviewer_command_authority_failure_message(command_name, resolution)
+
+
 def handle_pass_command(
     bot,
     state: dict,
@@ -166,14 +172,16 @@ def handle_pass_command(
     issue_data = review_state.ensure_review_entry(state, issue_number, create=True)
     if issue_data is None:
         return "❌ Unable to load review state.", False
-    current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
-    if assignee_error:
-        return assignee_error, False
-    passed_reviewer, reviewer_error = _single_current_assignee_or_error(current_assignees)
-    if reviewer_error:
-        return reviewer_error, False
-    if passed_reviewer.lower() != comment_author.lower():
-        return "❌ Only the currently assigned reviewer can use `/pass`.", False
+    authority = assignment_flow.resolve_reviewer_command_authority(
+        bot,
+        state,
+        assignment_request,
+        actor=comment_author,
+    )
+    if not authority.get("authorized"):
+        return _reviewer_command_authority_error("pass", authority), False
+    passed_reviewer = str(authority["tracked_reviewer"])
+    current_assignees = list(authority.get("live_control_plane_reviewers") or [])
     skipped = list(issue_data["skipped"])
     is_first_pass = len(skipped) == 0
     if passed_reviewer not in skipped:
@@ -417,7 +425,7 @@ def handle_queue_command(
 
 
 def handle_commands_command(bot) -> tuple[str, bool]:
-    return (f"ℹ️ **Available Commands**\n\n**Pass or step away:**\n- `{bot.BOT_MENTION} /pass [reason]` - Pass this review to next in queue (current reviewer only)\n- `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from queue until a date\n- `{bot.BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)\n\n**Assign reviewers:**\n- `{bot.BOT_MENTION} /r? @username` - Assign a specific reviewer\n- `{bot.BOT_MENTION} /r? producers` - Request the next reviewer from the queue\n- `{bot.BOT_MENTION} /claim` - Claim this review for yourself\n\n**Other:**\n- `{bot.BOT_MENTION} /done` - Mark a tracked non-PR issue review complete\n- `{bot.BOT_MENTION} /label +label-name` - Add a label\n- `{bot.BOT_MENTION} /label -label-name` - Remove a label\n- `{bot.BOT_MENTION} /rectify` - Reconcile this issue/PR review state from GitHub\n- `{bot.BOT_MENTION} /accept-no-fls-changes` - Update spec.lock and open a PR when no guidelines are impacted\n- `{bot.BOT_MENTION} /queue` - Show current queue status\n- `{bot.BOT_MENTION} /sync-members` - Sync queue with members.md"), True
+    return (f"ℹ️ **Available Commands**\n\n**Pass or step away:**\n- `{bot.BOT_MENTION} /pass [reason]` - Pass this review to next in queue (current reviewer only)\n- `{bot.BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from queue until a date\n- `{bot.BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up\n- `{bot.BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)\n\n**Assign reviewers:**\n- `{bot.BOT_MENTION} /r? @username` - Assign a specific reviewer\n- `{bot.BOT_MENTION} /r? producers` - Request the next reviewer from the queue\n- `{bot.BOT_MENTION} /claim` - Claim this review for yourself\n\n**Other:**\n- `{bot.BOT_MENTION} /done` - Mark a tracked non-PR issue review complete\n- `{bot.BOT_MENTION} /label +label-name` - Add a label\n- `{bot.BOT_MENTION} /label -label-name` - Remove a label\n- `{bot.BOT_MENTION} /rectify` - Reconcile this issue/PR review state from GitHub\n- `{bot.BOT_MENTION} /accept-no-fls-changes` - Update spec.lock and open a PR when no guidelines are impacted\n- `{bot.BOT_MENTION} /queue` - Show current queue status\n- `{bot.BOT_MENTION} /sync-members` - Sync queue with members.md"), True
 
 
 def handle_claim_command(
@@ -479,30 +487,21 @@ def handle_release_command(
         target_username = comment_author
         reason = " ".join(args) if args else None
     issue_key = str(issue_number)
-    tracked_reviewer = None
     assignment_method = None
     if "active_reviews" in state and issue_key in state["active_reviews"]:
         issue_data = state["active_reviews"][issue_key]
         if isinstance(issue_data, dict):
-            tracked_reviewer = issue_data.get("current_reviewer")
             assignment_method = issue_data.get("assignment_method")
-    current_assignees, assignee_error = _current_assignees_or_error(bot, issue_number)
-    if assignee_error:
-        return assignee_error, False
-    is_tracked = tracked_reviewer and tracked_reviewer.lower() == target_username.lower()
-    is_assigned = target_username.lower() in [assignee.lower() for assignee in current_assignees]
-    if not is_tracked and not is_assigned:
-        if releasing_other:
-            if tracked_reviewer:
-                return (f"❌ @{target_username} is not the current reviewer. Current reviewer: @{tracked_reviewer}"), False
-            if current_assignees:
-                return (f"❌ @{target_username} is not assigned to this issue/PR. Current assignee(s): @{', @'.join(current_assignees)}"), False
-            return f"❌ @{target_username} is not assigned to this issue/PR.", False
-        if tracked_reviewer:
-            return (f"❌ @{comment_author} is not the current reviewer. Current reviewer: @{tracked_reviewer}"), False
-        if current_assignees:
-            return (f"❌ @{comment_author} is not assigned to this issue/PR. Current assignee(s): @{', @'.join(current_assignees)}"), False
-            return "❌ No reviewer is currently assigned to release.", False
+    authority = assignment_flow.resolve_reviewer_command_authority(bot, state, request)
+    if not authority.get("authorized"):
+        return _reviewer_command_authority_error("release", authority), False
+    tracked_reviewer = str(authority["tracked_reviewer"])
+    if target_username.lower() != tracked_reviewer.lower():
+        return (f"❌ @{target_username} is not the current reviewer. Current reviewer: @{tracked_reviewer}"), False
+    if not releasing_other and comment_author.lower() != tracked_reviewer.lower():
+        return (
+            f"❌ Only the current reviewer (@{tracked_reviewer}) can use `/release` without triage+ permission."
+        ), False
     result = assignment_flow.confirm_reviewer_release(
         bot,
         state,

--- a/scripts/reviewer_bot_lib/comment_application.py
+++ b/scripts/reviewer_bot_lib/comment_application.py
@@ -280,7 +280,13 @@ def _feedback_handoff_should_replace(existing: object, candidate: dict) -> bool:
         return existing_key is None
     if existing_key is None:
         return True
-    return candidate_key >= existing_key
+    candidate_timestamp, candidate_source = candidate_key
+    existing_timestamp, existing_source = existing_key
+    if candidate_timestamp > existing_timestamp:
+        return True
+    if candidate_timestamp < existing_timestamp:
+        return False
+    return candidate_source == existing_source
 
 
 def handle_feedback_command(bot, state: dict, request: CommentEventRequest, decision) -> CommandExecutionResult:
@@ -325,7 +331,7 @@ def handle_feedback_command(bot, state: dict, request: CommentEventRequest, deci
     before = review_data.get("current_cycle_reviewer_handoff")
     if not _feedback_handoff_should_replace(before, handoff):
         return CommandExecutionResult(
-            response="ℹ️ Ignored stale `/feedback` handoff because a newer reviewer handoff is already recorded.",
+            response="ℹ️ Ignored stale `/feedback` handoff because a newer or same-time reviewer handoff is already recorded.",
             success=True,
             state_changed=False,
         )

--- a/scripts/reviewer_bot_lib/comment_application.py
+++ b/scripts/reviewer_bot_lib/comment_application.py
@@ -226,7 +226,7 @@ def _execute_release(bot, state: dict, decision, assignment_request: AssignmentR
         bot,
         state,
         assignment_request,
-        actor=None,
+        actor=decision.actor,
     )
     return _build_execution_result(
         decision.command_id,

--- a/scripts/reviewer_bot_lib/comment_application.py
+++ b/scripts/reviewer_bot_lib/comment_application.py
@@ -230,6 +230,56 @@ def _execute_rectify(bot, state: dict, decision, assignment_request: AssignmentR
     )
 
 
+def _execute_feedback(bot, state: dict, request: CommentEventRequest, decision) -> CommandExecutionResult:
+    if request.issue_state.lower() != "open":
+        return CommandExecutionResult(
+            response="❌ `/feedback` can only be used on open tracked review items.",
+            success=False,
+            state_changed=False,
+        )
+    authority = assignment_flow.resolve_reviewer_command_authority(
+        bot,
+        state,
+        request,
+        actor=decision.actor,
+    )
+    if not authority.get("authorized"):
+        return CommandExecutionResult(
+            response=assignment_flow.reviewer_command_authority_failure_message("feedback", authority),
+            success=False,
+            state_changed=False,
+        )
+    review_data = authority.get("review_data")
+    if not isinstance(review_data, dict):
+        return CommandExecutionResult(response="❌ Unable to load review state.", success=False, state_changed=False)
+    reviewed_head_sha = None
+    if request.is_pull_request:
+        active_head_sha = review_data.get("active_head_sha")
+        if not isinstance(active_head_sha, str) or not active_head_sha.strip():
+            return CommandExecutionResult(
+                response="❌ Unable to record `/feedback`: tracked PR head is unavailable.",
+                success=False,
+                state_changed=False,
+            )
+        reviewed_head_sha = active_head_sha
+    handoff = {
+        "source_event_key": request.comment_source_event_key or f"issue_comment:{request.comment_id}",
+        "timestamp": request.comment_created_at,
+        "actor": decision.actor,
+        "command_name": comment_command_policy.OrdinaryCommandId.FEEDBACK.value,
+        "reviewed_head_sha": reviewed_head_sha,
+    }
+    before = review_data.get("current_cycle_reviewer_handoff")
+    review_data["current_cycle_reviewer_handoff"] = handoff
+    activity_changed = record_reviewer_activity(review_data, request.comment_created_at)
+    state_changed = before != handoff or activity_changed
+    return CommandExecutionResult(
+        response="✅ Recorded reviewer feedback handoff. Reviewer-bot is now waiting on contributor response.",
+        success=True,
+        state_changed=state_changed,
+    )
+
+
 def _execute_assign_specific(bot, state: dict, decision, assignment_request: AssignmentRequest | None) -> CommandExecutionResult:
     username = decision.raw_args[0] if decision.raw_args else ""
     return _build_execution_result(
@@ -314,12 +364,15 @@ def apply_comment_command(
         execution = CommandExecutionResult(response=decision.response, success=decision.success, state_changed=False)
         react = decision.react
     else:
-        assignment_request = (
-            _build_assignment_request_from_comment_request(request)
-            if decision.needs_assignment_request
-            else None
-        )
-        execution = ORDINARY_COMMAND_HANDLERS[decision.command_id](bot, state, decision, assignment_request)
+        if decision.command_id == comment_command_policy.OrdinaryCommandId.FEEDBACK:
+            execution = _execute_feedback(bot, state, request, decision)
+        else:
+            assignment_request = (
+                _build_assignment_request_from_comment_request(request)
+                if decision.needs_assignment_request
+                else None
+            )
+            execution = ORDINARY_COMMAND_HANDLERS[decision.command_id](bot, state, decision, assignment_request)
         react = True
 
     comment_id = request.comment_id

--- a/scripts/reviewer_bot_lib/comment_application.py
+++ b/scripts/reviewer_bot_lib/comment_application.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from scripts.reviewer_bot_core import (
     comment_command_policy,
     comment_freshness_policy,
+    live_review_support,
     privileged_command_policy,
 )
 
@@ -262,6 +263,26 @@ def _execute_rectify(bot, state: dict, request: CommentEventRequest, decision) -
     )
 
 
+def _handoff_order_key(handoff: dict) -> tuple[object, str] | None:
+    timestamp = live_review_support.parse_github_timestamp(handoff.get("timestamp"))
+    if timestamp is None:
+        return None
+    source_event_key = handoff.get("source_event_key")
+    return timestamp, source_event_key if isinstance(source_event_key, str) else ""
+
+
+def _feedback_handoff_should_replace(existing: object, candidate: dict) -> bool:
+    if not isinstance(existing, dict):
+        return True
+    candidate_key = _handoff_order_key(candidate)
+    existing_key = _handoff_order_key(existing)
+    if candidate_key is None:
+        return existing_key is None
+    if existing_key is None:
+        return True
+    return candidate_key >= existing_key
+
+
 def handle_feedback_command(bot, state: dict, request: CommentEventRequest, decision) -> CommandExecutionResult:
     if request.issue_state.lower() != "open":
         return CommandExecutionResult(
@@ -302,6 +323,12 @@ def handle_feedback_command(bot, state: dict, request: CommentEventRequest, deci
         "reviewed_head_sha": reviewed_head_sha,
     }
     before = review_data.get("current_cycle_reviewer_handoff")
+    if not _feedback_handoff_should_replace(before, handoff):
+        return CommandExecutionResult(
+            response="ℹ️ Ignored stale `/feedback` handoff because a newer reviewer handoff is already recorded.",
+            success=True,
+            state_changed=False,
+        )
     review_data["current_cycle_reviewer_handoff"] = handoff
     activity_changed = record_reviewer_activity(review_data, request.comment_created_at)
     state_changed = before != handoff or activity_changed
@@ -370,11 +397,11 @@ def apply_comment_command(
         return False
 
     issue_number = request.issue_number
-    review_data = ensure_review_entry(state, issue_number, create=True)
-    if review_data is None:
-        return False
     source_event_key = request.comment_source_event_key or f"issue_comment:{request.comment_id}"
     if isinstance(decision, comment_command_policy.DeferPrivilegedHandoffDecision):
+        review_data = ensure_review_entry(state, issue_number, create=True)
+        if review_data is None:
+            return False
         permission_status = bot.github.get_user_permission_status(request.comment_author, "triage")
         handoff = privileged_command_policy.validate_accept_no_fls_changes_handoff(
             request,

--- a/scripts/reviewer_bot_lib/comment_application.py
+++ b/scripts/reviewer_bot_lib/comment_application.py
@@ -133,6 +133,12 @@ def _build_execution_result(command_id: comment_command_policy.OrdinaryCommandId
 
 
 def _execute_pass(bot, state: dict, decision, assignment_request: AssignmentRequest | None) -> CommandExecutionResult:
+    reviewer_authority = assignment_flow.resolve_reviewer_command_authority(
+        bot,
+        state,
+        assignment_request,
+        actor=decision.actor,
+    )
     return _build_execution_result(
         decision.command_id,
         commands_module.handle_pass_command(
@@ -142,6 +148,7 @@ def _execute_pass(bot, state: dict, decision, assignment_request: AssignmentRequ
             decision.actor,
             " ".join(decision.raw_args) if decision.raw_args else None,
             request=assignment_request,
+            reviewer_authority=reviewer_authority,
         ),
     )
 
@@ -214,23 +221,48 @@ def _execute_claim(bot, state: dict, decision, assignment_request: AssignmentReq
 
 
 def _execute_release(bot, state: dict, decision, assignment_request: AssignmentRequest | None) -> CommandExecutionResult:
+    reviewer_authority = assignment_flow.resolve_reviewer_command_authority(
+        bot,
+        state,
+        assignment_request,
+        actor=None,
+    )
     return _build_execution_result(
         decision.command_id,
-        commands_module.handle_release_command(bot, state, decision.issue_number, decision.actor, list(decision.raw_args), request=assignment_request),
+        commands_module.handle_release_command(
+            bot,
+            state,
+            decision.issue_number,
+            decision.actor,
+            list(decision.raw_args),
+            request=assignment_request,
+            reviewer_authority=reviewer_authority,
+        ),
     )
 
 
-def _execute_rectify(bot, state: dict, decision, assignment_request: AssignmentRequest | None) -> CommandExecutionResult:
-    del assignment_request
+def _execute_rectify(bot, state: dict, request: CommentEventRequest, decision) -> CommandExecutionResult:
     from . import reconcile as reconcile_module
 
+    reviewer_authority = assignment_flow.resolve_reviewer_command_authority(
+        bot,
+        state,
+        request,
+        actor=decision.actor,
+    )
     return _build_execution_result(
         decision.command_id,
-        reconcile_module.handle_rectify_command(bot, state, decision.issue_number, decision.actor),
+        reconcile_module.handle_rectify_command(
+            bot,
+            state,
+            decision.issue_number,
+            decision.actor,
+            reviewer_authority=reviewer_authority,
+        ),
     )
 
 
-def _execute_feedback(bot, state: dict, request: CommentEventRequest, decision) -> CommandExecutionResult:
+def handle_feedback_command(bot, state: dict, request: CommentEventRequest, decision) -> CommandExecutionResult:
     if request.issue_state.lower() != "open":
         return CommandExecutionResult(
             response="❌ `/feedback` can only be used on open tracked review items.",
@@ -293,6 +325,13 @@ def _execute_assign_from_queue(bot, state: dict, decision, assignment_request: A
         decision.command_id,
         commands_module.handle_assign_from_queue_command(bot, state, decision.issue_number, request=assignment_request),
     )
+
+
+def _command_skips_freshness_recording(classified: dict) -> bool:
+    return classified.get("command") in {
+        comment_command_policy.OrdinaryCommandId.FEEDBACK.value,
+        "_malformed_feedback_args",
+    }
 
 
 ORDINARY_COMMAND_HANDLERS = {
@@ -365,7 +404,9 @@ def apply_comment_command(
         react = decision.react
     else:
         if decision.command_id == comment_command_policy.OrdinaryCommandId.FEEDBACK:
-            execution = _execute_feedback(bot, state, request, decision)
+            execution = handle_feedback_command(bot, state, request, decision)
+        elif decision.command_id == comment_command_policy.OrdinaryCommandId.RECTIFY:
+            execution = _execute_rectify(bot, state, request, decision)
         else:
             assignment_request = (
                 _build_assignment_request_from_comment_request(request)
@@ -397,7 +438,7 @@ def process_comment_event(
     classified = classify_comment_payload(bot, request.comment_body)
     routing = _route_comment_application(classified, comment_id=comment_id)
     state_changed = False
-    if routing in {"freshness_only", "both"}:
+    if routing in {"freshness_only", "both"} and not _command_skips_freshness_recording(classified):
         state_changed = record_conversation_freshness(bot, state, request) or state_changed
     if routing in {"command_only", "both"}:
         state_changed = apply_comment_command(

--- a/scripts/reviewer_bot_lib/config.py
+++ b/scripts/reviewer_bot_lib/config.py
@@ -186,7 +186,7 @@ COMMANDS = {
     "pass": "Pass this review to next in queue",
     "away": "Step away from queue until date (YYYY-MM-DD)",
     "feedback": "Record that reviewer feedback is ready for contributor follow-up",
-    "release": "Release assignment (yours, or @username with triage+ permission)",
+    "release": "Release your current reviewer assignment",
     "rectify": "Reconcile this issue/PR's review state from GitHub",
     "claim": "Claim this review for yourself",
     "r?": "Assign a reviewer (@username or 'producers')",

--- a/scripts/reviewer_bot_lib/config.py
+++ b/scripts/reviewer_bot_lib/config.py
@@ -185,6 +185,7 @@ TRANSITION_PERIOD_DAYS = 14
 COMMANDS = {
     "pass": "Pass this review to next in queue",
     "away": "Step away from queue until date (YYYY-MM-DD)",
+    "feedback": "Record that reviewer feedback is ready for contributor follow-up",
     "release": "Release assignment (yours, or @username with triage+ permission)",
     "rectify": "Reconcile this issue/PR's review state from GitHub",
     "claim": "Claim this review for yourself",

--- a/scripts/reviewer_bot_lib/guidance.py
+++ b/scripts/reviewer_bot_lib/guidance.py
@@ -48,7 +48,7 @@ If you need to pass this review:
 - `{BOT_MENTION} /pass [reason]` - Pass just this issue to the next reviewer
 - `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
 - `{BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up
-- `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
+- `{BOT_MENTION} /release [reason]` - Release your current reviewer assignment
 
 To assign someone else:
 - `{BOT_MENTION} /r? @username` - Assign a specific reviewer
@@ -81,7 +81,7 @@ If you need to pass this review:
 - `{BOT_MENTION} /pass [reason]` - Pass just this issue to the next reviewer
 - `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
 - `{BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up
-- `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
+- `{BOT_MENTION} /release [reason]` - Release your current reviewer assignment
 
 To assign someone else:
 - `{BOT_MENTION} /r? @username` - Assign a specific reviewer
@@ -119,7 +119,7 @@ If you need to pass this review:
 - `{BOT_MENTION} /pass [reason]` - Pass just this issue to the next reviewer
 - `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
 - `{BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up
-- `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
+- `{BOT_MENTION} /release [reason]` - Release your current reviewer assignment
 
 To assign someone else:
 - `{BOT_MENTION} /r? @username` - Assign a specific reviewer
@@ -165,7 +165,7 @@ If you need to pass this review:
 - `{BOT_MENTION} /pass [reason]` - Pass just this PR to the next reviewer
 - `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
 - `{BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up
-- `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
+- `{BOT_MENTION} /release [reason]` - Release your current reviewer assignment
 
 To assign someone else:
 - `{BOT_MENTION} /r? @username` - Assign a specific reviewer

--- a/scripts/reviewer_bot_lib/guidance.py
+++ b/scripts/reviewer_bot_lib/guidance.py
@@ -47,6 +47,7 @@ As outlined in our [contribution guide](CONTRIBUTING.md), please:
 If you need to pass this review:
 - `{BOT_MENTION} /pass [reason]` - Pass just this issue to the next reviewer
 - `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
+- `{BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up
 - `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
 
 To assign someone else:
@@ -79,6 +80,7 @@ When the review is complete:
 If you need to pass this review:
 - `{BOT_MENTION} /pass [reason]` - Pass just this issue to the next reviewer
 - `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
+- `{BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up
 - `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
 
 To assign someone else:
@@ -116,6 +118,7 @@ If the changes **do** affect guidelines:
 If you need to pass this review:
 - `{BOT_MENTION} /pass [reason]` - Pass just this issue to the next reviewer
 - `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
+- `{BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up
 - `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
 
 To assign someone else:
@@ -161,6 +164,7 @@ As outlined in our [contribution guide](CONTRIBUTING.md), please:
 If you need to pass this review:
 - `{BOT_MENTION} /pass [reason]` - Pass just this PR to the next reviewer
 - `{BOT_MENTION} /away YYYY-MM-DD [reason]` - Step away from the queue until a date
+- `{BOT_MENTION} /feedback` - Mark reviewer feedback ready for contributor follow-up
 - `{BOT_MENTION} /release [@username] [reason]` - Release assignment (yours or someone else's with triage+ permission)
 
 To assign someone else:

--- a/scripts/reviewer_bot_lib/lifecycle.py
+++ b/scripts/reviewer_bot_lib/lifecycle.py
@@ -13,6 +13,7 @@ from . import assignment_flow
 from .config import CODING_GUIDELINE_LABEL, TRANSITION_NOTICE_MARKER_PREFIX
 from .review_state import (
     accept_channel_event,
+    clear_current_cycle_reviewer_handoff,
     ensure_review_entry,
     mark_review_complete,
     record_transition_notice_sent,
@@ -439,6 +440,9 @@ def handle_pull_request_target_synchronize(bot, state: dict) -> bool:
     previous_review_completed_by = review_data.get("review_completed_by")
     previous_review_completion_source = review_data.get("review_completion_source")
     review_data["active_head_sha"] = head_sha
+    handoff_changed = False
+    if previous_head_sha != head_sha:
+        handoff_changed = clear_current_cycle_reviewer_handoff(review_data)
     timestamp = request.event_created_at
     changed = accept_channel_event(
         review_data,
@@ -456,7 +460,7 @@ def handle_pull_request_target_synchronize(bot, state: dict) -> bool:
         or previous_review_completed_by != review_data.get("review_completed_by")
         or previous_review_completion_source != review_data.get("review_completion_source")
     )
-    return changed or previous_head_sha != review_data.get("active_head_sha") or approval_changed
+    return changed or previous_head_sha != review_data.get("active_head_sha") or approval_changed or handoff_changed
 
 
 def maybe_record_head_observation_repair(bot, issue_number: int, review_data: dict) -> HeadObservationRepairResult:
@@ -521,6 +525,7 @@ def maybe_record_head_observation_repair(bot, issue_number: int, review_data: di
     contributor_revision = review_data.get("contributor_revision", {}).get("accepted")
     if isinstance(contributor_revision, dict) and contributor_revision.get("reviewed_head_sha") == head_sha:
         review_data["active_head_sha"] = head_sha
+        clear_current_cycle_reviewer_handoff(review_data)
         return HeadObservationRepairResult(changed=True, outcome="changed")
     changed = accept_channel_event(
         review_data,
@@ -531,6 +536,7 @@ def maybe_record_head_observation_repair(bot, issue_number: int, review_data: di
         source_precedence=0,
     )
     review_data["active_head_sha"] = head_sha
+    clear_current_cycle_reviewer_handoff(review_data)
     review_data["current_cycle_completion"] = {}
     review_data["current_cycle_write_approval"] = {}
     review_data["review_completed_at"] = None

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -10,6 +10,7 @@ from scripts.reviewer_bot_core.comment_routing_policy import (
     ObserverCommentClassification,
 )
 
+from . import assignment_flow
 from . import deferred_gap_bookkeeping as gap_bookkeeping
 from . import reconcile_payloads as _reconcile_payloads
 from .comment_application import (
@@ -188,36 +189,58 @@ def handle_rectify_command(
     issue_number: int,
     comment_author: str,
 ) -> tuple[str, bool, bool]:
-    current_assignees = bot.github.get_issue_assignees(issue_number)
-    if current_assignees is None:
+    request = type(
+        "RectifyReviewerAuthorityRequest",
+        (),
+        {
+            "issue_number": issue_number,
+            "is_pull_request": bot.get_config_value("IS_PULL_REQUEST", "false").lower() == "true",
+        },
+    )()
+    reviewer_authority = assignment_flow.resolve_reviewer_command_authority(
+        bot,
+        state,
+        request,
+        actor=comment_author,
+    )
+    if reviewer_authority.get("authorized"):
+        return reconcile_active_review_entry(bot, state, issue_number)
+    if reviewer_authority.get("authorization_status") == "live_read_unavailable":
         return (
-            "❌ Unable to determine current assignees/reviewers from GitHub; refusing to continue.",
+            assignment_flow.reviewer_command_authority_failure_message("rectify", reviewer_authority),
             False,
             False,
         )
-    current_reviewer = current_assignees[0] if len(current_assignees) == 1 else None
 
-    is_current_reviewer = (
-        isinstance(current_reviewer, str)
-        and current_reviewer.lower() == comment_author.lower()
-    )
+    triage_status = bot.github.get_user_permission_status(comment_author, "triage")
 
-    triage_status = "denied"
-    if not is_current_reviewer:
-        triage_status = bot.github.get_user_permission_status(comment_author, "triage")
-
-    if not is_current_reviewer and triage_status == "unavailable":
+    if triage_status == "unavailable":
         return (
             "❌ Unable to verify triage permissions right now; refusing to continue.",
             False,
             False,
         )
 
-    if not is_current_reviewer and triage_status != "granted":
-        if current_reviewer:
+    if triage_status != "granted":
+        current_reviewer = reviewer_authority.get("tracked_reviewer")
+        live_reviewers = reviewer_authority.get("live_control_plane_reviewers") or []
+        if reviewer_authority.get("authorization_status") == "control_plane_mismatch":
             return (
-                f"❌ Only the assigned reviewer (@{current_reviewer}) or a maintainer with triage+ "
+                assignment_flow.reviewer_command_authority_failure_message("rectify", reviewer_authority),
+                False,
+                False,
+            )
+        if isinstance(current_reviewer, str) and current_reviewer:
+            return (
+                f"❌ Only the current reviewer (@{current_reviewer}) or a maintainer with triage+ "
                 "permission can run `/rectify`.",
+                False,
+                False,
+            )
+        if live_reviewers:
+            return (
+                "❌ Only the current reviewer or a maintainer with triage+ permission can run `/rectify`. "
+                f"Live reviewer(s): @{', @'.join(str(value) for value in live_reviewers)}.",
                 False,
                 False,
             )

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -188,6 +188,7 @@ def handle_rectify_command(
     state: dict,
     issue_number: int,
     comment_author: str,
+    reviewer_authority: dict[str, object] | None = None,
 ) -> tuple[str, bool, bool]:
     request = type(
         "RectifyReviewerAuthorityRequest",
@@ -197,7 +198,7 @@ def handle_rectify_command(
             "is_pull_request": bot.get_config_value("IS_PULL_REQUEST", "false").lower() == "true",
         },
     )()
-    reviewer_authority = assignment_flow.resolve_reviewer_command_authority(
+    reviewer_authority = reviewer_authority or assignment_flow.resolve_reviewer_command_authority(
         bot,
         state,
         request,

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -204,55 +204,14 @@ def handle_rectify_command(
         request,
         actor=comment_author,
     )
+    reviewer_authority = assignment_flow.require_reviewer_command_actor(reviewer_authority, comment_author)
     if reviewer_authority.get("authorized"):
         return reconcile_active_review_entry(bot, state, issue_number)
-    if reviewer_authority.get("authorization_status") == "live_read_unavailable":
-        return (
-            assignment_flow.reviewer_command_authority_failure_message("rectify", reviewer_authority),
-            False,
-            False,
-        )
-
-    triage_status = bot.github.get_user_permission_status(comment_author, "triage")
-
-    if triage_status == "unavailable":
-        return (
-            "❌ Unable to verify triage permissions right now; refusing to continue.",
-            False,
-            False,
-        )
-
-    if triage_status != "granted":
-        current_reviewer = reviewer_authority.get("tracked_reviewer")
-        live_reviewers = reviewer_authority.get("live_control_plane_reviewers") or []
-        if reviewer_authority.get("authorization_status") == "control_plane_mismatch":
-            return (
-                assignment_flow.reviewer_command_authority_failure_message("rectify", reviewer_authority),
-                False,
-                False,
-            )
-        if isinstance(current_reviewer, str) and current_reviewer:
-            return (
-                f"❌ Only the current reviewer (@{current_reviewer}) or a maintainer with triage+ "
-                "permission can run `/rectify`.",
-                False,
-                False,
-            )
-        if live_reviewers:
-            return (
-                "❌ Only the current reviewer or a maintainer with triage+ permission can run `/rectify`. "
-                f"Live reviewer(s): @{', @'.join(str(value) for value in live_reviewers)}.",
-                False,
-                False,
-            )
-        return (
-            "❌ Only maintainers with triage+ permission can run `/rectify` when no confirmed assigned "
-            "reviewer is tracked.",
-            False,
-            False,
-        )
-
-    return reconcile_active_review_entry(bot, state, issue_number)
+    return (
+        assignment_flow.reviewer_command_authority_failure_message("rectify", reviewer_authority),
+        False,
+        False,
+    )
 
 
 def _load_deferred_context(bot: ReconcileWorkflowRuntimeContext) -> dict:

--- a/scripts/reviewer_bot_lib/review_state.py
+++ b/scripts/reviewer_bot_lib/review_state.py
@@ -51,6 +51,10 @@ def clear_current_reviewer(state: dict, issue_number: int) -> bool:
     return review_state_machine.clear_current_reviewer(state, issue_number)
 
 
+def clear_current_cycle_reviewer_handoff(review_data: dict) -> bool:
+    return review_state_machine.clear_current_cycle_reviewer_handoff(review_data)
+
+
 def semantic_key_seen(review_data: dict, channel_name: str, semantic_key: str) -> bool:
     return review_state_machine.semantic_key_seen(review_data, channel_name, semantic_key)
 

--- a/scripts/reviewer_bot_lib/reviews.py
+++ b/scripts/reviewer_bot_lib/reviews.py
@@ -117,7 +117,10 @@ def apply_pr_approval_state(
     write_approval: dict,
     current_head_sha: str,
 ) -> None:
+    previous_head_sha = review_data.get("active_head_sha")
     review_data["active_head_sha"] = current_head_sha
+    if previous_head_sha != current_head_sha:
+        review_state.clear_current_cycle_reviewer_handoff(review_data)
     review_data["current_cycle_completion"] = completion
     review_data["current_cycle_write_approval"] = write_approval
     if completion.get("completed"):

--- a/tests/contract/reviewer_bot/test_comment_application_contract.py
+++ b/tests/contract/reviewer_bot/test_comment_application_contract.py
@@ -124,6 +124,7 @@ def test_c3b2_comment_application_deletion_manifest_leaves_only_privileged_branc
     for command_name in [
         '"pass"',
         '"away"',
+        '"feedback"',
         '"label"',
         '"sync-members"',
         '"queue"',

--- a/tests/contract/reviewer_bot/test_comment_application_contract.py
+++ b/tests/contract/reviewer_bot/test_comment_application_contract.py
@@ -185,6 +185,45 @@ def test_n1_comment_application_obeys_policy_selected_handler_without_inline_com
     assert calls == [(harness.runtime, state)]
 
 
+def test_comment_application_records_feedback_handoff_from_policy_command(monkeypatch):
+    harness = CommentRoutingHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    request = harness.request(
+        issue_number=42,
+        is_pull_request=False,
+        issue_author="dana",
+        comment_author="alice",
+        comment_body="@guidelines-bot /feedback",
+        comment_created_at="2026-03-17T10:00:00Z",
+        comment_source_event_key="issue_comment:100",
+    )
+    harness.runtime.github.get_issue_assignees = lambda issue_number: ["alice"]
+    side_effects = harness.capture_comment_side_effects()
+
+    changed = comment_application.process_comment_event(
+        harness.runtime,
+        state,
+        request,
+        classify_comment_payload=comment_routing.classify_comment_payload,
+        classify_issue_comment_actor=comment_routing.classify_issue_comment_actor,
+    )
+
+    assert changed is True
+    assert review["current_cycle_reviewer_handoff"] == {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    assert side_effects.comments == [
+        (42, "✅ Recorded reviewer feedback handoff. Reviewer-bot is now waiting on contributor response.")
+    ]
+
+
 def test_comment_application_no_longer_owns_privileged_handoff_validation_or_metadata_shaping():
     module_text = Path("scripts/reviewer_bot_lib/comment_application.py").read_text(encoding="utf-8")
 

--- a/tests/contract/reviewer_bot/test_review_state_contract.py
+++ b/tests/contract/reviewer_bot/test_review_state_contract.py
@@ -73,6 +73,7 @@ def test_ensure_review_entry_initializes_tracked_review_shape():
     assert review["sidecars"]["observer_discovery_watermarks"] == {}
     assert review["sidecars"]["reconciled_source_events"] == {}
     assert review["current_cycle_write_approval"] == {}
+    assert review["current_cycle_reviewer_handoff"] is None
 
 
 def test_state_contract_table_fixture_lists_frozen_sections_and_field_classifications():
@@ -94,6 +95,7 @@ def test_state_contract_table_fixture_lists_frozen_sections_and_field_classifica
         "- pending_privileged_commands: nested under sidecars",
         "- deferred_gaps: nested under sidecars",
         "- current_cycle_write_approval: lazily materialized",
+        "- current_cycle_reviewer_handoff: lazily materialized",
         "- observer_discovery_watermarks: nested under sidecars",
         "- reconciled_source_events: nested under sidecars as a map; tolerated legacy list shape",
         "- accepted: lazily materialized",
@@ -137,6 +139,7 @@ def test_ensure_review_entry_repairs_missing_nested_maps_and_legacy_list_fields(
     assert review["sidecars"]["repair_markers"] == _expected_repair_markers()
     assert review["current_cycle_completion"] == {}
     assert review["current_cycle_write_approval"] == {}
+    assert review["current_cycle_reviewer_handoff"] is None
     assert review["sidecars"]["reconciled_source_events"] == {}
 
 
@@ -218,6 +221,34 @@ def test_mark_review_complete_updates_completion_fields():
     assert review["review_completed_by"] == "alice"
     assert review["review_completion_source"] == "unit-test"
     assert review["current_cycle_completion"]["completed"] is True
+
+
+def test_current_cycle_reviewer_handoff_is_cleared_by_reviewer_replacement_and_release():
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+
+    review_state.set_current_reviewer(state, 42, "bob", at="2026-03-17T11:00:00Z")
+
+    assert review["current_cycle_reviewer_handoff"] is None
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:101",
+        "timestamp": "2026-03-17T12:00:00Z",
+        "actor": "bob",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+
+    assert review_state.clear_current_reviewer(state, 42) is True
+    assert review["current_cycle_reviewer_handoff"] is None
 
 
 def test_list_open_tracked_review_items_returns_only_assigned_entries():

--- a/tests/contract/reviewer_bot/test_review_state_contract.py
+++ b/tests/contract/reviewer_bot/test_review_state_contract.py
@@ -252,6 +252,80 @@ def test_current_cycle_reviewer_handoff_is_cleared_by_reviewer_replacement_and_r
     assert review["current_cycle_reviewer_handoff"] is None
 
 
+def test_current_cycle_reviewer_handoff_is_cleared_by_newer_contributor_followup():
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+
+    changed = review_state.accept_channel_event(
+        review,
+        "contributor_comment",
+        semantic_key="issue_comment:101",
+        timestamp="2026-03-17T11:00:00Z",
+        actor="dana",
+    )
+
+    assert changed is True
+    assert review["current_cycle_reviewer_handoff"] is None
+
+
+def test_current_cycle_reviewer_handoff_survives_older_contributor_followup():
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    handoff = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    review["current_cycle_reviewer_handoff"] = dict(handoff)
+
+    changed = review_state.accept_channel_event(
+        review,
+        "contributor_comment",
+        semantic_key="issue_comment:99",
+        timestamp="2026-03-17T09:00:00Z",
+        actor="dana",
+    )
+
+    assert changed is True
+    assert review["current_cycle_reviewer_handoff"] == handoff
+
+
+def test_current_cycle_reviewer_handoff_is_cleared_by_newer_contributor_revision():
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": "head-1",
+    }
+
+    changed = review_state.accept_channel_event(
+        review,
+        "contributor_revision",
+        semantic_key="pull_request_sync:42:head-2",
+        timestamp="2026-03-17T11:00:00Z",
+        reviewed_head_sha="head-2",
+        source_precedence=1,
+    )
+
+    assert changed is True
+    assert review["current_cycle_reviewer_handoff"] is None
+
+
 def test_list_open_tracked_review_items_returns_only_assigned_entries():
     state = make_state()
     review_state.ensure_review_entry(state, 42, create=True)

--- a/tests/contract/reviewer_bot/test_review_state_contract.py
+++ b/tests/contract/reviewer_bot/test_review_state_contract.py
@@ -175,6 +175,7 @@ def test_review_state_mutation_inventory_freezes_overlap_classification_and_live
         "- set_current_reviewer: local-state-only mutation",
         "- update_reviewer_activity: local-state-only mutation",
         "- mark_review_complete: local-state-only mutation",
+        "- clear_current_cycle_reviewer_handoff: local-state-only mutation",
         "- get_current_cycle_boundary: read-only helper",
         "- clear_transition_timers: local-state-only mutation",
         "- semantic_key_seen: read-only helper",
@@ -269,6 +270,7 @@ def test_review_state_module_exposes_named_mutation_surface():
         "set_current_reviewer",
         "update_reviewer_activity",
         "mark_review_complete",
+        "clear_current_cycle_reviewer_handoff",
         "get_current_cycle_boundary",
         ]:
         assert hasattr(review_state, name)

--- a/tests/fixtures/equivalence/comment_command/decision_scope.json
+++ b/tests/fixtures/equivalence/comment_command/decision_scope.json
@@ -3,6 +3,7 @@
   "in_scope_command_set": [
     "pass",
     "away",
+    "feedback",
     "label",
     "sync-members",
     "queue",

--- a/tests/fixtures/equivalence/comment_command/decision_scope.json
+++ b/tests/fixtures/equivalence/comment_command/decision_scope.json
@@ -17,6 +17,7 @@
     "_multiple_commands",
     "_malformed_known",
     "_malformed_unknown",
+    "_malformed_feedback_args",
     "unknown_command"
   ],
   "deferred_command_set": [

--- a/tests/fixtures/equivalence/comment_command/decision_scope.json
+++ b/tests/fixtures/equivalence/comment_command/decision_scope.json
@@ -25,6 +25,8 @@
   ],
   "equivalence_scenarios": [
     "queue_success",
+    "feedback_success",
+    "feedback_malformed_args",
     "label_triplet_handler",
     "away_missing_date",
     "multiple_commands_warning",

--- a/tests/fixtures/equivalence/review_state/api_inventory.md
+++ b/tests/fixtures/equivalence/review_state/api_inventory.md
@@ -7,6 +7,7 @@ Local-State-Only Mutation APIs
 - update_reviewer_activity: local-state-only mutation
 - mark_review_complete: local-state-only mutation
 - clear_transition_timers: local-state-only mutation
+- clear_current_cycle_reviewer_handoff: local-state-only mutation
 
 Live-Read-Assisted Mutation APIs
 - accept_reviewer_review_from_live_review: live-read-assisted mutation; C1c in-scope

--- a/tests/fixtures/state_contracts/review_state_contract_table.md
+++ b/tests/fixtures/state_contracts/review_state_contract_table.md
@@ -37,6 +37,7 @@ Per-Review-Entry Keys
 - pending_privileged_commands: nested under sidecars
 - current_cycle_completion: lazily materialized
 - current_cycle_write_approval: lazily materialized
+- current_cycle_reviewer_handoff: lazily materialized
 - reconciled_source_events: nested under sidecars as a map; tolerated legacy list shape
 
 Per-Channel Keys

--- a/tests/unit/reviewer_bot/test_commands.py
+++ b/tests/unit/reviewer_bot/test_commands.py
@@ -825,6 +825,80 @@ def test_feedback_command_rejects_triage_actor_who_is_not_current_reviewer(monke
     assert side_effects.reactions == [(100, "eyes")]
 
 
+def test_feedback_command_does_not_materialize_review_entry_when_no_active_review(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    harness.stub_assignees([])
+    side_effects = harness.capture_comment_side_effects()
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="alice",
+        body="@guidelines-bot /feedback",
+        issue_author="dana",
+        is_pull_request=False,
+    )
+
+    changed = comment_application.apply_comment_command(
+        harness.runtime,
+        state,
+        request,
+        {"command": "feedback", "args": [], "command_count": 1},
+        classify_issue_comment_actor=lambda current_request: "repo_user_principal",
+    )
+
+    assert changed is False
+    assert "42" not in state["active_reviews"]
+    assert side_effects.comments == [(42, "❌ No active tracked review exists for this issue/PR.")]
+    assert side_effects.reactions == [(100, "eyes")]
+
+
+def test_feedback_command_does_not_overwrite_newer_handoff(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:101",
+        "timestamp": "2026-03-17T11:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    harness.stub_assignees(["alice"])
+    side_effects = harness.capture_comment_side_effects()
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="alice",
+        body="@guidelines-bot /feedback",
+        issue_author="dana",
+        is_pull_request=False,
+        comment_id=100,
+        created_at="2026-03-17T10:00:00Z",
+    )
+
+    changed = comment_application.apply_comment_command(
+        harness.runtime,
+        state,
+        request,
+        {"command": "feedback", "args": [], "command_count": 1},
+        classify_issue_comment_actor=lambda current_request: "repo_user_principal",
+    )
+
+    assert changed is False
+    assert review["current_cycle_reviewer_handoff"] == {
+        "source_event_key": "issue_comment:101",
+        "timestamp": "2026-03-17T11:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    assert side_effects.comments == [
+        (42, "ℹ️ Ignored stale `/feedback` handoff because a newer reviewer handoff is already recorded.")
+    ]
+    assert side_effects.reactions == [(100, "eyes"), (100, "+1")]
+
+
 def test_feedback_command_plus_text_does_not_record_reviewer_comment_channel(monkeypatch):
     harness = CommentRoutingHarness(monkeypatch)
     state = make_state()

--- a/tests/unit/reviewer_bot/test_commands.py
+++ b/tests/unit/reviewer_bot/test_commands.py
@@ -216,6 +216,68 @@ def test_pass_command_posts_pr_guidance_for_new_reviewer(monkeypatch):
     assert posted == [guidance.get_pr_guidance("felix91gr", "PLeVasseur")]
 
 
+def test_pass_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_empty(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    state["queue"] = [
+        {"github": "alice", "name": "Alice"},
+        {"github": "bob", "name": "Bob"},
+    ]
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    request = harness.typed_assignment_request(issue_number=42, issue_author="dana", is_pull_request=True)
+    harness.stub_assignees([])
+    harness.stub_assignment()
+    posted = []
+    harness.runtime.github.post_comment = lambda issue_number, body: posted.append(body) or True
+
+    response, success = harness.handle_pass(state, 42, "alice", None, request=request)
+
+    assert success is True
+    assert "@bob is now assigned as the reviewer." in response
+    assert review["current_reviewer"] == "bob"
+    assert posted == [guidance.get_pr_guidance("bob", "dana")]
+
+
+def test_release_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_empty(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["assignment_method"] = "round-robin"
+    request = harness.typed_assignment_request(issue_number=42, issue_author="dana", is_pull_request=True)
+    harness.stub_assignees([])
+
+    response, success = harness.handle_release(state, 42, "alice", request=request)
+
+    assert success is True
+    assert "@alice has released this review" in response
+    assert review["current_reviewer"] is None
+
+
+def test_rectify_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_empty(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    harness.runtime.set_config_value("IS_PULL_REQUEST", "true")
+    harness.stub_assignees([])
+    calls = []
+    monkeypatch.setattr(
+        reconcile,
+        "reconcile_active_review_entry",
+        lambda bot, current_state, issue_number: calls.append((bot, current_state, issue_number)) or ("rectified", True, False),
+    )
+
+    message, success, changed = harness.handle_rectify(state, 42, "alice")
+
+    assert (message, success, changed) == ("rectified", True, False)
+    assert calls == [(harness.runtime, state, 42)]
+
+
 def test_assign_from_queue_posts_guidance_only_once(monkeypatch):
     harness = CommandHarness(monkeypatch)
     state = make_state()
@@ -657,6 +719,111 @@ def test_apply_comment_command_adds_reactions_and_posts_normalized_queue_respons
     assert side_effects.reactions == [(100, "eyes"), (100, "+1")]
 
 
+def test_feedback_command_records_issue_reviewer_handoff_without_channel_acceptance(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["assigned_at"] = "2026-03-17T09:00:00Z"
+    harness.stub_assignees(["alice"])
+    side_effects = harness.capture_comment_side_effects()
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="alice",
+        body="@guidelines-bot /feedback",
+        issue_author="dana",
+        is_pull_request=False,
+    )
+
+    changed = comment_application.apply_comment_command(
+        harness.runtime,
+        state,
+        request,
+        {"command": "feedback", "args": [], "command_count": 1},
+        classify_issue_comment_actor=lambda current_request: "repo_user_principal",
+    )
+
+    assert changed is True
+    assert review["current_cycle_reviewer_handoff"] == {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    assert review["reviewer_comment"]["accepted"] is None
+    assert review["assigned_at"] == "2026-03-17T09:00:00Z"
+    assert side_effects.comments == [
+        (42, "✅ Recorded reviewer feedback handoff. Reviewer-bot is now waiting on contributor response.")
+    ]
+    assert side_effects.reactions == [(100, "eyes"), (100, "+1")]
+
+
+def test_feedback_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_empty(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["active_head_sha"] = "head-1"
+    harness.stub_assignees([])
+    side_effects = harness.capture_comment_side_effects()
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="alice",
+        body="@guidelines-bot /feedback",
+        issue_author="dana",
+        is_pull_request=True,
+    )
+
+    changed = comment_application.apply_comment_command(
+        harness.runtime,
+        state,
+        request,
+        {"command": "feedback", "args": [], "command_count": 1},
+        classify_issue_comment_actor=lambda current_request: "repo_user_principal",
+    )
+
+    assert changed is True
+    assert review["current_cycle_reviewer_handoff"]["reviewed_head_sha"] == "head-1"
+    assert side_effects.comments == [
+        (42, "✅ Recorded reviewer feedback handoff. Reviewer-bot is now waiting on contributor response.")
+    ]
+
+
+def test_feedback_command_rejects_triage_actor_who_is_not_current_reviewer(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["active_head_sha"] = "head-1"
+    harness.stub_assignees([])
+    harness.stub_permission("granted")
+    side_effects = harness.capture_comment_side_effects()
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="maintainer",
+        body="@guidelines-bot /feedback",
+        issue_author="dana",
+        is_pull_request=True,
+    )
+
+    changed = comment_application.apply_comment_command(
+        harness.runtime,
+        state,
+        request,
+        {"command": "feedback", "args": [], "command_count": 1},
+        classify_issue_comment_actor=lambda current_request: "repo_user_principal",
+    )
+
+    assert changed is False
+    assert review["current_cycle_reviewer_handoff"] is None
+    assert side_effects.comments == [(42, "❌ Only the current reviewer (@alice) can use `/feedback`.")]
+    assert side_effects.reactions == [(100, "eyes")]
+
+
 def test_manual_dispatch_marks_authorization_unavailable_for_pending_privileged_command(monkeypatch):
     harness = CommandHarness(monkeypatch)
     state = make_state()
@@ -691,6 +858,7 @@ def test_manual_dispatch_marks_authorization_unavailable_for_pending_privileged_
     ("comment_body", "expected"),
     [
         ("@guidelines-bot /queue", ("queue", [])),
+        ("@guidelines-bot /feedback", ("feedback", [])),
         ("@guidelines-bot /r? producers", ("assign-from-queue", [])),
         ("@guidelines-bot /r? @alice", ("r?-user", ["@alice"])),
         ("@guidelines-bot queue", ("_malformed_known", ["queue"])),
@@ -708,6 +876,7 @@ def test_parse_command_preserves_known_command_classification(monkeypatch, comme
             "COMMANDS": {
                 "queue",
                 "pass",
+                "feedback",
                 "label",
                 "away",
                 "claim",

--- a/tests/unit/reviewer_bot/test_commands.py
+++ b/tests/unit/reviewer_bot/test_commands.py
@@ -8,6 +8,7 @@ from scripts.reviewer_bot_lib import (
     automation,
     commands,
     comment_application,
+    comment_routing,
     guidance,
     reconcile,
     review_state,
@@ -824,6 +825,77 @@ def test_feedback_command_rejects_triage_actor_who_is_not_current_reviewer(monke
     assert side_effects.reactions == [(100, "eyes")]
 
 
+def test_feedback_command_plus_text_does_not_record_reviewer_comment_channel(monkeypatch):
+    harness = CommentRoutingHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    harness.runtime.github.get_issue_assignees = lambda issue_number: ["alice"]
+    harness.runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: harness.runtime.GitHubApiResult(
+        200,
+        ["alice"],
+        {},
+        "ok",
+        True,
+        None,
+        0,
+        None,
+    )
+    side_effects = harness.capture_comment_side_effects()
+    request = harness.request(
+        issue_number=42,
+        is_pull_request=False,
+        issue_author="dana",
+        comment_author="alice",
+        comment_body="@guidelines-bot /feedback\nadditional feedback text",
+    )
+
+    changed = comment_application.process_comment_event(
+        harness.runtime,
+        state,
+        request,
+        classify_comment_payload=comment_routing.classify_comment_payload,
+        classify_issue_comment_actor=comment_routing.classify_issue_comment_actor,
+    )
+
+    assert changed is True
+    assert review["current_cycle_reviewer_handoff"]["command_name"] == "feedback"
+    assert review["reviewer_comment"]["accepted"] is None
+    assert side_effects.comments == [
+        (42, "✅ Recorded reviewer feedback handoff. Reviewer-bot is now waiting on contributor response.")
+    ]
+
+
+def test_feedback_command_with_arguments_rejects_without_channel_mutation(monkeypatch):
+    harness = CommentRoutingHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    side_effects = harness.capture_comment_side_effects()
+    request = harness.request(
+        issue_number=42,
+        is_pull_request=False,
+        issue_author="dana",
+        comment_author="alice",
+        comment_body="@guidelines-bot /feedback please",
+    )
+
+    changed = comment_application.process_comment_event(
+        harness.runtime,
+        state,
+        request,
+        classify_comment_payload=comment_routing.classify_comment_payload,
+        classify_issue_comment_actor=comment_routing.classify_issue_comment_actor,
+    )
+
+    assert changed is False
+    assert review["current_cycle_reviewer_handoff"] is None
+    assert review["reviewer_comment"]["accepted"] is None
+    assert side_effects.comments == [(42, "❌ `/feedback` does not accept arguments. Usage: `@guidelines-bot /feedback`")]
+
+
 def test_manual_dispatch_marks_authorization_unavailable_for_pending_privileged_command(monkeypatch):
     harness = CommandHarness(monkeypatch)
     state = make_state()
@@ -859,6 +931,7 @@ def test_manual_dispatch_marks_authorization_unavailable_for_pending_privileged_
     [
         ("@guidelines-bot /queue", ("queue", [])),
         ("@guidelines-bot /feedback", ("feedback", [])),
+        ("@guidelines-bot /feedback please", ("_malformed_feedback_args", [])),
         ("@guidelines-bot /r? producers", ("assign-from-queue", [])),
         ("@guidelines-bot /r? @alice", ("r?-user", ["@alice"])),
         ("@guidelines-bot queue", ("_malformed_known", ["queue"])),
@@ -916,6 +989,14 @@ def test_comment_application_delegates_ordinary_command_decision_to_core_policy(
 
     assert "comment_command_policy" in module_text
     assert "decision = comment_command_policy.decide_comment_command(" in module_text
+
+
+def test_h1_feedback_command_surface_keeps_inline_execution_owner_explicit():
+    module_text = Path("scripts/reviewer_bot_lib/comment_application.py").read_text(encoding="utf-8")
+
+    assert "def handle_feedback_command(" in module_text
+    assert "handle_feedback_command(bot, state, request, decision)" in module_text
+    assert "assignment_flow.resolve_reviewer_command_authority(" in module_text
 
 
 def test_commands_module_exposes_rectify_handler_for_decision_adapter_surface():

--- a/tests/unit/reviewer_bot/test_commands.py
+++ b/tests/unit/reviewer_bot/test_commands.py
@@ -13,6 +13,9 @@ from scripts.reviewer_bot_lib import (
     reconcile,
     review_state,
 )
+from scripts.reviewer_bot_lib import (
+    config as config_module,
+)
 from scripts.reviewer_bot_lib.config import FLS_AUDIT_LABEL
 from tests.fixtures.commands_harness import CommandHarness
 from tests.fixtures.comment_routing_harness import CommentRoutingHarness
@@ -258,28 +261,22 @@ def test_release_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_e
     assert review["current_reviewer"] is None
 
 
-def test_release_command_resolves_reviewer_authority_before_triage_fallback(monkeypatch):
+def test_release_command_rejects_triage_actor_who_is_not_current_reviewer(monkeypatch):
     harness = CommandHarness(monkeypatch)
     state = make_state()
     review = review_state.ensure_review_entry(state, 42, create=True)
     assert review is not None
     review["current_reviewer"] = "bob"
     harness.stub_assignees(["bob"])
-    calls = []
-    original_resolver = commands.assignment_flow.resolve_reviewer_command_authority
-
-    def resolve_with_order(*args, **kwargs):
-        calls.append("resolver")
-        return original_resolver(*args, **kwargs)
-
-    monkeypatch.setattr(commands.assignment_flow, "resolve_reviewer_command_authority", resolve_with_order)
-    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": calls.append("permission") or "granted"
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": (_ for _ in ()).throw(
+        AssertionError("/release must not fall back to triage permission")
+    )
 
     response, success = harness.handle_release(state, 42, "alice", ["@bob"])
 
-    assert success is True
-    assert "@alice has released @bob" in response
-    assert calls[:2] == ["resolver", "permission"]
+    assert success is False
+    assert response == "❌ Only the current reviewer (@bob) can use `/release`."
+    assert review["current_reviewer"] == "bob"
 
 
 def test_rectify_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_empty(monkeypatch):
@@ -303,10 +300,13 @@ def test_rectify_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_e
     assert calls == [(harness.runtime, state, 42)]
 
 
-def test_rectify_command_resolves_reviewer_authority_before_triage_fallback(monkeypatch):
+def test_rectify_command_rejects_triage_actor_who_is_not_current_reviewer(monkeypatch):
     harness = CommandHarness(monkeypatch)
     state = make_state()
-    harness.stub_assignees([])
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    harness.stub_assignees(["alice"])
     calls = []
     original_resolver = reconcile.assignment_flow.resolve_reviewer_command_authority
 
@@ -315,7 +315,9 @@ def test_rectify_command_resolves_reviewer_authority_before_triage_fallback(monk
         return original_resolver(*args, **kwargs)
 
     monkeypatch.setattr(reconcile.assignment_flow, "resolve_reviewer_command_authority", resolve_with_order)
-    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": calls.append("permission") or "granted"
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": (_ for _ in ()).throw(
+        AssertionError("/rectify must not fall back to triage permission")
+    )
     monkeypatch.setattr(
         reconcile,
         "reconcile_active_review_entry",
@@ -324,8 +326,10 @@ def test_rectify_command_resolves_reviewer_authority_before_triage_fallback(monk
 
     message, success, changed = harness.handle_rectify(state, 42, "maintainer")
 
-    assert (message, success, changed) == ("rectified", True, False)
-    assert calls == ["resolver", "permission", "reconcile"]
+    assert success is False
+    assert changed is False
+    assert message == "❌ Only the current reviewer (@alice) can use `/rectify`."
+    assert calls == ["resolver"]
 
 
 def test_assign_from_queue_posts_guidance_only_once(monkeypatch):
@@ -539,19 +543,18 @@ def test_claim_command_fails_closed_when_assignees_unavailable(monkeypatch):
     assert "Unable to determine current assignees/reviewers" in response
 
 
-def test_release_command_fails_closed_when_permission_unavailable(monkeypatch):
+def test_release_command_fails_closed_for_non_current_reviewer(monkeypatch):
     harness = CommandHarness(monkeypatch)
     state = make_state()
     review = review_state.ensure_review_entry(state, 42, create=True)
     assert review is not None
     review["current_reviewer"] = "bob"
     harness.stub_assignees(["bob"])
-    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": "unavailable"
 
     response, success = harness.handle_release(state, 42, "alice", ["@bob"])
 
     assert success is False
-    assert "Unable to verify triage permissions right now" in response
+    assert response == "❌ Only the current reviewer (@bob) can use `/release`."
 
 
 def test_release_command_fails_closed_when_assignees_unavailable(monkeypatch):
@@ -577,32 +580,28 @@ def test_assign_from_queue_command_fails_closed_when_assignees_unavailable(monke
     assert "Unable to determine current assignees/reviewers" in response
 
 
-def test_handle_rectify_command_reports_permission_unavailable(monkeypatch):
+def test_handle_rectify_command_reports_live_read_unavailable(monkeypatch):
     state = make_state()
     harness = CommandHarness(monkeypatch)
-    monkeypatch.setattr(reconcile, "ensure_review_entry", lambda current, issue_number, create=False: None)
-    harness.runtime.github.get_issue_assignees = lambda issue_number: []
-    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": "unavailable"
+    harness.runtime.github.get_issue_assignees = lambda issue_number: None
 
     message, success, changed = harness.handle_rectify(state, 42, "alice")
 
     assert success is False
     assert changed is False
-    assert "Unable to verify triage permissions right now" in message
+    assert "Unable to determine current assignees/reviewers" in message
 
 
-def test_handle_rectify_command_reports_permission_denied(monkeypatch):
+def test_handle_rectify_command_reports_no_active_review(monkeypatch):
     state = make_state()
     harness = CommandHarness(monkeypatch)
-    monkeypatch.setattr(reconcile, "ensure_review_entry", lambda current, issue_number, create=False: None)
-    harness.runtime.github.get_issue_assignees = lambda issue_number: []
-    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": "denied"
+    harness.stub_assignees([])
 
     message, success, changed = harness.handle_rectify(state, 42, "alice")
 
     assert success is False
     assert changed is False
-    assert "Only maintainers with triage+ permission" in message
+    assert message == "❌ No active tracked review exists for this issue/PR."
 
 
 def test_handle_rectify_command_uses_live_assignee_truth_over_stored_reviewer(monkeypatch):
@@ -1251,6 +1250,21 @@ def test_h1_feedback_command_surface_keeps_inline_execution_owner_explicit():
     assert "def handle_feedback_command(" in module_text
     assert "handle_feedback_command(bot, state, request, decision)" in module_text
     assert "assignment_flow.resolve_reviewer_command_authority(" in module_text
+
+
+def test_h1_command_surface_documents_reviewer_only_commands(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    commands_help, success = commands.handle_commands_command(harness.runtime)
+    registry_help = config_module.get_commands_help()
+    pr_guidance = guidance.get_pr_guidance("alice", "dana")
+
+    assert success is True
+    for text in (commands_help, registry_help, pr_guidance):
+        assert "/feedback" in text
+        assert "/release [reason]" in text or "/release`" in text
+        assert "someone else's with triage+" not in text
+        assert "release other reviewers" not in text
+    assert "`@guidelines-bot /rectify` - Reconcile this issue/PR review state from GitHub (current reviewer only)" in commands_help
 
 
 def test_commands_module_exposes_rectify_handler_for_decision_adapter_surface():

--- a/tests/unit/reviewer_bot/test_commands.py
+++ b/tests/unit/reviewer_bot/test_commands.py
@@ -258,6 +258,30 @@ def test_release_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_e
     assert review["current_reviewer"] is None
 
 
+def test_release_command_resolves_reviewer_authority_before_triage_fallback(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "bob"
+    harness.stub_assignees(["bob"])
+    calls = []
+    original_resolver = commands.assignment_flow.resolve_reviewer_command_authority
+
+    def resolve_with_order(*args, **kwargs):
+        calls.append("resolver")
+        return original_resolver(*args, **kwargs)
+
+    monkeypatch.setattr(commands.assignment_flow, "resolve_reviewer_command_authority", resolve_with_order)
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": calls.append("permission") or "granted"
+
+    response, success = harness.handle_release(state, 42, "alice", ["@bob"])
+
+    assert success is True
+    assert "@alice has released @bob" in response
+    assert calls[:2] == ["resolver", "permission"]
+
+
 def test_rectify_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_empty(monkeypatch):
     harness = CommandHarness(monkeypatch)
     state = make_state()
@@ -277,6 +301,31 @@ def test_rectify_command_accepts_confirmed_pr_reviewer_when_live_reviewers_are_e
 
     assert (message, success, changed) == ("rectified", True, False)
     assert calls == [(harness.runtime, state, 42)]
+
+
+def test_rectify_command_resolves_reviewer_authority_before_triage_fallback(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    harness.stub_assignees([])
+    calls = []
+    original_resolver = reconcile.assignment_flow.resolve_reviewer_command_authority
+
+    def resolve_with_order(*args, **kwargs):
+        calls.append("resolver")
+        return original_resolver(*args, **kwargs)
+
+    monkeypatch.setattr(reconcile.assignment_flow, "resolve_reviewer_command_authority", resolve_with_order)
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": calls.append("permission") or "granted"
+    monkeypatch.setattr(
+        reconcile,
+        "reconcile_active_review_entry",
+        lambda bot, current_state, issue_number: calls.append("reconcile") or ("rectified", True, False),
+    )
+
+    message, success, changed = harness.handle_rectify(state, 42, "maintainer")
+
+    assert (message, success, changed) == ("rectified", True, False)
+    assert calls == ["resolver", "permission", "reconcile"]
 
 
 def test_assign_from_queue_posts_guidance_only_once(monkeypatch):
@@ -493,6 +542,10 @@ def test_claim_command_fails_closed_when_assignees_unavailable(monkeypatch):
 def test_release_command_fails_closed_when_permission_unavailable(monkeypatch):
     harness = CommandHarness(monkeypatch)
     state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "bob"
+    harness.stub_assignees(["bob"])
     harness.runtime.github.get_user_permission_status = lambda username, required_permission="triage": "unavailable"
 
     response, success = harness.handle_release(state, 42, "alice", ["@bob"])
@@ -894,9 +947,136 @@ def test_feedback_command_does_not_overwrite_newer_handoff(monkeypatch):
         "reviewed_head_sha": None,
     }
     assert side_effects.comments == [
-        (42, "ℹ️ Ignored stale `/feedback` handoff because a newer reviewer handoff is already recorded.")
+        (42, "ℹ️ Ignored stale `/feedback` handoff because a newer or same-time reviewer handoff is already recorded.")
     ]
     assert side_effects.reactions == [(100, "eyes"), (100, "+1")]
+
+
+def test_feedback_command_does_not_overwrite_same_timestamp_different_event(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    harness.stub_assignees(["alice"])
+    side_effects = harness.capture_comment_side_effects()
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="alice",
+        body="@guidelines-bot /feedback",
+        issue_author="dana",
+        is_pull_request=False,
+        comment_id=101,
+        created_at="2026-03-17T10:00:00Z",
+    )
+
+    changed = comment_application.apply_comment_command(
+        harness.runtime,
+        state,
+        request,
+        {"command": "feedback", "args": [], "command_count": 1},
+        classify_issue_comment_actor=lambda current_request: "repo_user_principal",
+    )
+
+    assert changed is False
+    assert review["current_cycle_reviewer_handoff"]["source_event_key"] == "issue_comment:100"
+    assert side_effects.comments == [
+        (42, "ℹ️ Ignored stale `/feedback` handoff because a newer or same-time reviewer handoff is already recorded.")
+    ]
+
+
+def test_feedback_command_replays_same_event_idempotently(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["last_reviewer_activity"] = "2026-03-17T10:00:00Z"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    harness.stub_assignees(["alice"])
+    harness.capture_comment_side_effects()
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="alice",
+        body="@guidelines-bot /feedback",
+        issue_author="dana",
+        is_pull_request=False,
+        comment_id=100,
+        created_at="2026-03-17T10:00:00Z",
+    )
+
+    changed = comment_application.apply_comment_command(
+        harness.runtime,
+        state,
+        request,
+        {"command": "feedback", "args": [], "command_count": 1},
+        classify_issue_comment_actor=lambda current_request: "repo_user_principal",
+    )
+
+    assert changed is False
+    assert review["current_cycle_reviewer_handoff"] == {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+
+
+def test_feedback_command_overwrites_older_handoff(monkeypatch):
+    harness = CommandHarness(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T09:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    harness.stub_assignees(["alice"])
+    harness.capture_comment_side_effects()
+    request = harness.typed_comment_request(
+        issue_number=42,
+        actor="alice",
+        body="@guidelines-bot /feedback",
+        issue_author="dana",
+        is_pull_request=False,
+        comment_id=101,
+        created_at="2026-03-17T10:00:00Z",
+    )
+
+    changed = comment_application.apply_comment_command(
+        harness.runtime,
+        state,
+        request,
+        {"command": "feedback", "args": [], "command_count": 1},
+        classify_issue_comment_actor=lambda current_request: "repo_user_principal",
+    )
+
+    assert changed is True
+    assert review["current_cycle_reviewer_handoff"] == {
+        "source_event_key": "issue_comment:101",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
 
 
 def test_feedback_command_plus_text_does_not_record_reviewer_comment_channel(monkeypatch):

--- a/tests/unit/reviewer_bot/test_comment_command_equivalence.py
+++ b/tests/unit/reviewer_bot/test_comment_command_equivalence.py
@@ -11,6 +11,7 @@ from tests.fixtures.reviewer_bot_recorders import record_comment_side_effects
 C3B2_DELETION_MANIFEST = [
     "pass",
     "away",
+    "feedback",
     "label",
     "sync-members",
     "queue",

--- a/tests/unit/reviewer_bot/test_comment_command_equivalence.py
+++ b/tests/unit/reviewer_bot/test_comment_command_equivalence.py
@@ -51,9 +51,6 @@ def _legacy_decide_comment_command(bot, request, classified, *, actor_class: str
 
 def _legacy_apply_ordinary_decision(bot, state: dict, request, decision: dict) -> bool:
     issue_number = request.issue_number
-    review_data = comment_application.ensure_review_entry(state, issue_number, create=True)
-    if review_data is None:
-        return False
     assignment_request = comment_application._build_assignment_request_from_comment_request(request)
     if decision["kind"] == "execute_ordinary_command":
         typed_decision = comment_command_policy.ExecuteOrdinaryCommandDecision(

--- a/tests/unit/reviewer_bot/test_comment_command_equivalence.py
+++ b/tests/unit/reviewer_bot/test_comment_command_equivalence.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from scripts.reviewer_bot_core import comment_command_policy, privileged_command_policy
-from scripts.reviewer_bot_lib import commands, comment_application
+from scripts.reviewer_bot_lib import commands, comment_application, review_state
 from scripts.reviewer_bot_lib import config as config_module
 from tests.fixtures.commands_harness import CommandHarness
 from tests.fixtures.reviewer_bot import make_state
@@ -60,7 +60,10 @@ def _legacy_apply_ordinary_decision(bot, state: dict, request, decision: dict) -
             raw_args=tuple(decision["raw_args"]),
             needs_assignment_request=decision["needs_assignment_request"],
         )
-        execution = comment_application.ORDINARY_COMMAND_HANDLERS[decision["command_id"]](bot, state, typed_decision, assignment_request if decision["needs_assignment_request"] else None)
+        if decision["command_id"] == comment_command_policy.OrdinaryCommandId.FEEDBACK:
+            execution = comment_application.handle_feedback_command(bot, state, request, typed_decision)
+        else:
+            execution = comment_application.ORDINARY_COMMAND_HANDLERS[decision["command_id"]](bot, state, typed_decision, assignment_request if decision["needs_assignment_request"] else None)
         response = execution.response
         success = execution.success
         state_changed = execution.state_changed
@@ -109,6 +112,8 @@ def test_comment_command_fixture_declares_ordinary_scope_and_deferred_privileged
     assert fixture["deferred_command_set"] == ["accept-no-fls-changes"]
     assert fixture["equivalence_scenarios"] == [
         "queue_success",
+        "feedback_success",
+        "feedback_malformed_args",
         "label_triplet_handler",
         "away_missing_date",
         "multiple_commands_warning",
@@ -198,6 +203,28 @@ def test_command_decision_equivalence_matches_legacy_for_ordinary_paths(monkeypa
             ),
         ),
         (
+            "feedback_success",
+            {"command": "feedback", "args": [], "command_count": 1},
+            CommandHarness(monkeypatch).typed_comment_request(
+                issue_number=42,
+                actor="alice",
+                body="@guidelines-bot /feedback",
+                issue_author="dana",
+                is_pull_request=False,
+            ),
+        ),
+        (
+            "feedback_malformed_args",
+            {"command": "_malformed_feedback_args", "args": [], "command_count": 1},
+            CommandHarness(monkeypatch).typed_comment_request(
+                issue_number=42,
+                actor="alice",
+                body="@guidelines-bot /feedback please",
+                issue_author="dana",
+                is_pull_request=False,
+            ),
+        ),
+        (
             "label_triplet_handler",
             {"command": "label", "args": ["+triage"], "command_count": 1},
             CommandHarness(monkeypatch).typed_comment_request(
@@ -251,6 +278,12 @@ def test_command_decision_equivalence_matches_legacy_for_ordinary_paths(monkeypa
         new_harness = CommandHarness(monkeypatch)
         old_state = make_state()
         new_state = make_state()
+        if scenario_name == "feedback_success":
+            for harness, state in ((old_harness, old_state), (new_harness, new_state)):
+                review = review_state.ensure_review_entry(state, 42, create=True)
+                assert review is not None
+                review["current_reviewer"] = "alice"
+                harness.stub_assignees(["alice"])
         old_effects = record_comment_side_effects(old_harness.runtime)
         old_decision = _legacy_decide_comment_command(
             old_harness.runtime,

--- a/tests/unit/reviewer_bot/test_comment_command_equivalence.py
+++ b/tests/unit/reviewer_bot/test_comment_command_equivalence.py
@@ -25,6 +25,7 @@ C3B2_DELETION_MANIFEST = [
     "_multiple_commands",
     "_malformed_known",
     "_malformed_unknown",
+    "_malformed_feedback_args",
     "unknown_command",
 ]
 
@@ -172,7 +173,7 @@ def test_i1_comment_policy_types_ordinary_command_output_shape(monkeypatch):
 def test_i2_comment_application_routing_does_not_reopen_command_semantics_in_adapter():
     module_text = Path("scripts/reviewer_bot_lib/comment_application.py").read_text(encoding="utf-8")
 
-    assert 'if routing in {"freshness_only", "both"}:' in module_text
+    assert 'if routing in {"freshness_only", "both"} and not _command_skips_freshness_recording(classified):' in module_text
     assert 'if routing in {"command_only", "both"}:' in module_text
     assert "if command == " not in module_text
 

--- a/tests/unit/reviewer_bot/test_core_review_state_types.py
+++ b/tests/unit/reviewer_bot/test_core_review_state_types.py
@@ -7,11 +7,19 @@ def test_core_review_state_types_are_limited_to_c1_mutation_scope():
     assert is_dataclass(review_state_types.AcceptedChannelRecord)
     assert is_dataclass(review_state_types.DismissalAcceptedRecord)
     assert is_dataclass(review_state_types.ReviewChannelState)
+    assert is_dataclass(review_state_types.CurrentCycleReviewerHandoff)
     assert is_dataclass(review_state_types.ReviewEntryState)
 
     assert [field.name for field in fields(review_state_types.ReviewChannelState)] == [
         "accepted",
         "seen_keys",
+    ]
+    assert [field.name for field in fields(review_state_types.CurrentCycleReviewerHandoff)] == [
+        "source_event_key",
+        "timestamp",
+        "actor",
+        "command_name",
+        "reviewed_head_sha",
     ]
     assert [field.name for field in fields(review_state_types.ReviewEntryState)] == [
         "skipped",

--- a/tests/unit/reviewer_bot/test_core_review_state_types.py
+++ b/tests/unit/reviewer_bot/test_core_review_state_types.py
@@ -40,6 +40,7 @@ def test_core_review_state_types_are_limited_to_c1_mutation_scope():
         "review_dismissal",
         "current_cycle_completion",
         "current_cycle_write_approval",
+        "current_cycle_reviewer_handoff",
     ]
 
 
@@ -50,6 +51,7 @@ def test_core_review_state_types_preserve_current_sparse_and_precedence_shapes()
     assert entry.mandatory_approver_required is False
     assert entry.current_cycle_completion == {}
     assert entry.current_cycle_write_approval == {}
+    assert entry.current_cycle_reviewer_handoff is None
     assert entry.reviewer_comment.seen_keys == []
 
     accepted = review_state_types.AcceptedChannelRecord(

--- a/tests/unit/reviewer_bot/test_core_state_adapters.py
+++ b/tests/unit/reviewer_bot/test_core_state_adapters.py
@@ -61,6 +61,13 @@ def test_review_entry_adapter_round_trips_full_current_mutation_shape():
             "reviewer": "bob",
         },
         "current_cycle_write_approval": {"approved": False},
+        "current_cycle_reviewer_handoff": {
+            "source_event_key": "issue_comment:13",
+            "timestamp": "2026-03-20T04:00:00Z",
+            "actor": "bob",
+            "command_name": "feedback",
+            "reviewed_head_sha": "head-1",
+        },
     }
 
     adapted = state_adapters.review_entry_from_persisted(persisted)
@@ -100,6 +107,7 @@ def test_review_entry_adapter_matches_current_sparse_upgrade_semantics():
         "review_dismissal": {"accepted": None, "seen_keys": []},
         "current_cycle_completion": {},
         "current_cycle_write_approval": {},
+        "current_cycle_reviewer_handoff": None,
     }
 
 

--- a/tests/unit/reviewer_bot/test_core_state_adapters.py
+++ b/tests/unit/reviewer_bot/test_core_state_adapters.py
@@ -111,6 +111,33 @@ def test_review_entry_adapter_matches_current_sparse_upgrade_semantics():
     }
 
 
+def test_review_entry_adapter_drops_malformed_reviewer_handoff_shapes():
+    valid = {
+        "source_event_key": "issue_comment:13",
+        "timestamp": "2026-03-20T04:00:00Z",
+        "actor": "bob",
+        "command_name": "feedback",
+        "reviewed_head_sha": "head-1",
+    }
+    malformed_payloads = [
+        {**valid, "unexpected": "value"},
+        {key: value for key, value in valid.items() if key != "actor"},
+        {**valid, "source_event_key": ""},
+        {**valid, "timestamp": None},
+        {**valid, "actor": ""},
+        {**valid, "command_name": "pass"},
+        {**valid, "reviewed_head_sha": 42},
+    ]
+
+    for malformed in malformed_payloads:
+        adapted = state_adapters.review_entry_from_persisted(
+            {"current_cycle_reviewer_handoff": malformed}
+        )
+
+        assert adapted is not None
+        assert state_adapters.review_entry_to_persisted(adapted)["current_cycle_reviewer_handoff"] is None
+
+
 def test_review_entry_adapter_returns_none_for_unusable_persisted_shape():
     state = make_state()
     state["active_reviews"]["42"] = "broken"

--- a/tests/unit/reviewer_bot/test_lifecycle.py
+++ b/tests/unit/reviewer_bot/test_lifecycle.py
@@ -603,6 +603,26 @@ def test_handle_reopened_event_reopens_done_completion(monkeypatch):
     assert review["review_completion_source"] is None
 
 
+def test_handle_closed_event_removes_reviewer_handoff_with_review_entry(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+
+    assert lifecycle.handle_closed_event(runtime, state) is True
+    assert "42" not in state["active_reviews"]
+
+
 def test_maybe_record_head_observation_repair_uses_github_api_fallback_after_system_exit(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     review_data = {"active_head_sha": "head-0", "contributor_revision": {"accepted": None}}

--- a/tests/unit/reviewer_bot/test_lifecycle.py
+++ b/tests/unit/reviewer_bot/test_lifecycle.py
@@ -25,6 +25,13 @@ def test_handle_pull_request_target_synchronize_returns_true_for_head_only_mutat
     assert review is not None
     review["current_reviewer"] = "alice"
     review["active_head_sha"] = "head-1"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T09:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": "head-1",
+    }
     review["contributor_revision"]["seen_keys"] = ["pull_request_sync:42:head-2"]
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("PR_HEAD_SHA", "head-2")
@@ -33,6 +40,7 @@ def test_handle_pull_request_target_synchronize_returns_true_for_head_only_mutat
 
     assert lifecycle.handle_pull_request_target_synchronize(runtime, state) is True
     assert review["active_head_sha"] == "head-2"
+    assert review["current_cycle_reviewer_handoff"] is None
 
 
 def test_pr_comment_direct_path_is_epoch_gated(monkeypatch):
@@ -361,6 +369,13 @@ def test_maybe_record_head_observation_repair_records_changed_head_once(monkeypa
     review_data = {
         "active_head_sha": "head-1",
         "contributor_revision": {"accepted": None},
+        "current_cycle_reviewer_handoff": {
+            "source_event_key": "issue_comment:100",
+            "timestamp": "2026-03-17T09:00:00Z",
+            "actor": "alice",
+            "command_name": "feedback",
+            "reviewed_head_sha": "head-1",
+        },
         "current_cycle_completion": {"completed": True},
         "current_cycle_write_approval": {"has_write_approval": True},
         "review_completed_at": "2026-03-10T00:00:00Z",
@@ -385,6 +400,7 @@ def test_maybe_record_head_observation_repair_records_changed_head_once(monkeypa
     assert result.outcome == "changed"
     assert result.changed is True
     assert review_data["active_head_sha"] == "head-2"
+    assert review_data["current_cycle_reviewer_handoff"] is None
     assert accepted[0][0] == "contributor_revision"
     assert accepted[0][1]["semantic_key"] == "pull_request_head_observed:42:head-2"
     assert review_data["current_cycle_completion"] == {}

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -549,6 +549,50 @@ def test_k1g_rectify_reconcile_entrypoints_use_finalized_rectify_runtime_protoco
     assert rebuild_hints["bot"] is ReconcileRectifyRuntimeContext
 
 
+def test_rectify_accepts_current_reviewer_when_pr_live_reviewers_are_empty(monkeypatch):
+    bot = FakeReviewerBotRuntime(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    bot.set_config_value("IS_PULL_REQUEST", "true")
+    bot.github.get_issue_assignees = lambda issue_number: []
+    calls = []
+    monkeypatch.setattr(
+        reconcile,
+        "reconcile_active_review_entry",
+        lambda runtime, current_state, issue_number: calls.append((runtime, current_state, issue_number)) or ("rectified", True, False),
+    )
+
+    message, success, changed = reconcile.handle_rectify_command(bot, state, 42, "alice")
+
+    assert (message, success, changed) == ("rectified", True, False)
+    assert calls == [(bot, state, 42)]
+
+
+def test_rectify_rejects_non_current_reviewer_without_triage_fallback(monkeypatch):
+    bot = FakeReviewerBotRuntime(monkeypatch)
+    state = make_state()
+    review = review_state.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    bot.github.get_issue_assignees = lambda issue_number: ["alice"]
+    bot.github.get_user_permission_status = lambda username, required_permission="triage": (_ for _ in ()).throw(
+        AssertionError("/rectify must not fall back to triage permission")
+    )
+    monkeypatch.setattr(
+        reconcile,
+        "reconcile_active_review_entry",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("non-current reviewer must not reconcile")),
+    )
+
+    message, success, changed = reconcile.handle_rectify_command(bot, state, 42, "maintainer")
+
+    assert success is False
+    assert changed is False
+    assert message == "❌ Only the current reviewer (@alice) can use `/rectify`."
+
+
 def test_k1d_rectify_refresh_keeps_retained_owner_boundaries_explicit_in_reconcile_source():
     reconcile_text = Path("scripts/reviewer_bot_lib/reconcile.py").read_text(encoding="utf-8")
     context_text = Path("scripts/reviewer_bot_lib/runtime_protocols.py").read_text(encoding="utf-8")

--- a/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
+++ b/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
@@ -490,7 +490,7 @@ def test_issue_feedback_handoff_before_cycle_boundary_is_not_consumed():
     assert result["current_cycle_reviewer_handoff"] is None
 
 
-def test_issue_feedback_handoff_is_consumed_as_stale_after_newer_contributor_followup():
+def test_issue_feedback_handoff_is_cleared_after_newer_contributor_followup():
     state = make_state()
     review = make_tracked_review_state(
         state,
@@ -516,8 +516,9 @@ def test_issue_feedback_handoff_is_consumed_as_stale_after_newer_contributor_fol
     result = reviewer_response_policy.derive_reviewer_response_state(review, issue_is_pull_request=False)
 
     assert result["state"] == "awaiting_reviewer_response"
-    assert result["reason"] == "contributor_comment_newer"
-    assert result["anchor_timestamp"] == "2026-03-17T11:00:00Z"
+    assert result["reason"] == "no_reviewer_activity"
+    assert result["current_cycle_reviewer_handoff"] is None
+    assert review["current_cycle_reviewer_handoff"] is None
 
 
 def test_pr_feedback_handoff_requires_current_tracked_head():

--- a/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
+++ b/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
@@ -412,6 +412,96 @@ def test_issue_reviewer_response_returns_to_reviewer_after_contributor_followup(
     assert result["anchor_timestamp"] == "2026-03-18T11:00:00Z"
 
 
+def test_issue_feedback_handoff_returns_turn_to_contributor_without_channel_record():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+
+    result = reviewer_response_policy.derive_reviewer_response_state(review, issue_is_pull_request=False)
+
+    assert result["state"] == "awaiting_contributor_response"
+    assert result["reason"] == "completion_missing"
+    assert result["anchor_timestamp"] == "2026-03-17T10:00:00Z"
+    assert result["current_cycle_reviewer_handoff"]["semantic_key"] == "issue_comment:100"
+    assert review["reviewer_comment"]["accepted"] is None
+
+
+def test_issue_feedback_handoff_is_consumed_as_stale_after_newer_contributor_followup():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    accept_contributor_comment(
+        review,
+        semantic_key="issue_comment:101",
+        timestamp="2026-03-17T11:00:00Z",
+        actor="dana",
+    )
+
+    result = reviewer_response_policy.derive_reviewer_response_state(review, issue_is_pull_request=False)
+
+    assert result["state"] == "awaiting_reviewer_response"
+    assert result["reason"] == "contributor_comment_newer"
+    assert result["anchor_timestamp"] == "2026-03-17T11:00:00Z"
+
+
+def test_pr_feedback_handoff_requires_current_tracked_head():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": "head-1",
+    }
+
+    current_head_result = reviewer_response_policy.derive_reviewer_response_state(
+        review,
+        issue_is_pull_request=True,
+        current_head="head-1",
+    )
+    stale_head_result = reviewer_response_policy.derive_reviewer_response_state(
+        review,
+        issue_is_pull_request=True,
+        current_head="head-2",
+    )
+
+    assert current_head_result["state"] == "awaiting_contributor_response"
+    assert current_head_result["reason"] == "accepted_same_scope_reviewer_activity"
+    assert stale_head_result["state"] == "awaiting_reviewer_response"
+    assert stale_head_result["reason"] == "no_reviewer_activity"
+
+
 def test_issue_reviewer_response_ignores_prior_reviewer_records_after_reviewer_change():
     state = make_state()
     review = make_tracked_review_state(

--- a/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
+++ b/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
@@ -521,6 +521,41 @@ def test_issue_feedback_handoff_is_cleared_after_newer_contributor_followup():
     assert review["current_cycle_reviewer_handoff"] is None
 
 
+def test_issue_feedback_handoff_is_ignored_when_persisted_with_newer_contributor_followup():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+    review["contributor_comment"] = {
+        "accepted": {
+            "semantic_key": "issue_comment:101",
+            "timestamp": "2026-03-17T11:00:00Z",
+            "actor": "dana",
+            "reviewed_head_sha": None,
+            "source_precedence": 1,
+            "payload": {},
+        },
+        "seen_keys": ["issue_comment:101"],
+    }
+
+    result = reviewer_response_policy.derive_reviewer_response_state(review, issue_is_pull_request=False)
+
+    assert result["state"] == "awaiting_reviewer_response"
+    assert result["reason"] == "no_reviewer_activity"
+    assert result["current_cycle_reviewer_handoff"] is None
+
+
 def test_pr_feedback_handoff_requires_current_tracked_head():
     state = make_state()
     review = make_tracked_review_state(
@@ -553,6 +588,46 @@ def test_pr_feedback_handoff_requires_current_tracked_head():
     assert current_head_result["reason"] == "accepted_same_scope_reviewer_activity"
     assert stale_head_result["state"] == "awaiting_reviewer_response"
     assert stale_head_result["reason"] == "no_reviewer_activity"
+
+
+def test_pr_feedback_handoff_is_ignored_when_persisted_with_newer_contributor_revision():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["active_head_sha"] = "head-2"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": "head-2",
+    }
+    review["contributor_revision"] = {
+        "accepted": {
+            "semantic_key": "pull_request_sync:42:head-2",
+            "timestamp": "2026-03-17T11:00:00Z",
+            "actor": "dana",
+            "reviewed_head_sha": "head-2",
+            "source_precedence": 1,
+            "payload": {},
+        },
+        "seen_keys": ["pull_request_sync:42:head-2"],
+    }
+
+    result = reviewer_response_policy.derive_reviewer_response_state(
+        review,
+        issue_is_pull_request=True,
+        current_head="head-2",
+    )
+
+    assert result["state"] == "awaiting_reviewer_response"
+    assert result["reason"] == "no_reviewer_activity"
+    assert result["current_cycle_reviewer_handoff"] is None
 
 
 def test_pr_feedback_handoff_overrides_existing_approval_completion_without_clearing_it():

--- a/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
+++ b/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
@@ -438,6 +438,58 @@ def test_issue_feedback_handoff_returns_turn_to_contributor_without_channel_reco
     assert review["reviewer_comment"]["accepted"] is None
 
 
+def test_issue_feedback_handoff_overrides_existing_completion_without_clearing_it():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["review_completed_at"] = "2026-03-17T09:30:00Z"
+    review["review_completion_source"] = "command: /done"
+    review["current_cycle_completion"] = {"completed": True}
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+
+    result = reviewer_response_policy.derive_reviewer_response_state(review, issue_is_pull_request=False)
+
+    assert result["state"] == "awaiting_contributor_response"
+    assert result["reason"] == "completion_missing"
+    assert review["review_completed_at"] == "2026-03-17T09:30:00Z"
+    assert review["current_cycle_completion"] == {"completed": True}
+
+
+def test_issue_feedback_handoff_before_cycle_boundary_is_not_consumed():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T08:59:59Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": None,
+    }
+
+    result = reviewer_response_policy.derive_reviewer_response_state(review, issue_is_pull_request=False)
+
+    assert result["state"] == "awaiting_reviewer_response"
+    assert result["reason"] == "no_reviewer_activity"
+    assert result["current_cycle_reviewer_handoff"] is None
+
+
 def test_issue_feedback_handoff_is_consumed_as_stale_after_newer_contributor_followup():
     state = make_state()
     review = make_tracked_review_state(
@@ -500,6 +552,44 @@ def test_pr_feedback_handoff_requires_current_tracked_head():
     assert current_head_result["reason"] == "accepted_same_scope_reviewer_activity"
     assert stale_head_result["state"] == "awaiting_reviewer_response"
     assert stale_head_result["reason"] == "no_reviewer_activity"
+
+
+def test_pr_feedback_handoff_overrides_existing_approval_completion_without_clearing_it():
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["current_cycle_completion"] = {"completed": True}
+    review["current_cycle_write_approval"] = {"has_write_approval": True}
+    review["review_completed_at"] = "2026-03-17T09:30:00Z"
+    review["review_completion_source"] = "live_review_rebuild"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T10:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": "head-1",
+    }
+
+    result = reviewer_response_policy.derive_reviewer_response_state(
+        review,
+        issue_is_pull_request=True,
+        current_head="head-1",
+        approval_result={
+            "ok": True,
+            "completion": {"completed": True},
+            "write_approval": {"has_write_approval": True},
+        },
+    )
+
+    assert result["state"] == "awaiting_contributor_response"
+    assert result["reason"] == "accepted_same_scope_reviewer_activity"
+    assert review["review_completed_at"] == "2026-03-17T09:30:00Z"
+    assert review["current_cycle_write_approval"] == {"has_write_approval": True}
 
 
 def test_issue_reviewer_response_ignores_prior_reviewer_records_after_reviewer_change():

--- a/tests/unit/reviewer_bot/test_reviews_projection.py
+++ b/tests/unit/reviewer_bot/test_reviews_projection.py
@@ -148,6 +148,14 @@ def test_compute_pr_approval_state_result_is_pure():
 
 def test_apply_pr_approval_state_mutates_expected_fields():
     review = make_tracked_review_state(make_state(), 42)
+    review["active_head_sha"] = "head-0"
+    review["current_cycle_reviewer_handoff"] = {
+        "source_event_key": "issue_comment:100",
+        "timestamp": "2026-03-17T09:00:00Z",
+        "actor": "alice",
+        "command_name": "feedback",
+        "reviewed_head_sha": "head-0",
+    }
 
     reviews.apply_pr_approval_state(
         review,
@@ -157,6 +165,7 @@ def test_apply_pr_approval_state_mutates_expected_fields():
     )
 
     assert review["active_head_sha"] == "head-1"
+    assert review["current_cycle_reviewer_handoff"] is None
     assert review["current_cycle_completion"]["completed"] is True
     assert review["current_cycle_write_approval"]["has_write_approval"] is True
     assert review["review_completion_source"] == "live_review_rebuild"


### PR DESCRIPTION
## Summary
- execute retained post-incident hardening slice H1
- keep the change inside the frozen v19 hardening boundary for branch refactor/reviewer-bot-pr264-post-incident-hardening-v19-h1

## Verification
- chosen slice verification floor and deterministic additional tests from the v19 hardening plan
- artifact: /home/pete.levasseur/opencode-project-agents/safety-critical-rust-coding-guidelines/reviewer-bot/pr264-post-incident-hardening-v19/hardening-h1-local-proof.json
