### PR TITLE
refactor: clean reviewer workflow provenance

### DIFF
--- a/.github/workflows/reviewer-bot-issue-comment-direct.yml
+++ b/.github/workflows/reviewer-bot-issue-comment-direct.yml
@@ -65,7 +65,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app != null }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app && 'true' || 'false' }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/reviewer-bot-issue-comment-direct.yml
+++ b/.github/workflows/reviewer-bot-issue-comment-direct.yml
@@ -65,7 +65,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app && 'true' || 'false' }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ toJson(github.event.comment.performed_via_github_app) != 'null' && toJson(github.event.comment.performed_via_github_app) != 'false' && 'true' || 'false' }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/reviewer-bot-issue-comment-direct.yml
+++ b/.github/workflows/reviewer-bot-issue-comment-direct.yml
@@ -65,7 +65,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ toJson(github.event.comment.performed_via_github_app) != 'null' && toJson(github.event.comment.performed_via_github_app) != 'false' && 'true' || 'false' }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app.id > 0 && 'true' || 'false' }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/reviewer-bot-issues.yml
+++ b/.github/workflows/reviewer-bot-issues.yml
@@ -54,8 +54,9 @@ jobs:
           ISSUE_STATE: ${{ github.event.issue.state }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
           ISSUE_UPDATED_AT: ${{ github.event.issue.updated_at }}
-          EVENT_CREATED_AT: ${{ github.event.issue.updated_at }}
+          ISSUE_CLOSED_AT: ${{ github.event.issue.closed_at }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
           ISSUE_LABELS: ${{ toJson(github.event.issue.labels.*.name) }}

--- a/.github/workflows/reviewer-bot-pr-comment-router.yml
+++ b/.github/workflows/reviewer-bot-pr-comment-router.yml
@@ -53,8 +53,17 @@ jobs:
           comment_user_type = str((comment.get('user') or {}).get('type') or '').strip()
           comment_sender_type = str(sender.get('type') or '').strip()
           comment_author_association = str(comment.get('author_association') or '').strip()
-          performed_via_github_app_value = comment.get('performed_via_github_app')
-          performed_via_github_app = performed_via_github_app_value is True or isinstance(performed_via_github_app_value, dict)
+          def _performed_via_github_app_truth(value):
+              if isinstance(value, bool):
+                  return value
+              if isinstance(value, dict):
+                  try:
+                      return int(value.get('id') or 0) > 0
+                  except (TypeError, ValueError):
+                      return False
+              return False
+
+          performed_via_github_app = _performed_via_github_app_truth(comment.get('performed_via_github_app'))
           installation_id = installation.get('id')
           route_outcome = 'trusted_direct'
           pr_head_full_name = ''
@@ -190,7 +199,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ toJson(github.event.comment.performed_via_github_app) != 'null' && toJson(github.event.comment.performed_via_github_app) != 'false' && 'true' || 'false' }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app.id > 0 && 'true' || 'false' }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_HEAD_FULL_NAME: ${{ needs.route-pr-comment.outputs.pr_head_full_name }}
           PR_AUTHOR: ${{ needs.route-pr-comment.outputs.pr_author }}

--- a/.github/workflows/reviewer-bot-pr-comment-router.yml
+++ b/.github/workflows/reviewer-bot-pr-comment-router.yml
@@ -189,7 +189,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app != null }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app && 'true' || 'false' }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_HEAD_FULL_NAME: ${{ needs.route-pr-comment.outputs.pr_head_full_name }}
           PR_AUTHOR: ${{ needs.route-pr-comment.outputs.pr_author }}

--- a/.github/workflows/reviewer-bot-pr-comment-router.yml
+++ b/.github/workflows/reviewer-bot-pr-comment-router.yml
@@ -53,7 +53,8 @@ jobs:
           comment_user_type = str((comment.get('user') or {}).get('type') or '').strip()
           comment_sender_type = str(sender.get('type') or '').strip()
           comment_author_association = str(comment.get('author_association') or '').strip()
-          performed_via_github_app = bool(comment.get('performed_via_github_app'))
+          performed_via_github_app_value = comment.get('performed_via_github_app')
+          performed_via_github_app = performed_via_github_app_value is True or isinstance(performed_via_github_app_value, dict)
           installation_id = installation.get('id')
           route_outcome = 'trusted_direct'
           pr_head_full_name = ''
@@ -189,7 +190,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app && 'true' || 'false' }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ toJson(github.event.comment.performed_via_github_app) != 'null' && toJson(github.event.comment.performed_via_github_app) != 'false' && 'true' || 'false' }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_HEAD_FULL_NAME: ${{ needs.route-pr-comment.outputs.pr_head_full_name }}
           PR_AUTHOR: ${{ needs.route-pr-comment.outputs.pr_author }}

--- a/.github/workflows/reviewer-bot-pr-metadata.yml
+++ b/.github/workflows/reviewer-bot-pr-metadata.yml
@@ -2,7 +2,7 @@ name: Reviewer Bot PR Metadata
 
 on:
   pull_request_target:
-    types: [opened, labeled, closed, synchronize]
+    types: [opened, labeled, unlabeled, reopened, closed, synchronize]
 
 permissions:
   contents: read
@@ -53,7 +53,9 @@ jobs:
           ISSUE_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           IS_PULL_REQUEST: 'true'
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_CREATED_AT: ${{ github.event.pull_request.updated_at }}
+          PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
+          PR_UPDATED_AT: ${{ github.event.pull_request.updated_at }}
+          PR_CLOSED_AT: ${{ github.event.pull_request.closed_at }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
+++ b/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
@@ -28,7 +28,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app && 'true' || 'false' }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ toJson(github.event.comment.performed_via_github_app) != 'null' && toJson(github.event.comment.performed_via_github_app) != 'false' && 'true' || 'false' }}
         run: |
           python - <<'PY'
           import json

--- a/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
+++ b/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
@@ -28,7 +28,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app != null }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app && 'true' || 'false' }}
         run: |
           python - <<'PY'
           import json

--- a/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
+++ b/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
@@ -28,7 +28,7 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
-          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ toJson(github.event.comment.performed_via_github_app) != 'null' && toJson(github.event.comment.performed_via_github_app) != 'false' && 'true' || 'false' }}
+          COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app.id > 0 && 'true' || 'false' }}
         run: |
           python - <<'PY'
           import json

--- a/scripts/reviewer_bot_lib/app.py
+++ b/scripts/reviewer_bot_lib/app.py
@@ -60,7 +60,6 @@ def _classify_event_intent_from_context(bot: AppEventContextRuntime, context: Ev
             "unassigned",
             "reopened",
             "closed",
-            "synchronize",
         }:
             return bot.EVENT_INTENT_MUTATING
         return bot.EVENT_INTENT_NON_MUTATING_READONLY

--- a/scripts/reviewer_bot_lib/app.py
+++ b/scripts/reviewer_bot_lib/app.py
@@ -50,7 +50,7 @@ def _classify_event_intent_from_context(bot: AppEventContextRuntime, context: Ev
     event_name = context.event_name
     event_action = context.event_action
 
-    if event_name in {"issues", "pull_request_target"}:
+    if event_name == "issues":
         if event_action in {
             "opened",
             "edited",
@@ -62,6 +62,11 @@ def _classify_event_intent_from_context(bot: AppEventContextRuntime, context: Ev
             "closed",
             "synchronize",
         }:
+            return bot.EVENT_INTENT_MUTATING
+        return bot.EVENT_INTENT_NON_MUTATING_READONLY
+
+    if event_name == "pull_request_target":
+        if event_action in {"opened", "labeled", "unlabeled", "reopened", "closed", "synchronize"}:
             return bot.EVENT_INTENT_MUTATING
         return bot.EVENT_INTENT_NON_MUTATING_READONLY
 
@@ -204,6 +209,10 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
                 state_changed = bot.handlers.handle_issue_or_pr_opened(state)
             elif event_action == "labeled":
                 state_changed = bot.handlers.handle_labeled_event(state)
+            elif event_action == "unlabeled":
+                state_changed = bot.handlers.handle_unlabeled_event(state)
+            elif event_action == "reopened":
+                state_changed = bot.handlers.handle_reopened_event(state)
             elif event_action == "closed":
                 state_changed = bot.handlers.handle_closed_event(state)
             elif event_action == "synchronize":

--- a/scripts/reviewer_bot_lib/event_inputs.py
+++ b/scripts/reviewer_bot_lib/event_inputs.py
@@ -118,22 +118,48 @@ def _parse_route_outcome(value: str) -> PrCommentRouterOutcome | None:
         return None
 
 
-def _derive_lifecycle_event_created_at(bot: EventInputsContext, *, action: str, is_pull_request: bool) -> str:
+def _lifecycle_timestamp_config_name(*, action: str, is_pull_request: bool) -> str | None:
     if is_pull_request:
         if action == "opened":
-            return bot.get_config_value("PR_CREATED_AT").strip()
+            return "PR_CREATED_AT"
         if action == "closed":
-            return bot.get_config_value("PR_CLOSED_AT").strip()
+            return "PR_CLOSED_AT"
         if action in {"labeled", "unlabeled", "reopened", "synchronize"}:
-            return bot.get_config_value("PR_UPDATED_AT").strip()
-        return ""
+            return "PR_UPDATED_AT"
+        return None
     if action == "opened":
-        return bot.get_config_value("ISSUE_CREATED_AT").strip()
+        return "ISSUE_CREATED_AT"
     if action == "closed":
-        return bot.get_config_value("ISSUE_CLOSED_AT").strip()
+        return "ISSUE_CLOSED_AT"
     if action in {"edited", "assigned", "unassigned", "labeled", "unlabeled", "reopened"}:
-        return bot.get_config_value("ISSUE_UPDATED_AT").strip()
-    return ""
+        return "ISSUE_UPDATED_AT"
+    return None
+
+
+def _derive_lifecycle_event_created_at(bot: EventInputsContext, *, action: str, is_pull_request: bool) -> str:
+    config_name = _lifecycle_timestamp_config_name(action=action, is_pull_request=is_pull_request)
+    if config_name is None:
+        return ""
+    return bot.get_config_value(config_name).strip()
+
+
+def _validate_lifecycle_event_created_at(
+    builder: str,
+    *,
+    action: str,
+    is_pull_request: bool,
+    event_created_at: str,
+) -> None:
+    config_name = _lifecycle_timestamp_config_name(action=action, is_pull_request=is_pull_request)
+    if config_name is None:
+        return
+    problems: list[str] = []
+    if not event_created_at:
+        problems.append(f"{config_name} must be non-empty for {action}")
+    elif not _is_parseable_iso8601(event_created_at):
+        problems.append(f"{config_name} must be parseable ISO-8601 for {action}")
+    if problems:
+        _raise_invalid(builder, problems)
 
 
 def _read_workflow_run_name(bot: EventInputsContext) -> str:
@@ -360,8 +386,20 @@ def build_manual_dispatch_request(bot: EventInputsContext) -> ManualDispatchRequ
 
 
 def build_issue_lifecycle_request(bot: EventInputsContext) -> IssueLifecycleRequest:
+    builder = "build_issue_lifecycle_request"
     event_action = bot.get_config_value("EVENT_ACTION").strip()
     is_pull_request = bool(_parse_optional_bool(bot.get_config_value("IS_PULL_REQUEST")))
+    event_created_at = _derive_lifecycle_event_created_at(
+        bot,
+        action=event_action,
+        is_pull_request=is_pull_request,
+    )
+    _validate_lifecycle_event_created_at(
+        builder,
+        action=event_action,
+        is_pull_request=is_pull_request,
+        event_created_at=event_created_at,
+    )
     return IssueLifecycleRequest(
         event_action=event_action,
         issue_number=_parse_optional_int(bot.get_config_value("ISSUE_NUMBER")) or 0,
@@ -377,11 +415,7 @@ def build_issue_lifecycle_request(bot: EventInputsContext) -> IssueLifecycleRequ
         previous_title=bot.get_config_value("ISSUE_CHANGES_TITLE_FROM"),
         previous_body=bot.get_config_value("ISSUE_CHANGES_BODY_FROM"),
         pr_head_sha=bot.get_config_value("PR_HEAD_SHA").strip(),
-        event_created_at=_derive_lifecycle_event_created_at(
-            bot,
-            action=event_action,
-            is_pull_request=is_pull_request,
-        ),
+        event_created_at=event_created_at,
     )
 
 
@@ -394,10 +428,17 @@ def build_label_event_request(bot: EventInputsContext) -> LabelEventRequest:
 
 
 def build_pull_request_sync_request(bot: EventInputsContext) -> PullRequestSyncRequest:
+    event_created_at = _derive_lifecycle_event_created_at(bot, action="synchronize", is_pull_request=True)
+    _validate_lifecycle_event_created_at(
+        "build_pull_request_sync_request",
+        action="synchronize",
+        is_pull_request=True,
+        event_created_at=event_created_at,
+    )
     return PullRequestSyncRequest(
         issue_number=_parse_optional_int(bot.get_config_value("ISSUE_NUMBER")) or 0,
         head_sha=bot.get_config_value("PR_HEAD_SHA").strip(),
-        event_created_at=_derive_lifecycle_event_created_at(bot, action="synchronize", is_pull_request=True),
+        event_created_at=event_created_at,
     )
 
 

--- a/scripts/reviewer_bot_lib/event_inputs.py
+++ b/scripts/reviewer_bot_lib/event_inputs.py
@@ -118,6 +118,24 @@ def _parse_route_outcome(value: str) -> PrCommentRouterOutcome | None:
         return None
 
 
+def _derive_lifecycle_event_created_at(bot: EventInputsContext, *, action: str, is_pull_request: bool) -> str:
+    if is_pull_request:
+        if action == "opened":
+            return bot.get_config_value("PR_CREATED_AT").strip()
+        if action == "closed":
+            return bot.get_config_value("PR_CLOSED_AT").strip()
+        if action in {"labeled", "unlabeled", "reopened", "synchronize"}:
+            return bot.get_config_value("PR_UPDATED_AT").strip()
+        return ""
+    if action == "opened":
+        return bot.get_config_value("ISSUE_CREATED_AT").strip()
+    if action == "closed":
+        return bot.get_config_value("ISSUE_CLOSED_AT").strip()
+    if action in {"edited", "assigned", "unassigned", "labeled", "unlabeled", "reopened"}:
+        return bot.get_config_value("ISSUE_UPDATED_AT").strip()
+    return ""
+
+
 def _read_workflow_run_name(bot: EventInputsContext) -> str:
     event_path = bot.get_config_value("GITHUB_EVENT_PATH").strip()
     if not event_path:
@@ -342,10 +360,12 @@ def build_manual_dispatch_request(bot: EventInputsContext) -> ManualDispatchRequ
 
 
 def build_issue_lifecycle_request(bot: EventInputsContext) -> IssueLifecycleRequest:
+    event_action = bot.get_config_value("EVENT_ACTION").strip()
+    is_pull_request = bool(_parse_optional_bool(bot.get_config_value("IS_PULL_REQUEST")))
     return IssueLifecycleRequest(
-        event_action=bot.get_config_value("EVENT_ACTION").strip(),
+        event_action=event_action,
         issue_number=_parse_optional_int(bot.get_config_value("ISSUE_NUMBER")) or 0,
-        is_pull_request=bool(_parse_optional_bool(bot.get_config_value("IS_PULL_REQUEST"))),
+        is_pull_request=is_pull_request,
         issue_state=bot.get_config_value("ISSUE_STATE").strip(),
         issue_labels=_parse_labels(bot.get_config_value("ISSUE_LABELS")),
         label_name=bot.get_config_value("LABEL_NAME").strip(),
@@ -357,7 +377,11 @@ def build_issue_lifecycle_request(bot: EventInputsContext) -> IssueLifecycleRequ
         previous_title=bot.get_config_value("ISSUE_CHANGES_TITLE_FROM"),
         previous_body=bot.get_config_value("ISSUE_CHANGES_BODY_FROM"),
         pr_head_sha=bot.get_config_value("PR_HEAD_SHA").strip(),
-        event_created_at=bot.get_config_value("EVENT_CREATED_AT").strip(),
+        event_created_at=_derive_lifecycle_event_created_at(
+            bot,
+            action=event_action,
+            is_pull_request=is_pull_request,
+        ),
     )
 
 
@@ -373,7 +397,7 @@ def build_pull_request_sync_request(bot: EventInputsContext) -> PullRequestSyncR
     return PullRequestSyncRequest(
         issue_number=_parse_optional_int(bot.get_config_value("ISSUE_NUMBER")) or 0,
         head_sha=bot.get_config_value("PR_HEAD_SHA").strip(),
-        event_created_at=bot.get_config_value("EVENT_CREATED_AT").strip(),
+        event_created_at=_derive_lifecycle_event_created_at(bot, action="synchronize", is_pull_request=True),
     )
 
 

--- a/scripts/reviewer_bot_lib/lifecycle.py
+++ b/scripts/reviewer_bot_lib/lifecycle.py
@@ -183,7 +183,9 @@ def _reconcile_lifecycle_reviewer_authority(
     current_assignees = bot.github.get_issue_assignees(issue_number)
     if current_assignees is None:
         raise RuntimeError(f"Unable to determine assignees for #{issue_number}")
-    cycle_started_at = request.event_created_at or request.updated_at or _now_iso()
+    if not request.event_created_at:
+        raise RuntimeError(f"Missing lifecycle timestamp for {request.event_action} event")
+    cycle_started_at = request.event_created_at
     if len(current_assignees) == 1:
         reviewer = current_assignees[0]
         if request.issue_author and reviewer.lower() == request.issue_author.lower():
@@ -297,7 +299,9 @@ def handle_issue_edited_event(bot, state: dict) -> bool:
     review_data = ensure_review_entry(state, issue_number)
     if review_data is None:
         return False
-    updated_at = request.updated_at or _now_iso()
+    if not request.event_created_at:
+        raise RuntimeError("Missing lifecycle timestamp for edited event")
+    updated_at = request.event_created_at
     current_title = request.issue_title
     current_body = request.issue_body
     previous_title = request.previous_title

--- a/scripts/reviewer_bot_lib/lifecycle.py
+++ b/scripts/reviewer_bot_lib/lifecycle.py
@@ -431,7 +431,7 @@ def handle_pull_request_target_synchronize(bot, state: dict) -> bool:
     if not head_sha:
         raise RuntimeError("Missing PR_HEAD_SHA for synchronize event")
     if not request.event_created_at:
-        raise RuntimeError("Missing EVENT_CREATED_AT for synchronize event")
+        raise RuntimeError("Missing lifecycle timestamp for synchronize event")
     bot.collect_touched_item(issue_number)
     previous_head_sha = review_data.get("active_head_sha")
     previous_completion = deepcopy(review_data.get("current_cycle_completion"))

--- a/tests/contract/reviewer_bot/test_adapter_contract.py
+++ b/tests/contract/reviewer_bot/test_adapter_contract.py
@@ -509,12 +509,43 @@ def test_event_inputs_rejects_missing_lifecycle_timestamp_for_supported_actions(
         event_inputs.build_issue_lifecycle_request(runtime)
 
 
+@pytest.mark.parametrize(
+    ("event_action", "is_pull_request", "config_name", "expected_problem"),
+    [
+        ("opened", "false", "ISSUE_CREATED_AT", "ISSUE_CREATED_AT must be parseable ISO-8601 for opened"),
+        ("assigned", "false", "ISSUE_UPDATED_AT", "ISSUE_UPDATED_AT must be parseable ISO-8601 for assigned"),
+        ("closed", "true", "PR_CLOSED_AT", "PR_CLOSED_AT must be parseable ISO-8601 for closed"),
+        ("synchronize", "true", "PR_UPDATED_AT", "PR_UPDATED_AT must be parseable ISO-8601 for synchronize"),
+    ],
+)
+def test_event_inputs_rejects_invalid_lifecycle_timestamp_for_supported_actions(
+    monkeypatch, event_action, is_pull_request, config_name, expected_problem
+):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("EVENT_ACTION", event_action)
+    runtime.set_config_value("IS_PULL_REQUEST", is_pull_request)
+    runtime.set_config_value(config_name, "not-a-date")
+
+    with pytest.raises(event_inputs.InvalidEventInput, match=expected_problem):
+        event_inputs.build_issue_lifecycle_request(runtime)
+
+
 def test_event_inputs_rejects_missing_pull_request_sync_timestamp(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("PR_HEAD_SHA", "head-2")
 
     with pytest.raises(event_inputs.InvalidEventInput, match="PR_UPDATED_AT must be non-empty for synchronize"):
+        event_inputs.build_pull_request_sync_request(runtime)
+
+
+def test_event_inputs_rejects_invalid_pull_request_sync_timestamp(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("PR_HEAD_SHA", "head-2")
+    runtime.set_config_value("PR_UPDATED_AT", "not-a-date")
+
+    with pytest.raises(event_inputs.InvalidEventInput, match="PR_UPDATED_AT must be parseable ISO-8601 for synchronize"):
         event_inputs.build_pull_request_sync_request(runtime)
 
 

--- a/tests/contract/reviewer_bot/test_adapter_contract.py
+++ b/tests/contract/reviewer_bot/test_adapter_contract.py
@@ -373,25 +373,26 @@ def test_event_inputs_build_issue_lifecycle_request_from_runtime_config(monkeypa
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.set_config_value("EVENT_ACTION", "assigned")
     runtime.set_config_value("ISSUE_NUMBER", "42")
-    runtime.set_config_value("IS_PULL_REQUEST", "true")
+    runtime.set_config_value("IS_PULL_REQUEST", "false")
     runtime.set_config_value("ISSUE_STATE", "open")
     runtime.set_config_value("ISSUE_LABELS", '["coding guideline"]')
     runtime.set_config_value("LABEL_NAME", "coding guideline")
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("SENDER_LOGIN", "alice")
+    runtime.set_config_value("ISSUE_CREATED_AT", "2026-03-17T09:00:00Z")
     runtime.set_config_value("ISSUE_UPDATED_AT", "2026-03-17T10:00:00Z")
+    runtime.set_config_value("ISSUE_CLOSED_AT", "2026-03-17T11:00:00Z")
     runtime.set_config_value("ISSUE_TITLE", "New title")
     runtime.set_config_value("ISSUE_BODY", "new body")
     runtime.set_config_value("ISSUE_CHANGES_TITLE_FROM", "Old title")
     runtime.set_config_value("ISSUE_CHANGES_BODY_FROM", "old body")
     runtime.set_config_value("PR_HEAD_SHA", "head-2")
-    runtime.set_config_value("EVENT_CREATED_AT", "2026-03-17T10:05:00Z")
 
     request = event_inputs.build_issue_lifecycle_request(runtime)
 
     assert request.event_action == "assigned"
     assert request.issue_number == 42
-    assert request.is_pull_request is True
+    assert request.is_pull_request is False
     assert request.issue_state == "open"
     assert request.issue_labels == ("coding guideline",)
     assert request.label_name == "coding guideline"
@@ -403,7 +404,61 @@ def test_event_inputs_build_issue_lifecycle_request_from_runtime_config(monkeypa
     assert request.previous_title == "Old title"
     assert request.previous_body == "old body"
     assert request.pr_head_sha == "head-2"
-    assert request.event_created_at == "2026-03-17T10:05:00Z"
+    assert request.event_created_at == "2026-03-17T10:00:00Z"
+
+
+@pytest.mark.parametrize(
+    ("event_action", "expected_timestamp"),
+    [
+        ("opened", "2026-03-17T09:00:00Z"),
+        ("edited", "2026-03-17T10:00:00Z"),
+        ("assigned", "2026-03-17T10:00:00Z"),
+        ("unassigned", "2026-03-17T10:00:00Z"),
+        ("labeled", "2026-03-17T10:00:00Z"),
+        ("unlabeled", "2026-03-17T10:00:00Z"),
+        ("reopened", "2026-03-17T10:00:00Z"),
+        ("closed", "2026-03-17T11:00:00Z"),
+    ],
+)
+def test_event_inputs_derives_issue_lifecycle_timestamp_from_action_fields(
+    monkeypatch, event_action, expected_timestamp
+):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("EVENT_ACTION", event_action)
+    runtime.set_config_value("IS_PULL_REQUEST", "false")
+    runtime.set_config_value("ISSUE_CREATED_AT", "2026-03-17T09:00:00Z")
+    runtime.set_config_value("ISSUE_UPDATED_AT", "2026-03-17T10:00:00Z")
+    runtime.set_config_value("ISSUE_CLOSED_AT", "2026-03-17T11:00:00Z")
+
+    request = event_inputs.build_issue_lifecycle_request(runtime)
+
+    assert request.event_created_at == expected_timestamp
+
+
+@pytest.mark.parametrize(
+    ("event_action", "expected_timestamp"),
+    [
+        ("opened", "2026-03-17T09:30:00Z"),
+        ("labeled", "2026-03-17T10:30:00Z"),
+        ("unlabeled", "2026-03-17T10:30:00Z"),
+        ("reopened", "2026-03-17T10:30:00Z"),
+        ("synchronize", "2026-03-17T10:30:00Z"),
+        ("closed", "2026-03-17T11:30:00Z"),
+    ],
+)
+def test_event_inputs_derives_pr_lifecycle_timestamp_from_action_fields(
+    monkeypatch, event_action, expected_timestamp
+):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("EVENT_ACTION", event_action)
+    runtime.set_config_value("IS_PULL_REQUEST", "true")
+    runtime.set_config_value("PR_CREATED_AT", "2026-03-17T09:30:00Z")
+    runtime.set_config_value("PR_UPDATED_AT", "2026-03-17T10:30:00Z")
+    runtime.set_config_value("PR_CLOSED_AT", "2026-03-17T11:30:00Z")
+
+    request = event_inputs.build_issue_lifecycle_request(runtime)
+
+    assert request.event_created_at == expected_timestamp
 
 
 def test_event_inputs_build_label_and_sync_requests_from_runtime_config(monkeypatch):
@@ -412,7 +467,7 @@ def test_event_inputs_build_label_and_sync_requests_from_runtime_config(monkeypa
     runtime.set_config_value("IS_PULL_REQUEST", "true")
     runtime.set_config_value("LABEL_NAME", "sign-off: create pr")
     runtime.set_config_value("PR_HEAD_SHA", "head-2")
-    runtime.set_config_value("EVENT_CREATED_AT", "2026-03-17T10:05:00Z")
+    runtime.set_config_value("PR_UPDATED_AT", "2026-03-17T10:05:00Z")
 
     label_request = event_inputs.build_label_event_request(runtime)
     sync_request = event_inputs.build_pull_request_sync_request(runtime)

--- a/tests/contract/reviewer_bot/test_adapter_contract.py
+++ b/tests/contract/reviewer_bot/test_adapter_contract.py
@@ -278,6 +278,34 @@ def test_event_inputs_build_comment_request_and_pr_admission_from_runtime_config
     assert pr_admission.github_run_attempt == 2
 
 
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [("true", True), ("false", False)],
+)
+def test_event_inputs_parses_performed_via_app_boolean_boundary(monkeypatch, raw_value, expected):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("EVENT_NAME", "issue_comment")
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("IS_PULL_REQUEST", "true")
+    runtime.set_config_value("ISSUE_STATE", "open")
+    runtime.set_config_value("ISSUE_AUTHOR", "dana")
+    runtime.set_config_value("ISSUE_LABELS", '["coding guideline"]')
+    runtime.set_config_value("COMMENT_ID", "100")
+    runtime.set_config_value("COMMENT_AUTHOR", "alice")
+    runtime.set_config_value("COMMENT_AUTHOR_ID", "200")
+    runtime.set_config_value("COMMENT_BODY", "hello")
+    runtime.set_config_value("COMMENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    runtime.set_config_value("COMMENT_SOURCE_EVENT_KEY", "issue_comment:100")
+    runtime.set_config_value("COMMENT_USER_TYPE", "User")
+    runtime.set_config_value("COMMENT_SENDER_TYPE", "User")
+    runtime.set_config_value("COMMENT_INSTALLATION_ID", "")
+    runtime.set_config_value("COMMENT_PERFORMED_VIA_GITHUB_APP", raw_value)
+
+    request = event_inputs.build_comment_event_request(runtime)
+
+    assert request.comment_performed_via_github_app is expected
+
+
 def test_event_inputs_build_pr_admission_rejects_request_boundary_mismatch(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.set_config_value("EVENT_NAME", "issue_comment")
@@ -459,6 +487,35 @@ def test_event_inputs_derives_pr_lifecycle_timestamp_from_action_fields(
     request = event_inputs.build_issue_lifecycle_request(runtime)
 
     assert request.event_created_at == expected_timestamp
+
+
+@pytest.mark.parametrize(
+    ("event_action", "is_pull_request", "expected_problem"),
+    [
+        ("opened", "false", "ISSUE_CREATED_AT must be non-empty for opened"),
+        ("assigned", "false", "ISSUE_UPDATED_AT must be non-empty for assigned"),
+        ("closed", "true", "PR_CLOSED_AT must be non-empty for closed"),
+        ("synchronize", "true", "PR_UPDATED_AT must be non-empty for synchronize"),
+    ],
+)
+def test_event_inputs_rejects_missing_lifecycle_timestamp_for_supported_actions(
+    monkeypatch, event_action, is_pull_request, expected_problem
+):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("EVENT_ACTION", event_action)
+    runtime.set_config_value("IS_PULL_REQUEST", is_pull_request)
+
+    with pytest.raises(event_inputs.InvalidEventInput, match=expected_problem):
+        event_inputs.build_issue_lifecycle_request(runtime)
+
+
+def test_event_inputs_rejects_missing_pull_request_sync_timestamp(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("PR_HEAD_SHA", "head-2")
+
+    with pytest.raises(event_inputs.InvalidEventInput, match="PR_UPDATED_AT must be non-empty for synchronize"):
+        event_inputs.build_pull_request_sync_request(runtime)
 
 
 def test_event_inputs_build_label_and_sync_requests_from_runtime_config(monkeypatch):

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -65,7 +65,52 @@ def test_issue_lifecycle_workflow_exports_retained_request_boundary_fields():
     assert "IS_PULL_REQUEST: 'false'" in workflow_text
     assert "ISSUE_STATE: ${{ github.event.issue.state }}" in workflow_text
     assert "LABEL_NAME: ${{ github.event.label.name }}" in workflow_text
-    assert "EVENT_CREATED_AT: ${{ github.event.issue.updated_at }}" in workflow_text
+    assert "ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}" in workflow_text
+    assert "ISSUE_UPDATED_AT: ${{ github.event.issue.updated_at }}" in workflow_text
+    assert "ISSUE_CLOSED_AT: ${{ github.event.issue.closed_at }}" in workflow_text
+    assert "EVENT_CREATED_AT: ${{ github.event.issue.updated_at }}" not in workflow_text
+
+
+def test_pr_metadata_workflow_covers_retained_event_matrix():
+    workflow = yaml.safe_load(Path(".github/workflows/reviewer-bot-pr-metadata.yml").read_text(encoding="utf-8"))
+    on_block = workflow.get("on", workflow.get(True))
+
+    assert on_block["pull_request_target"]["types"] == [
+        "opened",
+        "labeled",
+        "unlabeled",
+        "reopened",
+        "closed",
+        "synchronize",
+    ]
+
+
+def test_pr_metadata_workflow_exports_raw_timestamp_boundary_fields():
+    workflow_text = Path(".github/workflows/reviewer-bot-pr-metadata.yml").read_text(encoding="utf-8")
+
+    assert "PR_CREATED_AT: ${{ github.event.pull_request.created_at }}" in workflow_text
+    assert "PR_UPDATED_AT: ${{ github.event.pull_request.updated_at }}" in workflow_text
+    assert "PR_CLOSED_AT: ${{ github.event.pull_request.closed_at }}" in workflow_text
+    assert "EVENT_CREATED_AT: ${{ github.event.pull_request.updated_at }}" not in workflow_text
+
+
+@pytest.mark.parametrize(
+    "workflow_path",
+    [
+        ".github/workflows/reviewer-bot-pr-comment-router.yml",
+        ".github/workflows/reviewer-bot-issue-comment-direct.yml",
+        ".github/workflows/reviewer-bot-pr-review-comment-observer.yml",
+    ],
+)
+def test_comment_workflows_export_performed_via_app_boolean_truth(workflow_path):
+    workflow_text = Path(workflow_path).read_text(encoding="utf-8")
+
+    assert "COMMENT_USER_TYPE" in workflow_text
+    assert "COMMENT_SENDER_TYPE" in workflow_text
+    assert "COMMENT_INSTALLATION_ID" in workflow_text
+    assert "COMMENT_PERFORMED_VIA_GITHUB_APP" in workflow_text
+    assert "COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app && 'true' || 'false' }}" in workflow_text
+    assert "github.event.comment.performed_via_github_app != null" not in workflow_text
 
 def test_pr_comment_router_workflow_builds_payload_inline_without_bot_src_root():
     workflow = Path(".github/workflows/reviewer-bot-pr-comment-router.yml").read_text(encoding="utf-8")

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -1,4 +1,5 @@
 import json
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -109,17 +110,42 @@ def test_comment_workflows_export_performed_via_app_boolean_truth(workflow_path)
     assert "COMMENT_SENDER_TYPE" in workflow_text
     assert "COMMENT_INSTALLATION_ID" in workflow_text
     assert "COMMENT_PERFORMED_VIA_GITHUB_APP" in workflow_text
-    assert "COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ toJson(github.event.comment.performed_via_github_app) != 'null' && toJson(github.event.comment.performed_via_github_app) != 'false' && 'true' || 'false' }}" in workflow_text
+    assert "COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app.id > 0 && 'true' || 'false' }}" in workflow_text
     assert "github.event.comment.performed_via_github_app != null" not in workflow_text
     assert "github.event.comment.performed_via_github_app && 'true' || 'false'" not in workflow_text
+    assert "toJson(github.event.comment.performed_via_github_app) != 'null'" not in workflow_text
 
 
 def test_pr_comment_router_normalizes_performed_via_app_without_raw_truthiness():
     workflow_text = Path(".github/workflows/reviewer-bot-pr-comment-router.yml").read_text(encoding="utf-8")
 
-    assert "performed_via_github_app_value = comment.get('performed_via_github_app')" in workflow_text
-    assert "performed_via_github_app = performed_via_github_app_value is True or isinstance(performed_via_github_app_value, dict)" in workflow_text
+    assert "def _performed_via_github_app_truth(value):" in workflow_text
+    assert "return int(value.get('id') or 0) > 0" in workflow_text
     assert "bool(comment.get('performed_via_github_app'))" not in workflow_text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, False),
+        (False, False),
+        (True, True),
+        ({}, False),
+        ({"id": 0}, False),
+        ({"id": "0"}, False),
+        ({"id": 123}, True),
+        ({"id": "123"}, True),
+        ("false", False),
+    ],
+)
+def test_pr_comment_router_performed_via_app_helper_executes_source_shape_cases(value, expected):
+    workflow_text = Path(".github/workflows/reviewer-bot-pr-comment-router.yml").read_text(encoding="utf-8")
+    start = workflow_text.index("def _performed_via_github_app_truth(value):")
+    end = workflow_text.index("\n\n          performed_via_github_app =", start)
+    namespace = {}
+    exec(textwrap.dedent(workflow_text[start:end]), namespace)
+
+    assert namespace["_performed_via_github_app_truth"](value) is expected
 
 def test_pr_comment_router_workflow_builds_payload_inline_without_bot_src_root():
     workflow = Path(".github/workflows/reviewer-bot-pr-comment-router.yml").read_text(encoding="utf-8")

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -109,8 +109,17 @@ def test_comment_workflows_export_performed_via_app_boolean_truth(workflow_path)
     assert "COMMENT_SENDER_TYPE" in workflow_text
     assert "COMMENT_INSTALLATION_ID" in workflow_text
     assert "COMMENT_PERFORMED_VIA_GITHUB_APP" in workflow_text
-    assert "COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app && 'true' || 'false' }}" in workflow_text
+    assert "COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ toJson(github.event.comment.performed_via_github_app) != 'null' && toJson(github.event.comment.performed_via_github_app) != 'false' && 'true' || 'false' }}" in workflow_text
     assert "github.event.comment.performed_via_github_app != null" not in workflow_text
+    assert "github.event.comment.performed_via_github_app && 'true' || 'false'" not in workflow_text
+
+
+def test_pr_comment_router_normalizes_performed_via_app_without_raw_truthiness():
+    workflow_text = Path(".github/workflows/reviewer-bot-pr-comment-router.yml").read_text(encoding="utf-8")
+
+    assert "performed_via_github_app_value = comment.get('performed_via_github_app')" in workflow_text
+    assert "performed_via_github_app = performed_via_github_app_value is True or isinstance(performed_via_github_app_value, dict)" in workflow_text
+    assert "bool(comment.get('performed_via_github_app'))" not in workflow_text
 
 def test_pr_comment_router_workflow_builds_payload_inline_without_bot_src_root():
     workflow = Path(".github/workflows/reviewer-bot-pr-comment-router.yml").read_text(encoding="utf-8")

--- a/tests/integration/reviewer_bot/test_app_execution.py
+++ b/tests/integration/reviewer_bot/test_app_execution.py
@@ -187,7 +187,7 @@ def test_execute_run_opened_issue_assignment_failure_does_not_persist_reviewer_s
     monkeypatch.setenv("ISSUE_LABELS", '["coding guideline"]')
     monkeypatch.setenv("ISSUE_STATE", "open")
     monkeypatch.setenv("IS_PULL_REQUEST", "false")
-    monkeypatch.setenv("EVENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    monkeypatch.setenv("ISSUE_CREATED_AT", "2026-03-17T10:00:00Z")
 
     result = reviewer_bot.execute_run(reviewer_bot.build_event_context(runtime), runtime)
 
@@ -224,7 +224,7 @@ def test_execute_run_opened_issue_adopts_existing_single_live_assignee(monkeypat
     monkeypatch.setenv("ISSUE_LABELS", '["coding guideline"]')
     monkeypatch.setenv("ISSUE_STATE", "open")
     monkeypatch.setenv("IS_PULL_REQUEST", "false")
-    monkeypatch.setenv("EVENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    monkeypatch.setenv("ISSUE_CREATED_AT", "2026-03-17T10:00:00Z")
 
     result = reviewer_bot.execute_run(reviewer_bot.build_event_context(runtime), runtime)
 
@@ -430,13 +430,74 @@ def test_bootstrapped_runtime_executes_pr_metadata_closed_dispatch_path(monkeypa
     monkeypatch.setenv("ISSUE_AUTHOR", "dana")
     monkeypatch.setenv("ISSUE_LABELS", '["triage"]')
     monkeypatch.setenv("PR_HEAD_SHA", "head-1")
-    monkeypatch.setenv("EVENT_CREATED_AT", "2026-04-13T04:31:00Z")
+    monkeypatch.setenv("PR_CLOSED_AT", "2026-04-13T04:31:00Z")
 
     context = reviewer_bot.build_event_context(runtime)
     result = reviewer_bot.execute_run(context, runtime)
 
     assert context.event_name == "pull_request_target"
     assert context.event_action == "closed"
+    assert calls == [state]
+    assert result.exit_code == 0
+    assert result.state_changed is True
+    assert runtime.ACTIVE_LEASE_CONTEXT is None
+
+
+@pytest.mark.parametrize(
+    ("event_action", "handler_name", "label_name"),
+    [
+        ("opened", "handle_issue_or_pr_opened", ""),
+        ("labeled", "handle_labeled_event", "coding guideline"),
+        ("unlabeled", "handle_unlabeled_event", "coding guideline"),
+        ("reopened", "handle_reopened_event", ""),
+        ("closed", "handle_closed_event", ""),
+        ("synchronize", "handle_pull_request_target_synchronize", ""),
+    ],
+)
+def test_bootstrapped_runtime_executes_pr_metadata_dispatch_matrix(
+    monkeypatch, event_action, handler_name, label_name
+):
+    runtime = reviewer_bot._runtime_bot()
+    state = make_state()
+    calls = []
+
+    def acquire_lock():
+        runtime.ACTIVE_LEASE_CONTEXT = object()
+        return runtime.ACTIVE_LEASE_CONTEXT
+
+    def release_lock():
+        runtime.ACTIVE_LEASE_CONTEXT = None
+        return True
+
+    def handler(current_state):
+        calls.append(current_state)
+        return True
+
+    monkeypatch.setattr(runtime.locks, "acquire", acquire_lock)
+    monkeypatch.setattr(runtime.locks, "release", release_lock)
+    monkeypatch.setattr(runtime.state_store, "load_state", lambda *, fail_on_unavailable=False: state)
+    monkeypatch.setattr(runtime.state_store, "save_state", lambda current_state: True)
+    monkeypatch.setattr(runtime.adapters.workflow, "process_pass_until_expirations", lambda current_state: (current_state, []))
+    monkeypatch.setattr(runtime.adapters.workflow, "sync_members_with_queue", lambda current_state: (current_state, []))
+    monkeypatch.setattr(runtime.adapters.workflow, "sync_status_labels_for_items", lambda current_state, issue_numbers: False)
+    monkeypatch.setattr(runtime.handlers, handler_name, handler)
+    monkeypatch.setenv("EVENT_NAME", "pull_request_target")
+    monkeypatch.setenv("EVENT_ACTION", event_action)
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("IS_PULL_REQUEST", "true")
+    monkeypatch.setenv("ISSUE_AUTHOR", "dana")
+    monkeypatch.setenv("ISSUE_LABELS", '["coding guideline"]')
+    monkeypatch.setenv("LABEL_NAME", label_name)
+    monkeypatch.setenv("PR_HEAD_SHA", "head-1")
+    monkeypatch.setenv("PR_CREATED_AT", "2026-04-13T04:30:00Z")
+    monkeypatch.setenv("PR_UPDATED_AT", "2026-04-13T04:31:00Z")
+    monkeypatch.setenv("PR_CLOSED_AT", "2026-04-13T04:32:00Z")
+
+    context = reviewer_bot.build_event_context(runtime)
+    result = reviewer_bot.execute_run(context, runtime)
+
+    assert context.event_name == "pull_request_target"
+    assert context.event_action == event_action
     assert calls == [state]
     assert result.exit_code == 0
     assert result.state_changed is True
@@ -491,8 +552,9 @@ def test_bootstrapped_runtime_executes_issue_lifecycle_dispatch_matrix(
     monkeypatch.setenv("ISSUE_AUTHOR", "dana")
     monkeypatch.setenv("ISSUE_LABELS", '["coding guideline"]')
     monkeypatch.setenv("LABEL_NAME", label_name)
+    monkeypatch.setenv("ISSUE_CREATED_AT", "2026-04-13T04:30:00Z")
     monkeypatch.setenv("ISSUE_UPDATED_AT", "2026-04-13T04:31:00Z")
-    monkeypatch.setenv("EVENT_CREATED_AT", "2026-04-13T04:31:00Z")
+    monkeypatch.setenv("ISSUE_CLOSED_AT", "2026-04-13T04:32:00Z")
 
     context = reviewer_bot.build_event_context(runtime)
     result = reviewer_bot.execute_run(context, runtime)
@@ -519,7 +581,7 @@ def test_bootstrapped_runtime_pr_metadata_closed_executes_real_status_label_proj
     monkeypatch.setenv("ISSUE_AUTHOR", "dana")
     monkeypatch.setenv("ISSUE_LABELS", '["triage"]')
     monkeypatch.setenv("PR_HEAD_SHA", "head-1")
-    monkeypatch.setenv("EVENT_CREATED_AT", "2026-04-13T04:31:00Z")
+    monkeypatch.setenv("PR_CLOSED_AT", "2026-04-13T04:31:00Z")
 
     result = reviewer_bot.execute_run(reviewer_bot.build_event_context(runtime), runtime)
 

--- a/tests/unit/reviewer_bot/test_app_event_intent.py
+++ b/tests/unit/reviewer_bot/test_app_event_intent.py
@@ -49,6 +49,26 @@ def test_classify_event_intent_same_repo_dismissed_review_is_read_only(monkeypat
     assert intent == runtime.EVENT_INTENT_NON_MUTATING_READONLY
 
 
+@pytest.mark.parametrize(
+    "event_action",
+    ["opened", "edited", "labeled", "unlabeled", "assigned", "unassigned", "reopened", "closed"],
+)
+def test_classify_event_intent_issue_lifecycle_retained_matrix_is_mutating(monkeypatch, event_action):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+
+    intent = app.classify_event_intent(runtime, "issues", event_action)
+
+    assert intent == runtime.EVENT_INTENT_MUTATING
+
+
+def test_classify_event_intent_issue_synchronize_is_read_only(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+
+    intent = app.classify_event_intent(runtime, "issues", "synchronize")
+
+    assert intent == runtime.EVENT_INTENT_NON_MUTATING_READONLY
+
+
 def test_classify_event_intent_review_comment_is_non_mutating_defer(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     intent = app.classify_event_intent(runtime, "pull_request_review_comment", "created")

--- a/tests/unit/reviewer_bot/test_app_event_intent.py
+++ b/tests/unit/reviewer_bot/test_app_event_intent.py
@@ -56,6 +56,27 @@ def test_classify_event_intent_review_comment_is_non_mutating_defer(monkeypatch)
 
 
 @pytest.mark.parametrize(
+    "event_action",
+    ["opened", "labeled", "unlabeled", "reopened", "closed", "synchronize"],
+)
+def test_classify_event_intent_pr_metadata_retained_matrix_is_mutating(monkeypatch, event_action):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+
+    intent = app.classify_event_intent(runtime, "pull_request_target", event_action)
+
+    assert intent == runtime.EVENT_INTENT_MUTATING
+
+
+@pytest.mark.parametrize("event_action", ["edited", "assigned", "unassigned", "ready_for_review"])
+def test_classify_event_intent_pr_metadata_unshipped_actions_are_read_only(monkeypatch, event_action):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+
+    intent = app.classify_event_intent(runtime, "pull_request_target", event_action)
+
+    assert intent == runtime.EVENT_INTENT_NON_MUTATING_READONLY
+
+
+@pytest.mark.parametrize(
     ("workflow_run_event", "workflow_run_event_action"),
     [
         ("pull_request_review", "submitted"),

--- a/tests/unit/reviewer_bot/test_lifecycle.py
+++ b/tests/unit/reviewer_bot/test_lifecycle.py
@@ -5,6 +5,7 @@ import pytest
 
 from scripts.reviewer_bot_lib import (
     comment_routing,
+    event_inputs,
     lifecycle,
     maintenance,
     maintenance_schedule,
@@ -415,6 +416,7 @@ def test_handle_issue_or_pr_opened_fails_closed_when_assignees_unavailable(monke
     runtime.set_config_value("EVENT_ACTION", "opened")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+    runtime.set_config_value("ISSUE_CREATED_AT", "2026-03-17T10:00:00Z")
     runtime.github.get_issue_assignees = lambda issue_number: None
 
     with pytest.raises(RuntimeError, match="Unable to determine assignees"):
@@ -425,9 +427,11 @@ def test_handle_issue_or_pr_opened_does_not_mutate_reviewer_state_on_assignment_
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.ACTIVE_LEASE_CONTEXT = object()
     state = make_state()
+    runtime.set_config_value("EVENT_ACTION", "opened")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+    runtime.set_config_value("ISSUE_CREATED_AT", "2026-03-17T10:00:00Z")
     runtime.github.get_issue_assignees = lambda issue_number: []
     runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
         200,
@@ -490,9 +494,11 @@ def test_handle_assigned_event_clears_reviewer_authority_on_multiple_live_assign
     review = review_state.ensure_review_entry(state, 42, create=True)
     assert review is not None
     review["current_reviewer"] = "alice"
+    runtime.set_config_value("EVENT_ACTION", "assigned")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+    runtime.set_config_value("ISSUE_UPDATED_AT", "2026-03-17T10:00:00Z")
     runtime.github.get_issue_assignees = lambda issue_number: ["alice", "bob"]
     runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
         200,
@@ -516,9 +522,11 @@ def test_handle_unassigned_event_clears_reviewer_authority_when_live_assignee_mi
     review = review_state.ensure_review_entry(state, 42, create=True)
     assert review is not None
     review["current_reviewer"] = "alice"
+    runtime.set_config_value("EVENT_ACTION", "unassigned")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+    runtime.set_config_value("ISSUE_UPDATED_AT", "2026-03-17T10:00:00Z")
     runtime.github.get_issue_assignees = lambda issue_number: []
     runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
         200,
@@ -542,6 +550,7 @@ def test_issue_edit_by_author_records_contributor_freshness(monkeypatch):
     review = review_state.ensure_review_entry(state, 42, create=True)
     assert review is not None
     review["current_reviewer"] = "alice"
+    runtime.set_config_value("EVENT_ACTION", "edited")
     runtime.set_config_value("IS_PULL_REQUEST", "false")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
@@ -602,8 +611,10 @@ def test_handle_reopened_event_reopens_done_completion(monkeypatch):
     review["review_completed_by"] = "alice"
     review["review_completion_source"] = "command: /done"
     review["current_cycle_completion"] = {"completed": True}
+    runtime.set_config_value("EVENT_ACTION", "reopened")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["fls-audit"]))
+    runtime.set_config_value("ISSUE_UPDATED_AT", "2026-03-17T10:00:00Z")
     runtime.github.get_issue_assignees = lambda issue_number: []
     runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
         200,
@@ -619,6 +630,18 @@ def test_handle_reopened_event_reopens_done_completion(monkeypatch):
     assert lifecycle.handle_reopened_event(runtime, state) is True
     assert review["review_completed_at"] is None
     assert review["review_completion_source"] is None
+
+
+def test_handle_issue_or_pr_opened_rejects_missing_lifecycle_timestamp(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.ACTIVE_LEASE_CONTEXT = object()
+    state = make_state()
+    runtime.set_config_value("EVENT_ACTION", "opened")
+    runtime.set_config_value("ISSUE_NUMBER", "42")
+    runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
+
+    with pytest.raises(event_inputs.InvalidEventInput, match="ISSUE_CREATED_AT must be non-empty for opened"):
+        lifecycle.handle_issue_or_pr_opened(runtime, state)
 
 
 def test_handle_closed_event_removes_reviewer_handoff_with_review_entry(monkeypatch):

--- a/tests/unit/reviewer_bot/test_lifecycle.py
+++ b/tests/unit/reviewer_bot/test_lifecycle.py
@@ -644,6 +644,13 @@ def test_handle_issue_or_pr_opened_rejects_missing_lifecycle_timestamp(monkeypat
         lifecycle.handle_issue_or_pr_opened(runtime, state)
 
 
+def test_lifecycle_does_not_fallback_to_updated_at_or_now_for_event_authority():
+    lifecycle_text = Path("scripts/reviewer_bot_lib/lifecycle.py").read_text(encoding="utf-8")
+
+    assert "request.event_created_at or request.updated_at" not in lifecycle_text
+    assert "request.updated_at or _now_iso()" not in lifecycle_text
+
+
 def test_handle_closed_event_removes_reviewer_handoff_with_review_entry(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.ACTIVE_LEASE_CONTEXT = object()

--- a/tests/unit/reviewer_bot/test_lifecycle.py
+++ b/tests/unit/reviewer_bot/test_lifecycle.py
@@ -35,7 +35,7 @@ def test_handle_pull_request_target_synchronize_returns_true_for_head_only_mutat
     review["contributor_revision"]["seen_keys"] = ["pull_request_sync:42:head-2"]
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("PR_HEAD_SHA", "head-2")
-    runtime.set_config_value("EVENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    runtime.set_config_value("PR_UPDATED_AT", "2026-03-17T10:00:00Z")
     monkeypatch.setattr(reviews, "rebuild_pr_approval_state", lambda bot, issue_number, review_data: (None, None))
 
     assert lifecycle.handle_pull_request_target_synchronize(runtime, state) is True
@@ -412,6 +412,7 @@ def test_handle_issue_or_pr_opened_fails_closed_when_assignees_unavailable(monke
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.ACTIVE_LEASE_CONTEXT = object()
     state = make_state()
+    runtime.set_config_value("EVENT_ACTION", "opened")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
     runtime.github.get_issue_assignees = lambda issue_number: None
@@ -458,10 +459,11 @@ def test_handle_issue_or_pr_opened_adopts_existing_single_live_assignee(monkeypa
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.ACTIVE_LEASE_CONTEXT = object()
     state = make_state()
+    runtime.set_config_value("EVENT_ACTION", "opened")
     runtime.set_config_value("ISSUE_NUMBER", "42")
     runtime.set_config_value("ISSUE_AUTHOR", "dana")
     runtime.set_config_value("ISSUE_LABELS", json.dumps(["coding guideline"]))
-    runtime.set_config_value("EVENT_CREATED_AT", "2026-03-17T10:00:00Z")
+    runtime.set_config_value("ISSUE_CREATED_AT", "2026-03-17T10:00:00Z")
     runtime.github.get_issue_assignees = lambda issue_number: ["alice"]
     runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: runtime.GitHubApiResult(
         200,


### PR DESCRIPTION
## Summary
- execute retained post-incident hardening slice H2
- keep the change inside the frozen v19 hardening boundary for branch refactor/reviewer-bot-pr264-post-incident-hardening-v19-h2

## Verification
- chosen slice verification floor and deterministic additional tests from the v19 hardening plan
- artifact: /home/pete.levasseur/opencode-project-agents/safety-critical-rust-coding-guidelines/reviewer-bot/pr264-post-incident-hardening-v19/hardening-h2-local-proof.json
