### PR TITLE
refactor: align reviewer board attention parity

### DIFF
--- a/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
+++ b/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
@@ -43,6 +43,7 @@ jobs:
               'source_workflow_file': '.github/workflows/reviewer-bot-pr-review-comment-observer.yml',
               'source_run_id': int(os.environ['GITHUB_RUN_ID']),
               'source_run_attempt': int(os.environ['GITHUB_RUN_ATTEMPT']),
+              'source_artifact_name': f"reviewer-bot-review-comment-context-{os.environ['GITHUB_RUN_ID']}-attempt-{os.environ['GITHUB_RUN_ATTEMPT']}",
               'source_event_name': 'pull_request_review_comment',
               'source_event_action': 'created',
               'source_event_key': f"pull_request_review_comment:{os.environ['COMMENT_ID']}",

--- a/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
+++ b/.github/workflows/reviewer-bot-pr-review-comment-observer.yml
@@ -26,6 +26,7 @@ jobs:
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id }}
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
+          COMMENT_COMMIT_ID: ${{ github.event.comment.commit_id }}
           COMMENT_SENDER_TYPE: ${{ github.event.sender.type }}
           COMMENT_INSTALLATION_ID: ${{ github.event.installation.id }}
           COMMENT_PERFORMED_VIA_GITHUB_APP: ${{ github.event.comment.performed_via_github_app.id > 0 && 'true' || 'false' }}
@@ -52,6 +53,7 @@ jobs:
               'comment_author': os.environ['COMMENT_AUTHOR'],
               'comment_author_id': int(os.environ['COMMENT_AUTHOR_ID']),
               'comment_user_type': os.environ['COMMENT_USER_TYPE'],
+              'source_commit_id': os.environ.get('COMMENT_COMMIT_ID', '').strip() or None,
               'comment_sender_type': os.environ['COMMENT_SENDER_TYPE'],
               'comment_installation_id': os.environ.get('COMMENT_INSTALLATION_ID', '').strip() or None,
               'comment_performed_via_github_app': os.environ['COMMENT_PERFORMED_VIA_GITHUB_APP'] == 'true',

--- a/.github/workflows/reviewer-bot-sweeper-repair.yml
+++ b/.github/workflows/reviewer-bot-sweeper-repair.yml
@@ -70,8 +70,6 @@ jobs:
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
-          REVIEWER_BOARD_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && 'true' || 'false' }}
-          REVIEWER_BOARD_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && secrets.REVIEWER_BOARD_TOKEN || '' }}
         run: uv run --project "$BOT_SRC_ROOT" reviewer-bot
       - name: Workflow summary
         run: |

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -20,6 +20,25 @@ from . import live_review_support, reviewer_review_helpers
 
 _UNSET = object()
 _ASSIGNMENT_GUIDANCE_AUTHORS = {"github-actions", "github-actions[bot]", "guidelines-bot"}
+_FAIL_CLOSED_REVIEWER_ACTIVITY_GAP_REASONS = frozenset(
+    {
+        "observer_failed",
+        "observer_cancelled",
+        "observer_run_missing",
+        "observer_state_unknown",
+        "artifact_missing",
+        "artifact_invalid",
+        "artifact_expired",
+        "reconcile_failed_closed",
+    }
+)
+_REVIEWER_ACTIVITY_GAP_KINDS = frozenset(
+    {
+        "issue_comment:created",
+        "pull_request_review:submitted",
+        "pull_request_review_comment:created",
+    }
+)
 
 
 def _record_timestamp(record: dict | None, *, parse_timestamp) -> datetime | None:
@@ -137,6 +156,72 @@ def _build_current_scope_key(
         f"reviewer={current_reviewer}|head={_scope_value(current_head)}|"
         f"cycle={_scope_value(cycle_boundary)}|anchor={_scope_value(anchor_timestamp)}"
     )
+
+
+def _deferred_gaps(review_data: dict) -> dict:
+    sidecars = review_data.get("sidecars")
+    if not isinstance(sidecars, dict):
+        return {}
+    deferred_gaps = sidecars.get("deferred_gaps")
+    return deferred_gaps if isinstance(deferred_gaps, dict) else {}
+
+
+def _gap_source_kind(gap: dict) -> str | None:
+    source_event_kind = gap.get("source_event_kind")
+    if isinstance(source_event_kind, str) and source_event_kind.strip():
+        return source_event_kind
+    source_event_key = gap.get("source_event_key")
+    if not isinstance(source_event_key, str):
+        return None
+    if source_event_key.startswith("issue_comment:"):
+        return "issue_comment:created"
+    if source_event_key.startswith("pull_request_review_comment:"):
+        return "pull_request_review_comment:created"
+    if source_event_key.startswith("pull_request_review:"):
+        return "pull_request_review:submitted"
+    return None
+
+
+def _gap_event_timestamp(gap: dict):
+    return live_review_support.parse_github_timestamp(gap.get("source_event_created_at"))
+
+
+def _visible_review_commit_id(gap: dict) -> str | None:
+    diagnostic = gap.get("visible_review_diagnostic")
+    payload = diagnostic.get("payload") if isinstance(diagnostic, dict) else None
+    commit_id = payload.get("commit_id") if isinstance(payload, dict) else None
+    return commit_id if isinstance(commit_id, str) and commit_id.strip() else None
+
+
+def has_fail_closed_reviewer_activity_for_current_scope(
+    review_data: dict,
+    *,
+    anchor_timestamp: str | None = None,
+    current_head_sha: str | None = None,
+) -> bool:
+    floor = live_review_support.parse_github_timestamp(anchor_timestamp)
+    if floor is None:
+        _, cycle_boundary = _initial_cycle_boundary(review_data)
+        floor = live_review_support.parse_github_timestamp(cycle_boundary)
+    for gap in _deferred_gaps(review_data).values():
+        if not isinstance(gap, dict):
+            continue
+        if gap.get("operator_action_required") is False:
+            continue
+        if gap.get("reason") not in _FAIL_CLOSED_REVIEWER_ACTIVITY_GAP_REASONS:
+            continue
+        source_kind = _gap_source_kind(gap)
+        if source_kind not in _REVIEWER_ACTIVITY_GAP_KINDS:
+            continue
+        event_timestamp = _gap_event_timestamp(gap)
+        if floor is not None and event_timestamp is not None and event_timestamp < floor:
+            continue
+        if source_kind == "pull_request_review:submitted" and isinstance(current_head_sha, str) and current_head_sha:
+            commit_id = _visible_review_commit_id(gap)
+            if commit_id is not None and commit_id != current_head_sha:
+                continue
+        return True
+    return False
 
 
 def _current_scope_fields(

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -158,14 +158,6 @@ def _build_current_scope_key(
     )
 
 
-def _deferred_gaps(review_data: dict) -> dict:
-    sidecars = review_data.get("sidecars")
-    if not isinstance(sidecars, dict):
-        return {}
-    deferred_gaps = sidecars.get("deferred_gaps")
-    return deferred_gaps if isinstance(deferred_gaps, dict) else {}
-
-
 def _gap_source_kind(gap: dict) -> str | None:
     source_event_kind = gap.get("source_event_kind")
     if isinstance(source_event_kind, str) and source_event_kind.strip():
@@ -193,20 +185,39 @@ def _visible_review_commit_id(gap: dict) -> str | None:
     return commit_id if isinstance(commit_id, str) and commit_id.strip() else None
 
 
+def _visible_activity_author(gap: dict) -> str | None:
+    diagnostic = gap.get("visible_review_diagnostic")
+    payload = diagnostic.get("payload") if isinstance(diagnostic, dict) else None
+    author = payload.get("author") if isinstance(payload, dict) else None
+    if isinstance(author, str) and author.strip():
+        return author
+    actor = gap.get("actor")
+    if isinstance(actor, str) and actor.strip():
+        return actor
+    comment = gap.get("comment")
+    user = comment.get("user") if isinstance(comment, dict) else None
+    login = user.get("login") if isinstance(user, dict) else None
+    return login if isinstance(login, str) and login.strip() else None
+
+
 def has_fail_closed_reviewer_activity_for_current_scope(
     review_data: dict,
+    fail_closed_gaps,
     *,
     anchor_timestamp: str | None = None,
     current_head_sha: str | None = None,
 ) -> bool:
+    current_reviewer = review_data.get("current_reviewer")
+    if not isinstance(current_reviewer, str) or not current_reviewer.strip():
+        return False
     floor = live_review_support.parse_github_timestamp(anchor_timestamp)
     if floor is None:
         _, cycle_boundary = _initial_cycle_boundary(review_data)
         floor = live_review_support.parse_github_timestamp(cycle_boundary)
-    for gap in _deferred_gaps(review_data).values():
+    for gap in fail_closed_gaps:
         if not isinstance(gap, dict):
             continue
-        if gap.get("operator_action_required") is False:
+        if gap.get("operator_action_required") is not True:
             continue
         if gap.get("reason") not in _FAIL_CLOSED_REVIEWER_ACTIVITY_GAP_REASONS:
             continue
@@ -214,11 +225,18 @@ def has_fail_closed_reviewer_activity_for_current_scope(
         if source_kind not in _REVIEWER_ACTIVITY_GAP_KINDS:
             continue
         event_timestamp = _gap_event_timestamp(gap)
-        if floor is not None and event_timestamp is not None and event_timestamp < floor:
+        if event_timestamp is None:
             continue
-        if source_kind == "pull_request_review:submitted" and isinstance(current_head_sha, str) and current_head_sha:
+        if floor is not None and event_timestamp < floor:
+            continue
+        author = _visible_activity_author(gap)
+        if not isinstance(author, str) or author.lower() != current_reviewer.lower():
+            continue
+        if source_kind == "pull_request_review:submitted":
+            if not isinstance(current_head_sha, str) or not current_head_sha.strip():
+                continue
             commit_id = _visible_review_commit_id(gap)
-            if commit_id is not None and commit_id != current_head_sha:
+            if commit_id != current_head_sha:
                 continue
         return True
     return False
@@ -563,6 +581,7 @@ def derive_reviewer_response_state(
                 reason="no_reviewer_activity",
                 scope_fields=_current_scope_fields(review_data, current_reviewer, current_head, None),
                 anchor_timestamp=_initial_reviewer_anchor(review_data),
+                current_head_sha=current_head,
                 reviewer_comment=reviewer_comment,
                 reviewer_review=reviewer_review,
                 current_cycle_reviewer_handoff=reviewer_handoff,

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -182,7 +182,10 @@ def _visible_review_commit_id(gap: dict) -> str | None:
     diagnostic = gap.get("visible_review_diagnostic")
     payload = diagnostic.get("payload") if isinstance(diagnostic, dict) else None
     commit_id = payload.get("commit_id") if isinstance(payload, dict) else None
-    return commit_id if isinstance(commit_id, str) and commit_id.strip() else None
+    if isinstance(commit_id, str) and commit_id.strip():
+        return commit_id
+    source_commit_id = gap.get("source_commit_id")
+    return source_commit_id if isinstance(source_commit_id, str) and source_commit_id.strip() else None
 
 
 def _visible_activity_author(gap: dict) -> str | None:
@@ -191,6 +194,9 @@ def _visible_activity_author(gap: dict) -> str | None:
     author = payload.get("author") if isinstance(payload, dict) else None
     if isinstance(author, str) and author.strip():
         return author
+    source_actor = gap.get("source_actor_login")
+    if isinstance(source_actor, str) and source_actor.strip():
+        return source_actor
     actor = gap.get("actor")
     if isinstance(actor, str) and actor.strip():
         return actor

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -185,7 +185,13 @@ def _visible_review_commit_id(gap: dict) -> str | None:
     if isinstance(commit_id, str) and commit_id.strip():
         return commit_id
     source_commit_id = gap.get("source_commit_id")
-    return source_commit_id if isinstance(source_commit_id, str) and source_commit_id.strip() else None
+    if isinstance(source_commit_id, str) and source_commit_id.strip():
+        return source_commit_id
+    comment = gap.get("comment")
+    comment_commit_id = None
+    if isinstance(comment, dict):
+        comment_commit_id = comment.get("commit_id") or comment.get("original_commit_id")
+    return comment_commit_id if isinstance(comment_commit_id, str) and comment_commit_id.strip() else None
 
 
 def _visible_activity_author(gap: dict) -> str | None:
@@ -238,7 +244,7 @@ def has_fail_closed_reviewer_activity_for_current_scope(
         author = _visible_activity_author(gap)
         if not isinstance(author, str) or author.lower() != current_reviewer.lower():
             continue
-        if source_kind == "pull_request_review:submitted":
+        if source_kind in {"pull_request_review:submitted", "pull_request_review_comment:created"}:
             if not isinstance(current_head_sha, str) or not current_head_sha.strip():
                 continue
             commit_id = _visible_review_commit_id(gap)

--- a/scripts/reviewer_bot_lib/deferred_gap_bookkeeping.py
+++ b/scripts/reviewer_bot_lib/deferred_gap_bookkeeping.py
@@ -235,11 +235,49 @@ def _payload_or_existing(payload: dict, existing: dict, key: str):
     return existing.get(key) if value is None else value
 
 
+def _first_present_payload_value(payload: dict, keys: tuple[str, ...]):
+    for key in keys:
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _copy_source_evidence(fields: dict, payload: dict, existing: dict) -> None:
+    evidence_fields = {
+        "source_actor_login": ("source_actor_login", "comment_author", "actor_login"),
+        "source_actor_id": ("source_actor_id", "comment_author_id", "actor_id"),
+        "source_actor_user_type": ("source_actor_user_type", "comment_user_type"),
+        "source_actor_sender_type": ("source_actor_sender_type", "comment_sender_type"),
+        "source_actor_installation_id": ("source_actor_installation_id", "comment_installation_id"),
+        "source_actor_performed_via_github_app": (
+            "source_actor_performed_via_github_app",
+            "comment_performed_via_github_app",
+        ),
+        "source_comment_id": ("source_comment_id", "comment_id"),
+        "source_review_id": ("source_review_id", "review_id", "pull_request_review_id"),
+        "source_commit_id": ("source_commit_id",),
+        "source_review_state": ("source_review_state",),
+    }
+    for target_key, source_keys in evidence_fields.items():
+        value = _first_present_payload_value(payload, source_keys)
+        if value is None:
+            value = existing.get(target_key)
+        if value is not None:
+            fields[target_key] = value
+
+
 def _source_event_created_at(payload: dict, existing: dict):
     return (
         payload.get("source_created_at")
+        or payload.get("comment_created_at")
         or payload.get("source_submitted_at")
         or payload.get("source_dismissed_at")
+        or payload.get("source_event_created_at")
         or existing.get("source_event_created_at")
     )
 
@@ -280,6 +318,7 @@ def record_deferred_gap_diagnostic(
     source_dismissed_at = _payload_or_existing(payload, existing, "source_dismissed_at")
     if source_dismissed_at is not None:
         fields["source_dismissed_at"] = source_dismissed_at
+    _copy_source_evidence(fields, payload, existing)
     existing.update(fields)
     changed = previous != existing
     deferred_gaps[source_event_key] = existing

--- a/scripts/reviewer_bot_lib/event_inputs.py
+++ b/scripts/reviewer_bot_lib/event_inputs.py
@@ -447,8 +447,8 @@ def build_pull_request_sync_request(bot: EventInputsContext) -> PullRequestSyncR
 
 
 def build_replay_comment_event_request(payload, *, live_comment=None, comment_body: str | None = None) -> CommentEventRequest:
-    if getattr(getattr(payload, "identity", None), "schema_version", None) != 3:
-        raise InvalidEventInput("build_replay_comment_event_request", ("schema-v3 comment-like payload required",))
+    if not hasattr(payload, "identity") or not hasattr(payload, "comment_id"):
+        raise InvalidEventInput("build_replay_comment_event_request", ("typed deferred comment payload required",))
     if not hasattr(payload, "issue_state") or not hasattr(payload, "issue_author") or not hasattr(payload, "issue_labels"):
         raise InvalidEventInput("build_replay_comment_event_request", ("typed deferred comment payload required",))
     resolved_body = payload.comment_body if comment_body is None else comment_body

--- a/scripts/reviewer_bot_lib/event_inputs.py
+++ b/scripts/reviewer_bot_lib/event_inputs.py
@@ -446,7 +446,13 @@ def build_pull_request_sync_request(bot: EventInputsContext) -> PullRequestSyncR
     )
 
 
-def build_replay_comment_event_request(payload, *, live_comment=None, comment_body: str | None = None) -> CommentEventRequest:
+def build_replay_comment_event_request(
+    payload,
+    *,
+    live_comment=None,
+    live_pr=None,
+    comment_body: str | None = None,
+) -> CommentEventRequest:
     if not hasattr(payload, "identity") or not hasattr(payload, "comment_id"):
         raise InvalidEventInput("build_replay_comment_event_request", ("typed deferred comment payload required",))
     if not hasattr(payload, "issue_state") or not hasattr(payload, "issue_author") or not hasattr(payload, "issue_labels"):
@@ -467,12 +473,18 @@ def build_replay_comment_event_request(payload, *, live_comment=None, comment_bo
         if live_comment is not None and live_comment.comment_performed_via_github_app_available
         else payload.comment_performed_via_github_app
     )
+    issue_author = payload.issue_author
+    if live_pr is not None and not issue_author.strip():
+        issue_author = live_pr.issue_author
+    issue_labels = payload.issue_labels
+    if live_pr is not None and not issue_labels:
+        issue_labels = live_pr.issue_labels
     return CommentEventRequest(
         issue_number=payload.identity.pr_number,
         is_pull_request=True,
         issue_state=payload.issue_state,
-        issue_author=payload.issue_author,
-        issue_labels=payload.issue_labels,
+        issue_author=issue_author,
+        issue_labels=issue_labels,
         comment_id=payload.comment_id,
         comment_author=(live_comment.comment_author if live_comment is not None else payload.comment_author),
         comment_author_id=payload.comment_author_id,

--- a/scripts/reviewer_bot_lib/maintenance.py
+++ b/scripts/reviewer_bot_lib/maintenance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import asdict
 
 import yaml
 
@@ -105,6 +106,7 @@ def _handle_manual_dispatch_request(bot, state: dict, request) -> bool:
         desired = preview.desired
         payload["board_attention"] = desired.needs_attention if desired is not None else None
         payload["board_waiting_since"] = desired.waiting_since if desired is not None else None
+        payload["board_projection"] = asdict(desired) if desired is not None else None
         _emit_preview_json(payload)
         return False
     bot.assert_lock_held("handle_manual_dispatch")

--- a/scripts/reviewer_bot_lib/maintenance.py
+++ b/scripts/reviewer_bot_lib/maintenance.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict
 
 import yaml
 
@@ -106,7 +105,6 @@ def _handle_manual_dispatch_request(bot, state: dict, request) -> bool:
         desired = preview.desired
         payload["board_attention"] = desired.needs_attention if desired is not None else None
         payload["board_waiting_since"] = desired.waiting_since if desired is not None else None
-        payload["board_projection"] = asdict(desired) if desired is not None else None
         _emit_preview_json(payload)
         return False
     bot.assert_lock_held("handle_manual_dispatch")

--- a/scripts/reviewer_bot_lib/project_board.py
+++ b/scripts/reviewer_bot_lib/project_board.py
@@ -6,7 +6,7 @@ import copy
 from dataclasses import asdict, dataclass
 from typing import Any
 
-from scripts.reviewer_bot_core import reviewer_response_policy
+from scripts.reviewer_bot_core import live_review_support, reviewer_response_policy
 
 from . import deferred_gap_bookkeeping as gap_bookkeeping
 from .config import (
@@ -275,6 +275,14 @@ def _deferred_gap_records(review_data: dict[str, Any]) -> tuple[dict, ...]:
     )
 
 
+def _timestamp_at_or_after_anchor(value: Any, anchor: str | None) -> bool:
+    timestamp = live_review_support.parse_github_timestamp(value)
+    anchor_timestamp = live_review_support.parse_github_timestamp(anchor)
+    if timestamp is None or anchor_timestamp is None:
+        return False
+    return timestamp >= anchor_timestamp
+
+
 def _derive_review_state(
     bot: ProjectBoardProjectionContext,
     issue_number: int,
@@ -383,9 +391,9 @@ def derive_board_projection(input: BoardProjectionInput) -> BoardProjectionValue
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_TRIAGE_APPROVAL_REQUIRED
     elif derivation.state != "awaiting_reviewer_response":
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_NO
-    elif review_data.get("transition_notice_sent_at"):
+    elif _timestamp_at_or_after_anchor(review_data.get("transition_notice_sent_at"), derivation.anchor_timestamp):
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_TRANSITION_NOTICE_SENT
-    elif review_data.get("transition_warning_sent"):
+    elif _timestamp_at_or_after_anchor(review_data.get("transition_warning_sent"), derivation.anchor_timestamp):
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_WARNING_SENT
 
     return BoardProjectionValues(

--- a/scripts/reviewer_bot_lib/project_board.py
+++ b/scripts/reviewer_bot_lib/project_board.py
@@ -6,6 +6,8 @@ import copy
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from scripts.reviewer_bot_core import reviewer_response_policy
+
 from .config import (
     REVIEWER_BOARD_ENABLED_ENV,
     REVIEWER_BOARD_FIELD_ASSIGNED_AT,
@@ -92,6 +94,9 @@ class ReviewStateDerivation:
     state: str
     anchor_timestamp: str | None
     reason: str | None
+    current_scope_key: str | None
+    current_scope_basis: str | None
+    current_head_sha: str | None
 
 
 @dataclass(frozen=True)
@@ -279,6 +284,9 @@ def _derive_review_state(
         state=state,
         anchor_timestamp=derived.get("anchor_timestamp") if isinstance(derived.get("anchor_timestamp"), str) else None,
         reason=derived.get("reason") if isinstance(derived.get("reason"), str) else None,
+        current_scope_key=derived.get("current_scope_key") if isinstance(derived.get("current_scope_key"), str) else None,
+        current_scope_basis=derived.get("current_scope_basis") if isinstance(derived.get("current_scope_basis"), str) else None,
+        current_head_sha=derived.get("current_head_sha") if isinstance(derived.get("current_head_sha"), str) else None,
     )
 
 
@@ -355,10 +363,17 @@ def derive_board_projection(input: BoardProjectionInput) -> BoardProjectionValue
 
     needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_NO
     repair_needed = load_repair_marker(review_data, "status_label_projection")
-    if isinstance(repair_needed, dict) and repair_needed.get("kind") == "projection_failure":
+    fail_closed_reviewer_activity = reviewer_response_policy.has_fail_closed_reviewer_activity_for_current_scope(
+        review_data,
+        anchor_timestamp=derivation.anchor_timestamp,
+        current_head_sha=derivation.current_head_sha,
+    )
+    if (isinstance(repair_needed, dict) and repair_needed.get("kind") == "projection_failure") or fail_closed_reviewer_activity:
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED
     elif review_data.get("mandatory_approver_required"):
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_TRIAGE_APPROVAL_REQUIRED
+    elif derivation.state == "awaiting_contributor_response" and derivation.reason == "current_head_alternate_approval_present":
+        needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_NO
     elif review_data.get("transition_notice_sent_at"):
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_TRANSITION_NOTICE_SENT
     elif review_data.get("transition_warning_sent"):

--- a/scripts/reviewer_bot_lib/project_board.py
+++ b/scripts/reviewer_bot_lib/project_board.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from scripts.reviewer_bot_core import reviewer_response_policy
 
+from . import deferred_gap_bookkeeping as gap_bookkeeping
 from .config import (
     REVIEWER_BOARD_ENABLED_ENV,
     REVIEWER_BOARD_FIELD_ASSIGNED_AT,
@@ -267,6 +268,13 @@ def _format_date(value: Any) -> str | None:
     return value[:10]
 
 
+def _deferred_gap_records(review_data: dict[str, Any]) -> tuple[dict, ...]:
+    return tuple(
+        gap_bookkeeping.get_deferred_gap(review_data, source_event_key)
+        for source_event_key in gap_bookkeeping.list_deferred_gap_keys(review_data)
+    )
+
+
 def _derive_review_state(
     bot: ProjectBoardProjectionContext,
     issue_number: int,
@@ -365,6 +373,7 @@ def derive_board_projection(input: BoardProjectionInput) -> BoardProjectionValue
     repair_needed = load_repair_marker(review_data, "status_label_projection")
     fail_closed_reviewer_activity = reviewer_response_policy.has_fail_closed_reviewer_activity_for_current_scope(
         review_data,
+        _deferred_gap_records(review_data),
         anchor_timestamp=derivation.anchor_timestamp,
         current_head_sha=derivation.current_head_sha,
     )
@@ -372,7 +381,7 @@ def derive_board_projection(input: BoardProjectionInput) -> BoardProjectionValue
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED
     elif review_data.get("mandatory_approver_required"):
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_TRIAGE_APPROVAL_REQUIRED
-    elif derivation.state == "awaiting_contributor_response" and derivation.reason == "current_head_alternate_approval_present":
+    elif derivation.state != "awaiting_reviewer_response":
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_NO
     elif review_data.get("transition_notice_sent_at"):
         needs_attention = REVIEWER_BOARD_OPTION_ATTENTION_TRANSITION_NOTICE_SENT

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from scripts.reviewer_bot_core import comment_routing_policy, reconcile_replay_policy
 from scripts.reviewer_bot_core.comment_routing_policy import (
@@ -76,6 +76,18 @@ ParsedWorkflowRunPayload = DeferredReviewPayload | DeferredCommentPayload
 class WorkflowRunHandlerResult:
     state_changed: bool
     touched_items: list[int]
+
+
+@dataclass(frozen=True)
+class RecoverableDeferredPayloadIdentity:
+    source_run_id: int
+    source_run_attempt: int
+    source_event_name: str
+    source_event_action: str
+    source_event_key: str
+    pr_number: int
+    actor_login: str
+    source_event_created_at: str
 
 
 def _log(bot: ReconcileWorkflowRuntimeContext, level: str, message: str, **fields) -> None:
@@ -247,21 +259,87 @@ def optional_router_payload_missing(bot: ReconcileWorkflowRuntimeContext, event_
 
 
 _DEFERRED_PARSE_ERRORS = (RuntimeError, KeyError, TypeError, ValueError)
+_RECOVERABLE_DEFERRED_EVENT_KEY_PREFIXES = {
+    ("issue_comment", "created"): "issue_comment:",
+    ("pull_request_review_comment", "created"): "pull_request_review_comment:",
+    ("pull_request_review", "submitted"): "pull_request_review:",
+    ("pull_request_review", "dismissed"): "pull_request_review_dismissed:",
+}
 
 
-def _recover_deferred_payload_target(payload: object) -> tuple[int, str]:
+def _recover_positive_int(payload: dict, field_name: str) -> int:
+    try:
+        value = int(payload.get(field_name))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}") from exc
+    if value <= 0:
+        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}")
+    return value
+
+
+def _recover_nonempty_string(payload: dict, field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}")
+    return value.strip()
+
+
+def _first_recoverable_string(payload: dict, field_names: tuple[str, ...], diagnostic_name: str) -> str:
+    for field_name in field_names:
+        value = payload.get(field_name)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise RuntimeError(f"Deferred context payload lacks a recoverable {diagnostic_name}")
+
+
+def _recover_deferred_payload_identity(payload: object) -> RecoverableDeferredPayloadIdentity:
     if not isinstance(payload, dict):
         raise RuntimeError("Deferred context payload lacks a recoverable diagnostic target")
-    try:
-        pr_number = int(payload.get("pr_number"))
-    except (TypeError, ValueError) as exc:
-        raise RuntimeError("Deferred context payload lacks a recoverable PR number") from exc
-    source_event_key = payload.get("source_event_key")
-    if pr_number <= 0:
-        raise RuntimeError("Deferred context payload lacks a recoverable PR number")
-    if not isinstance(source_event_key, str) or not source_event_key.strip():
-        raise RuntimeError("Deferred context payload lacks a recoverable source_event_key")
-    return pr_number, source_event_key.strip()
+    pr_number = _recover_positive_int(payload, "pr_number")
+    source_run_id = _recover_positive_int(payload, "source_run_id")
+    source_run_attempt = _recover_positive_int(payload, "source_run_attempt")
+    source_event_name = _recover_nonempty_string(payload, "source_event_name")
+    source_event_action = _recover_nonempty_string(payload, "source_event_action")
+    source_event_key = _recover_nonempty_string(payload, "source_event_key")
+    expected_key_prefix = _RECOVERABLE_DEFERRED_EVENT_KEY_PREFIXES.get((source_event_name, source_event_action))
+    if expected_key_prefix is None:
+        raise RuntimeError("Deferred context payload lacks a supported recoverable event kind")
+    if not source_event_key.startswith(expected_key_prefix):
+        raise RuntimeError("Deferred context payload source_event_key does not match recoverable event kind")
+    actor_login = _first_recoverable_string(
+        payload,
+        ("source_actor_login", "comment_author", "actor_login", "review_author"),
+        "source actor login",
+    )
+    source_event_created_at = _first_recoverable_string(
+        payload,
+        (
+            "source_created_at",
+            "comment_created_at",
+            "source_submitted_at",
+            "source_dismissed_at",
+            "source_event_created_at",
+        ),
+        "source event timestamp",
+    )
+    payload["pr_number"] = pr_number
+    payload["source_run_id"] = source_run_id
+    payload["source_run_attempt"] = source_run_attempt
+    payload["source_event_name"] = source_event_name
+    payload["source_event_action"] = source_event_action
+    payload["source_event_key"] = source_event_key
+    payload.setdefault("source_actor_login", actor_login)
+    payload.setdefault("source_event_created_at", source_event_created_at)
+    return RecoverableDeferredPayloadIdentity(
+        source_run_id=source_run_id,
+        source_run_attempt=source_run_attempt,
+        source_event_name=source_event_name,
+        source_event_action=source_event_action,
+        source_event_key=source_event_key,
+        pr_number=pr_number,
+        actor_login=actor_login,
+        source_event_created_at=source_event_created_at,
+    )
 
 
 def _payload_source_commit_id(payload: dict) -> str | None:
@@ -271,18 +349,25 @@ def _payload_source_commit_id(payload: dict) -> str | None:
     return source_commit_id.strip()
 
 
-def _hydrate_live_review_comment_commit_id(context: DeferredCommentReplayContext, payload: dict, live_comment: dict) -> bool:
+def _hydrate_live_review_comment_commit_id(
+    context: DeferredCommentReplayContext,
+    live_comment: dict,
+) -> DeferredCommentReplayContext | None:
     if context.expected_event_name != "pull_request_review_comment":
-        return True
-    source_commit_id = _payload_source_commit_id(payload)
+        return context
+    payload = context.payload.raw_payload
+    source_commit_id = context.payload.source_commit_id or _payload_source_commit_id(payload)
     if source_commit_id is not None:
         payload["source_commit_id"] = source_commit_id
-        return True
+        if context.payload.source_commit_id == source_commit_id:
+            return context
+        return replace(context, payload=replace(context.payload, source_commit_id=source_commit_id))
     live_commit_id = live_comment.get("commit_id")
     if isinstance(live_commit_id, str) and live_commit_id.strip():
-        payload["source_commit_id"] = live_commit_id.strip()
-        return True
-    return False
+        source_commit_id = live_commit_id.strip()
+        payload["source_commit_id"] = source_commit_id
+        return replace(context, payload=replace(context.payload, source_commit_id=source_commit_id))
+    return None
 
 
 def _record_missing_review_comment_commit_id(
@@ -397,8 +482,10 @@ def _reconcile_deferred_comment(
             failure_kind=decision.failure_kind,
         )
         return changed or gap_changed
-    if not _hydrate_live_review_comment_commit_id(context, payload, live_comment):
+    hydrated_context = _hydrate_live_review_comment_commit_id(context, live_comment)
+    if hydrated_context is None:
         return _record_missing_review_comment_commit_id(bot, review_data, payload)
+    context = hydrated_context
     comment_context = _read_live_comment_replay_context(live_comment, payload)
     live_body = live_comment.get("body")
     if not isinstance(live_body, str):
@@ -680,9 +767,11 @@ def handle_workflow_run_event_result(bot: ReconcileWorkflowRuntimeContext, state
         parsed_payload = parse_deferred_context_payload(payload)
     except _DEFERRED_PARSE_ERRORS as exc:
         try:
-            pr_number, source_event_key = _recover_deferred_payload_target(payload)
+            recovered_identity = _recover_deferred_payload_identity(payload)
         except RuntimeError as recover_exc:
             raise RuntimeError(f"{recover_exc}; original parse error: {exc}") from exc
+        _reconcile_payloads.validate_triggering_run_identity(bot, payload)
+        pr_number = recovered_identity.pr_number
         review_data = ensure_review_entry(state, pr_number)
         if review_data is None:
             _log(
@@ -690,9 +779,39 @@ def handle_workflow_run_event_result(bot: ReconcileWorkflowRuntimeContext, state
                 "info",
                 f"Ignoring invalid deferred workflow_run for missing active review entry on PR #{pr_number}",
                 issue_number=pr_number,
-                source_event_key=source_event_key,
+                source_event_key=recovered_identity.source_event_key,
             )
             return WorkflowRunHandlerResult(False, [])
+        try:
+            live_pr_state = _read_live_pr_state_for_reconcile(bot, pr_number)
+            if live_pr_state == "closed":
+                _log(
+                    bot,
+                    "info",
+                    f"Ignoring invalid deferred workflow_run for closed PR #{pr_number}",
+                    issue_number=pr_number,
+                    source_event_key=recovered_identity.source_event_key,
+                )
+                return WorkflowRunHandlerResult(False, [])
+            if live_pr_state != "open":
+                raise ReconcileReadError(
+                    f"live PR #{pr_number} state is unsupported for replay: {live_pr_state}",
+                    failure_kind="invalid_payload",
+                )
+        except RuntimeError as live_pr_exc:
+            bot.collect_touched_item(pr_number)
+            failure_kind = live_pr_exc.failure_kind if isinstance(live_pr_exc, ReconcileReadError) else None
+            gap_changed = gap_bookkeeping.record_deferred_gap_diagnostic(
+                bot,
+                review_data,
+                payload,
+                "reconcile_failed_closed",
+                f"{live_pr_exc} See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.",
+                failure_kind=failure_kind,
+            )
+            if gap_changed:
+                return _build_result(True, pr_number)
+            raise
         bot.collect_touched_item(pr_number)
         gap_changed = gap_bookkeeping.record_deferred_gap_diagnostic(
             bot,

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -78,18 +78,6 @@ class WorkflowRunHandlerResult:
     touched_items: list[int]
 
 
-@dataclass(frozen=True)
-class RecoverableDeferredPayloadIdentity:
-    source_run_id: int
-    source_run_attempt: int
-    source_event_name: str
-    source_event_action: str
-    source_event_key: str
-    pr_number: int
-    actor_login: str
-    source_event_created_at: str
-
-
 def _log(bot: ReconcileWorkflowRuntimeContext, level: str, message: str, **fields) -> None:
     bot.logger.event(level, message, **fields)
 
@@ -259,87 +247,6 @@ def optional_router_payload_missing(bot: ReconcileWorkflowRuntimeContext, event_
 
 
 _DEFERRED_PARSE_ERRORS = (RuntimeError, KeyError, TypeError, ValueError)
-_RECOVERABLE_DEFERRED_EVENT_KEY_PREFIXES = {
-    ("issue_comment", "created"): "issue_comment:",
-    ("pull_request_review_comment", "created"): "pull_request_review_comment:",
-    ("pull_request_review", "submitted"): "pull_request_review:",
-    ("pull_request_review", "dismissed"): "pull_request_review_dismissed:",
-}
-
-
-def _recover_positive_int(payload: dict, field_name: str) -> int:
-    try:
-        value = int(payload.get(field_name))
-    except (TypeError, ValueError) as exc:
-        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}") from exc
-    if value <= 0:
-        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}")
-    return value
-
-
-def _recover_nonempty_string(payload: dict, field_name: str) -> str:
-    value = payload.get(field_name)
-    if not isinstance(value, str) or not value.strip():
-        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}")
-    return value.strip()
-
-
-def _first_recoverable_string(payload: dict, field_names: tuple[str, ...], diagnostic_name: str) -> str:
-    for field_name in field_names:
-        value = payload.get(field_name)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    raise RuntimeError(f"Deferred context payload lacks a recoverable {diagnostic_name}")
-
-
-def _recover_deferred_payload_identity(payload: object) -> RecoverableDeferredPayloadIdentity:
-    if not isinstance(payload, dict):
-        raise RuntimeError("Deferred context payload lacks a recoverable diagnostic target")
-    pr_number = _recover_positive_int(payload, "pr_number")
-    source_run_id = _recover_positive_int(payload, "source_run_id")
-    source_run_attempt = _recover_positive_int(payload, "source_run_attempt")
-    source_event_name = _recover_nonempty_string(payload, "source_event_name")
-    source_event_action = _recover_nonempty_string(payload, "source_event_action")
-    source_event_key = _recover_nonempty_string(payload, "source_event_key")
-    expected_key_prefix = _RECOVERABLE_DEFERRED_EVENT_KEY_PREFIXES.get((source_event_name, source_event_action))
-    if expected_key_prefix is None:
-        raise RuntimeError("Deferred context payload lacks a supported recoverable event kind")
-    if not source_event_key.startswith(expected_key_prefix):
-        raise RuntimeError("Deferred context payload source_event_key does not match recoverable event kind")
-    actor_login = _first_recoverable_string(
-        payload,
-        ("source_actor_login", "comment_author", "actor_login", "review_author"),
-        "source actor login",
-    )
-    source_event_created_at = _first_recoverable_string(
-        payload,
-        (
-            "source_created_at",
-            "comment_created_at",
-            "source_submitted_at",
-            "source_dismissed_at",
-            "source_event_created_at",
-        ),
-        "source event timestamp",
-    )
-    payload["pr_number"] = pr_number
-    payload["source_run_id"] = source_run_id
-    payload["source_run_attempt"] = source_run_attempt
-    payload["source_event_name"] = source_event_name
-    payload["source_event_action"] = source_event_action
-    payload["source_event_key"] = source_event_key
-    payload.setdefault("source_actor_login", actor_login)
-    payload.setdefault("source_event_created_at", source_event_created_at)
-    return RecoverableDeferredPayloadIdentity(
-        source_run_id=source_run_id,
-        source_run_attempt=source_run_attempt,
-        source_event_name=source_event_name,
-        source_event_action=source_event_action,
-        source_event_key=source_event_key,
-        pr_number=pr_number,
-        actor_login=actor_login,
-        source_event_created_at=source_event_created_at,
-    )
 
 
 def _payload_source_commit_id(payload: dict) -> str | None:
@@ -767,10 +674,11 @@ def handle_workflow_run_event_result(bot: ReconcileWorkflowRuntimeContext, state
         parsed_payload = parse_deferred_context_payload(payload)
     except _DEFERRED_PARSE_ERRORS as exc:
         try:
-            recovered_identity = _recover_deferred_payload_identity(payload)
+            recovered_identity = _reconcile_payloads.recover_deferred_payload_identity(payload)
         except RuntimeError as recover_exc:
             raise RuntimeError(f"{recover_exc}; original parse error: {exc}") from exc
-        _reconcile_payloads.validate_triggering_run_identity(bot, payload)
+        diagnostic_payload = recovered_identity.diagnostic_payload
+        _reconcile_payloads.validate_triggering_run_identity(bot, diagnostic_payload)
         pr_number = recovered_identity.pr_number
         review_data = ensure_review_entry(state, pr_number)
         if review_data is None:
@@ -804,7 +712,7 @@ def handle_workflow_run_event_result(bot: ReconcileWorkflowRuntimeContext, state
             gap_changed = gap_bookkeeping.record_deferred_gap_diagnostic(
                 bot,
                 review_data,
-                payload,
+                diagnostic_payload,
                 "reconcile_failed_closed",
                 f"{live_pr_exc} See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.",
                 failure_kind=failure_kind,
@@ -816,7 +724,7 @@ def handle_workflow_run_event_result(bot: ReconcileWorkflowRuntimeContext, state
         gap_changed = gap_bookkeeping.record_deferred_gap_diagnostic(
             bot,
             review_data,
-            payload,
+            diagnostic_payload,
             "artifact_invalid",
             f"{exc} See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.",
             failure_kind="invalid_payload",

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -246,6 +246,65 @@ def optional_router_payload_missing(bot: ReconcileWorkflowRuntimeContext, event_
     return False
 
 
+_DEFERRED_PARSE_ERRORS = (RuntimeError, KeyError, TypeError, ValueError)
+
+
+def _recover_deferred_payload_target(payload: object) -> tuple[int, str]:
+    if not isinstance(payload, dict):
+        raise RuntimeError("Deferred context payload lacks a recoverable diagnostic target")
+    try:
+        pr_number = int(payload.get("pr_number"))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Deferred context payload lacks a recoverable PR number") from exc
+    source_event_key = payload.get("source_event_key")
+    if pr_number <= 0:
+        raise RuntimeError("Deferred context payload lacks a recoverable PR number")
+    if not isinstance(source_event_key, str) or not source_event_key.strip():
+        raise RuntimeError("Deferred context payload lacks a recoverable source_event_key")
+    return pr_number, source_event_key.strip()
+
+
+def _payload_source_commit_id(payload: dict) -> str | None:
+    source_commit_id = payload.get("source_commit_id")
+    if not isinstance(source_commit_id, str) or not source_commit_id.strip():
+        return None
+    return source_commit_id.strip()
+
+
+def _hydrate_live_review_comment_commit_id(context: DeferredCommentReplayContext, payload: dict, live_comment: dict) -> bool:
+    if context.expected_event_name != "pull_request_review_comment":
+        return True
+    source_commit_id = _payload_source_commit_id(payload)
+    if source_commit_id is not None:
+        payload["source_commit_id"] = source_commit_id
+        return True
+    live_commit_id = live_comment.get("commit_id")
+    if isinstance(live_commit_id, str) and live_commit_id.strip():
+        payload["source_commit_id"] = live_commit_id.strip()
+        return True
+    return False
+
+
+def _record_missing_review_comment_commit_id(
+    bot: ReconcileWorkflowRuntimeContext,
+    review_data: dict,
+    payload: dict,
+    *,
+    failure_kind: str | None = "invalid_payload",
+) -> bool:
+    return gap_bookkeeping.record_deferred_gap_diagnostic(
+        bot,
+        review_data,
+        payload,
+        "artifact_invalid",
+        (
+            "Deferred review comment artifact source_commit_id could not be recovered from live review comment; "
+            f"replay suppressed. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}."
+        ),
+        failure_kind=failure_kind,
+    )
+
+
 def _classify_deferred_comment_payload(payload: DeferredCommentPayload) -> dict:
     if payload.source_comment_class is not None and payload.source_has_non_command_text is not None:
         return {
@@ -305,6 +364,13 @@ def _reconcile_deferred_comment(
     try:
         live_comment = _read_reconcile_object(bot, context.live_comment_endpoint, label=f"deferred comment {comment_id}")
     except ReconcileReadError as exc:
+        if context.expected_event_name == "pull_request_review_comment" and _payload_source_commit_id(payload) is None:
+            return _record_missing_review_comment_commit_id(
+                bot,
+                review_data,
+                payload,
+                failure_kind=exc.failure_kind,
+            )
         decision = reconcile_replay_policy.decide_comment_replay(
             comment_id=comment_id,
             source_comment_class=str(source_classified.get("comment_class", ObserverCommentClassification.PLAIN_TEXT)),
@@ -331,6 +397,8 @@ def _reconcile_deferred_comment(
             failure_kind=decision.failure_kind,
         )
         return changed or gap_changed
+    if not _hydrate_live_review_comment_commit_id(context, payload, live_comment):
+        return _record_missing_review_comment_commit_id(bot, review_data, payload)
     comment_context = _read_live_comment_replay_context(live_comment, payload)
     live_body = live_comment.get("body")
     if not isinstance(live_body, str):
@@ -608,7 +676,33 @@ def handle_workflow_run_event_result(bot: ReconcileWorkflowRuntimeContext, state
         if event_context.workflow_artifact_contract == "artifact_optional_router" and _is_missing_optional_router_payload_error(exc):
             return WorkflowRunHandlerResult(False, [])
         raise
-    parsed_payload = parse_deferred_context_payload(payload)
+    try:
+        parsed_payload = parse_deferred_context_payload(payload)
+    except _DEFERRED_PARSE_ERRORS as exc:
+        try:
+            pr_number, source_event_key = _recover_deferred_payload_target(payload)
+        except RuntimeError as recover_exc:
+            raise RuntimeError(f"{recover_exc}; original parse error: {exc}") from exc
+        review_data = ensure_review_entry(state, pr_number)
+        if review_data is None:
+            _log(
+                bot,
+                "info",
+                f"Ignoring invalid deferred workflow_run for missing active review entry on PR #{pr_number}",
+                issue_number=pr_number,
+                source_event_key=source_event_key,
+            )
+            return WorkflowRunHandlerResult(False, [])
+        bot.collect_touched_item(pr_number)
+        gap_changed = gap_bookkeeping.record_deferred_gap_diagnostic(
+            bot,
+            review_data,
+            payload,
+            "artifact_invalid",
+            f"{exc} See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.",
+            failure_kind="invalid_payload",
+        )
+        return _build_result(gap_changed, pr_number)
     pr_number = parsed_payload.pr_number
     if pr_number <= 0:
         raise RuntimeError("Deferred context is missing a valid PR number")

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -247,6 +247,12 @@ def optional_router_payload_missing(bot: ReconcileWorkflowRuntimeContext, event_
 
 
 def _classify_deferred_comment_payload(payload: DeferredCommentPayload) -> dict:
+    if payload.source_comment_class is not None and payload.source_has_non_command_text is not None:
+        return {
+            "comment_class": payload.source_comment_class,
+            "has_non_command_text": payload.source_has_non_command_text,
+            "command_count": 1 if payload.source_comment_class in {"command_only", "command_plus_text"} else 0,
+        }
     normalized_body = "\n".join(line.rstrip() for line in payload.comment_body.replace("\r\n", "\n").split("\n")).strip()
     classified = comment_routing_policy.classify_comment_payload(
         "@guidelines-bot",
@@ -258,6 +264,12 @@ def _classify_deferred_comment_payload(payload: DeferredCommentPayload) -> dict:
         "has_non_command_text": bool(classified.get("has_non_command_text")),
         "command_count": int(classified.get("command_count", 0)),
     }
+
+
+def _deferred_comment_body_digest_matches(payload: DeferredCommentPayload, live_body: str) -> bool:
+    if payload.source_body_digest is not None:
+        return digest_comment_body(live_body) == payload.source_body_digest
+    return digest_comment_body(live_body) == digest_comment_body(payload.comment_body)
 
 
 def _reconcile_deferred_comment(
@@ -323,7 +335,7 @@ def _reconcile_deferred_comment(
     if not isinstance(live_body, str):
         raise RuntimeError("Live deferred comment body is unavailable")
     live_classified = classify_comment_payload(bot, live_body)
-    if digest_comment_body(live_body) != digest_comment_body(context.payload.comment_body):
+    if not _deferred_comment_body_digest_matches(context.payload, live_body):
         decision = reconcile_replay_policy.decide_comment_replay(
             comment_id=comment_id,
             source_comment_class=str(source_classified.get("comment_class", ObserverCommentClassification.PLAIN_TEXT)),

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -281,7 +281,7 @@ def _reconcile_deferred_comment(
     payload = context.payload.raw_payload
     comment_id = context.comment_id
     pr_number = context.pr_number
-    _read_live_pr_replay_context(bot, pr_number)
+    live_pr_context = _read_live_pr_replay_context(bot, pr_number)
     source_freshness_eligible = context.source_freshness_eligible
     source_classified = _classify_deferred_comment_payload(context.payload)
 
@@ -289,6 +289,7 @@ def _reconcile_deferred_comment(
         return build_replay_comment_event_request(
             context.payload,
             live_comment=comment_context,
+            live_pr=live_pr_context,
             comment_body=comment_body,
         )
 

--- a/scripts/reviewer_bot_lib/reconcile_payloads.py
+++ b/scripts/reviewer_bot_lib/reconcile_payloads.py
@@ -56,6 +56,11 @@ class DeferredCommentPayload:
     issue_state: str
     issue_labels: tuple[str, ...]
     raw_payload: dict
+    source_commit_id: str | None = None
+    source_body_digest: str | None = None
+    source_comment_class: str | None = None
+    source_has_non_command_text: bool | None = None
+    source_freshness_eligible: bool = True
 
     @property
     def pr_number(self) -> int:
@@ -90,7 +95,7 @@ class DeferredCommentReplayContext:
 
     @property
     def source_freshness_eligible(self) -> bool:
-        return True
+        return self.payload.source_freshness_eligible
 
 
 @dataclass(frozen=True)
@@ -115,8 +120,16 @@ class DeferredReviewReplayContext:
 
 
 def _build_deferred_identity(payload: dict) -> DeferredArtifactIdentity:
+    payload_kind = payload.get("payload_kind")
+    if payload_kind is None and payload.get("schema_version") == 2:
+        source_event_name = payload.get("source_event_name")
+        source_event_action = payload.get("source_event_action")
+        if source_event_action == "created" and source_event_name == "issue_comment":
+            payload_kind = DeferredPayloadKind.DEFERRED_COMMENT.value
+        elif source_event_action == "created" and source_event_name == "pull_request_review_comment":
+            payload_kind = DeferredPayloadKind.DEFERRED_REVIEW_COMMENT.value
     try:
-        resolved_payload_kind = DeferredPayloadKind(str(payload["payload_kind"]))
+        resolved_payload_kind = DeferredPayloadKind(str(payload_kind))
     except (KeyError, ValueError) as exc:
         raise RuntimeError("Unsupported deferred workflow_run payload") from exc
     return DeferredArtifactIdentity(
@@ -160,6 +173,9 @@ def build_deferred_review_replay_context(
 
 
 def _validate_deferred_comment_artifact(payload: dict) -> None:
+    if payload.get("schema_version") == 2:
+        _validate_legacy_deferred_comment_artifact(payload)
+        return
     required = {
         "payload_kind",
         "schema_version",
@@ -198,6 +214,42 @@ def _validate_deferred_comment_artifact(payload: dict) -> None:
         raise RuntimeError("Deferred comment artifact comment_performed_via_github_app must be boolean")
 
 
+def _validate_legacy_deferred_comment_artifact(payload: dict) -> None:
+    required = {
+        "schema_version",
+        "source_run_id",
+        "source_run_attempt",
+        "source_event_name",
+        "source_event_action",
+        "source_event_key",
+        "pr_number",
+        "comment_id",
+        "comment_class",
+        "has_non_command_text",
+        "source_body_digest",
+        "source_created_at",
+        "actor_login",
+    }
+    missing = sorted(required - set(payload))
+    if missing:
+        raise RuntimeError("Deferred legacy comment artifact missing required fields: " + ", ".join(missing))
+    if payload.get("schema_version") != 2:
+        raise RuntimeError("Deferred workflow_run payload schema_version is not accepted")
+    if payload.get("source_event_action") != "created" or payload.get("source_event_name") not in {
+        "issue_comment",
+        "pull_request_review_comment",
+    }:
+        raise RuntimeError("Deferred legacy comment artifact event type is not accepted")
+    if not isinstance(payload.get("comment_id"), int) or not isinstance(payload.get("pr_number"), int):
+        raise RuntimeError("Deferred legacy comment artifact comment_id and pr_number must be integers")
+    if not isinstance(payload.get("source_created_at"), str) or not isinstance(payload.get("source_body_digest"), str):
+        raise RuntimeError("Deferred legacy comment artifact timestamp or body digest is malformed")
+    if not isinstance(payload.get("comment_class"), str) or not isinstance(payload.get("has_non_command_text"), bool):
+        raise RuntimeError("Deferred legacy comment artifact classification is malformed")
+    if not isinstance(payload.get("actor_login"), str) or not payload["actor_login"].strip():
+        raise RuntimeError("Deferred legacy comment artifact actor login is unavailable")
+
+
 def _validate_deferred_review_artifact(payload: dict) -> None:
     required = {
         "payload_kind",
@@ -226,11 +278,37 @@ def _validate_deferred_review_comment_artifact(payload: dict) -> None:
 def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | DeferredCommentPayload:
     if not isinstance(payload, dict):
         raise RuntimeError("Deferred context payload must be a JSON object")
-    if payload.get("schema_version") != 3:
-        raise RuntimeError("Deferred workflow_run payload schema_version is not accepted")
     identity = _build_deferred_identity(payload)
     if identity.payload_kind == DeferredPayloadKind.DEFERRED_COMMENT or identity.payload_kind == DeferredPayloadKind.DEFERRED_REVIEW_COMMENT:
         _validate_deferred_review_comment_artifact(payload)
+        if identity.schema_version == 2:
+            actor_id = payload.get("actor_id")
+            try:
+                comment_author_id = int(actor_id) if actor_id is not None else 0
+            except (TypeError, ValueError):
+                comment_author_id = 0
+            return DeferredCommentPayload(
+                identity=identity,
+                comment_id=int(payload["comment_id"]),
+                comment_body="",
+                comment_created_at=str(payload["source_created_at"]),
+                comment_author=str(payload["actor_login"]),
+                comment_author_id=comment_author_id,
+                comment_user_type=str(payload.get("actor_user_type") or "User"),
+                comment_sender_type=str(payload.get("actor_sender_type") or "User"),
+                comment_installation_id=(str(payload["comment_installation_id"]) if payload.get("comment_installation_id") else None),
+                comment_performed_via_github_app=bool(payload.get("comment_performed_via_github_app", False)),
+                issue_author=str(payload.get("issue_author") or ""),
+                issue_state=str(payload.get("issue_state") or "open"),
+                issue_labels=tuple(str(label) for label in payload.get("issue_labels", ())),
+                raw_payload=payload,
+                source_commit_id=(str(payload["source_commit_id"]) if payload.get("source_commit_id") is not None else None),
+                source_body_digest=str(payload["source_body_digest"]),
+                source_comment_class=str(payload["comment_class"]),
+                source_has_non_command_text=bool(payload["has_non_command_text"]),
+            )
+        if identity.schema_version != 3:
+            raise RuntimeError("Deferred workflow_run payload schema_version is not accepted")
         return DeferredCommentPayload(
             identity=identity,
             comment_id=int(payload["comment_id"]),
@@ -246,6 +324,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
             issue_state=str(payload["issue_state"]),
             issue_labels=tuple(str(label) for label in payload["issue_labels"]),
             raw_payload=payload,
+            source_commit_id=(str(payload["source_commit_id"]) if payload.get("source_commit_id") is not None else None),
         )
     if identity.payload_kind == DeferredPayloadKind.DEFERRED_REVIEW_SUBMITTED or identity.payload_kind == DeferredPayloadKind.DEFERRED_REVIEW_DISMISSED:
         _validate_deferred_review_artifact(payload)

--- a/scripts/reviewer_bot_lib/reconcile_payloads.py
+++ b/scripts/reviewer_bot_lib/reconcile_payloads.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 
 
@@ -23,6 +24,31 @@ class DeferredArtifactIdentity:
     source_event_action: str
     source_event_key: str
     pr_number: int
+
+
+@dataclass(frozen=True)
+class DeferredIdentityContract:
+    payload_kind: DeferredPayloadKind
+    source_event_name: str
+    source_event_action: str
+    source_event_key_prefix: str
+    object_id_field: str
+    actor_fields: tuple[str, ...]
+    timestamp_fields: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RecoveredDeferredPayloadIdentity:
+    source_run_id: int
+    source_run_attempt: int
+    source_event_name: str
+    source_event_action: str
+    source_event_key: str
+    pr_number: int
+    source_object_id: int
+    actor_login: str
+    source_event_created_at: str
+    diagnostic_payload: dict
 
 
 @dataclass(frozen=True)
@@ -119,35 +145,140 @@ class DeferredReviewReplayContext:
         return self.payload.actor_login or ""
 
 
-_EXPECTED_IDENTITY_CONTRACTS: dict[DeferredPayloadKind, tuple[str, str, str]] = {
-    DeferredPayloadKind.DEFERRED_COMMENT: ("issue_comment", "created", "issue_comment:"),
-    DeferredPayloadKind.DEFERRED_REVIEW_COMMENT: (
-        "pull_request_review_comment",
-        "created",
-        "pull_request_review_comment:",
+_DEFERRED_IDENTITY_CONTRACTS: dict[DeferredPayloadKind, DeferredIdentityContract] = {
+    DeferredPayloadKind.DEFERRED_COMMENT: DeferredIdentityContract(
+        payload_kind=DeferredPayloadKind.DEFERRED_COMMENT,
+        source_event_name="issue_comment",
+        source_event_action="created",
+        source_event_key_prefix="issue_comment:",
+        object_id_field="comment_id",
+        actor_fields=("source_actor_login", "comment_author", "actor_login"),
+        timestamp_fields=("source_created_at", "comment_created_at", "source_event_created_at"),
     ),
-    DeferredPayloadKind.DEFERRED_REVIEW_SUBMITTED: (
-        "pull_request_review",
-        "submitted",
-        "pull_request_review:",
+    DeferredPayloadKind.DEFERRED_REVIEW_COMMENT: DeferredIdentityContract(
+        payload_kind=DeferredPayloadKind.DEFERRED_REVIEW_COMMENT,
+        source_event_name="pull_request_review_comment",
+        source_event_action="created",
+        source_event_key_prefix="pull_request_review_comment:",
+        object_id_field="comment_id",
+        actor_fields=("source_actor_login", "comment_author", "actor_login"),
+        timestamp_fields=("source_created_at", "comment_created_at", "source_event_created_at"),
     ),
-    DeferredPayloadKind.DEFERRED_REVIEW_DISMISSED: (
-        "pull_request_review",
-        "dismissed",
-        "pull_request_review_dismissed:",
+    DeferredPayloadKind.DEFERRED_REVIEW_SUBMITTED: DeferredIdentityContract(
+        payload_kind=DeferredPayloadKind.DEFERRED_REVIEW_SUBMITTED,
+        source_event_name="pull_request_review",
+        source_event_action="submitted",
+        source_event_key_prefix="pull_request_review:",
+        object_id_field="review_id",
+        actor_fields=("source_actor_login", "review_author", "actor_login"),
+        timestamp_fields=("source_submitted_at", "source_event_created_at"),
+    ),
+    DeferredPayloadKind.DEFERRED_REVIEW_DISMISSED: DeferredIdentityContract(
+        payload_kind=DeferredPayloadKind.DEFERRED_REVIEW_DISMISSED,
+        source_event_name="pull_request_review",
+        source_event_action="dismissed",
+        source_event_key_prefix="pull_request_review_dismissed:",
+        object_id_field="review_id",
+        actor_fields=("source_actor_login", "review_author", "actor_login"),
+        timestamp_fields=("source_dismissed_at", "source_event_created_at"),
     ),
 }
+_DEFERRED_CONTRACTS_BY_EVENT: dict[tuple[str, str], DeferredIdentityContract] = {
+    (contract.source_event_name, contract.source_event_action): contract
+    for contract in _DEFERRED_IDENTITY_CONTRACTS.values()
+}
+
+
+def _contract_for_event(source_event_name: object, source_event_action: object) -> DeferredIdentityContract | None:
+    if not isinstance(source_event_name, str) or not isinstance(source_event_action, str):
+        return None
+    return _DEFERRED_CONTRACTS_BY_EVENT.get((source_event_name.strip(), source_event_action.strip()))
+
+
+def _positive_int(payload: dict, field_name: str) -> int:
+    try:
+        value = int(payload.get(field_name))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}") from exc
+    if value <= 0:
+        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}")
+    return value
+
+
+def _nonempty_string(payload: dict, field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"Deferred context payload lacks a recoverable {field_name}")
+    return value.strip()
+
+
+def _first_string(payload: dict, field_names: tuple[str, ...], diagnostic_name: str) -> str:
+    for field_name in field_names:
+        value = payload.get(field_name)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise RuntimeError(f"Deferred context payload lacks a recoverable {diagnostic_name}")
+
+
+def _recoverable_timestamp(payload: dict, field_names: tuple[str, ...]) -> str:
+    timestamp = _first_string(payload, field_names, "source event timestamp")
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RuntimeError("Deferred context payload source event timestamp is not parseable ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise RuntimeError("Deferred context payload source event timestamp must include timezone")
+    return timestamp
+
+
+def _optional_nonempty_string(payload: dict, field_name: str) -> str | None:
+    value = payload.get(field_name)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _diagnostic_payload(payload: dict, contract: DeferredIdentityContract, *, source_run_id: int, source_run_attempt: int, pr_number: int, source_event_key: str, source_object_id: int, actor_login: str, source_event_created_at: str) -> dict:
+    diagnostic = {
+        "source_run_id": source_run_id,
+        "source_run_attempt": source_run_attempt,
+        "source_event_name": contract.source_event_name,
+        "source_event_action": contract.source_event_action,
+        "source_event_key": source_event_key,
+        "pr_number": pr_number,
+        contract.object_id_field: source_object_id,
+        "source_actor_login": actor_login,
+        "source_event_created_at": source_event_created_at,
+    }
+    for field_name in (
+        "source_workflow_file",
+        "source_artifact_name",
+        "source_commit_id",
+        "source_review_state",
+        "source_dismissed_at",
+    ):
+        value = _optional_nonempty_string(payload, field_name)
+        if value is not None:
+            diagnostic[field_name] = value
+    actor_id = payload.get("source_actor_id", payload.get("comment_author_id", payload.get("actor_id")))
+    if actor_id is not None:
+        diagnostic["source_actor_id"] = actor_id
+    if contract.object_id_field == "comment_id":
+        diagnostic["source_comment_id"] = source_object_id
+    if contract.object_id_field == "review_id":
+        diagnostic["source_review_id"] = source_object_id
+    return diagnostic
 
 
 def _build_deferred_identity(payload: dict) -> DeferredArtifactIdentity:
     payload_kind = payload.get("payload_kind")
     if payload_kind is None and payload.get("schema_version") == 2:
-        source_event_name = payload.get("source_event_name")
-        source_event_action = payload.get("source_event_action")
-        if source_event_action == "created" and source_event_name == "issue_comment":
-            payload_kind = DeferredPayloadKind.DEFERRED_COMMENT.value
-        elif source_event_action == "created" and source_event_name == "pull_request_review_comment":
-            payload_kind = DeferredPayloadKind.DEFERRED_REVIEW_COMMENT.value
+        contract = _contract_for_event(payload.get("source_event_name"), payload.get("source_event_action"))
+        if contract is not None and contract.payload_kind in {
+            DeferredPayloadKind.DEFERRED_COMMENT,
+            DeferredPayloadKind.DEFERRED_REVIEW_COMMENT,
+        }:
+            payload_kind = contract.payload_kind.value
     try:
         resolved_payload_kind = DeferredPayloadKind(str(payload_kind))
     except (KeyError, ValueError) as exc:
@@ -165,16 +296,57 @@ def _build_deferred_identity(payload: dict) -> DeferredArtifactIdentity:
 
 
 def _validate_identity_contract(identity: DeferredArtifactIdentity) -> None:
-    expected_event_name, expected_event_action, expected_key_prefix = _EXPECTED_IDENTITY_CONTRACTS[
-        identity.payload_kind
-    ]
+    contract = _DEFERRED_IDENTITY_CONTRACTS[identity.payload_kind]
     if (
-        identity.source_event_name != expected_event_name
-        or identity.source_event_action != expected_event_action
+        identity.source_event_name != contract.source_event_name
+        or identity.source_event_action != contract.source_event_action
     ):
         raise RuntimeError("Deferred workflow_run payload kind/event mismatch")
-    if not identity.source_event_key.startswith(expected_key_prefix):
+    if not identity.source_event_key.startswith(contract.source_event_key_prefix):
         raise RuntimeError("Deferred workflow_run payload source_event_key prefix mismatch")
+
+
+def recover_deferred_payload_identity(payload: object) -> RecoveredDeferredPayloadIdentity:
+    if not isinstance(payload, dict):
+        raise RuntimeError("Deferred context payload lacks a recoverable diagnostic target")
+    source_run_id = _positive_int(payload, "source_run_id")
+    source_run_attempt = _positive_int(payload, "source_run_attempt")
+    pr_number = _positive_int(payload, "pr_number")
+    source_event_name = _nonempty_string(payload, "source_event_name")
+    source_event_action = _nonempty_string(payload, "source_event_action")
+    contract = _contract_for_event(source_event_name, source_event_action)
+    if contract is None:
+        raise RuntimeError("Deferred context payload lacks a supported recoverable event kind")
+    source_object_id = _positive_int(payload, contract.object_id_field)
+    source_event_key = _nonempty_string(payload, "source_event_key")
+    expected_source_event_key = f"{contract.source_event_key_prefix}{source_object_id}"
+    if source_event_key != expected_source_event_key:
+        raise RuntimeError("Deferred context payload source_event_key does not match recoverable object id")
+    actor_login = _first_string(payload, contract.actor_fields, "source actor login")
+    source_event_created_at = _recoverable_timestamp(payload, contract.timestamp_fields)
+    diagnostic_payload = _diagnostic_payload(
+        payload,
+        contract,
+        source_run_id=source_run_id,
+        source_run_attempt=source_run_attempt,
+        pr_number=pr_number,
+        source_event_key=source_event_key,
+        source_object_id=source_object_id,
+        actor_login=actor_login,
+        source_event_created_at=source_event_created_at,
+    )
+    return RecoveredDeferredPayloadIdentity(
+        source_run_id=source_run_id,
+        source_run_attempt=source_run_attempt,
+        source_event_name=contract.source_event_name,
+        source_event_action=contract.source_event_action,
+        source_event_key=source_event_key,
+        pr_number=pr_number,
+        source_object_id=source_object_id,
+        actor_login=actor_login,
+        source_event_created_at=source_event_created_at,
+        diagnostic_payload=diagnostic_payload,
+    )
 
 
 def build_deferred_comment_replay_context(
@@ -183,7 +355,10 @@ def build_deferred_comment_replay_context(
     expected_event_name: str,
     live_comment_endpoint: str,
 ) -> DeferredCommentReplayContext:
-    if payload.identity.source_event_key != f"{expected_event_name}:{payload.comment_id}":
+    contract = _contract_for_event(expected_event_name, "created")
+    if contract is None or contract.object_id_field != "comment_id":
+        raise RuntimeError("Deferred comment artifact event type is not accepted")
+    if payload.identity.source_event_key != f"{contract.source_event_key_prefix}{payload.comment_id}":
         raise RuntimeError("Deferred comment artifact source_event_key mismatch")
     return DeferredCommentReplayContext(
         payload=payload,
@@ -197,10 +372,12 @@ def build_deferred_review_replay_context(
     *,
     expected_event_action: str,
 ) -> DeferredReviewReplayContext:
-    expected_prefix = "pull_request_review:" if expected_event_action == "submitted" else "pull_request_review_dismissed:"
+    contract = _contract_for_event("pull_request_review", expected_event_action)
+    if contract is None or contract.object_id_field != "review_id":
+        raise RuntimeError("Deferred review artifact event type is not accepted")
     if payload.identity.source_event_action != expected_event_action:
         raise RuntimeError("Deferred review artifact action mismatch")
-    if payload.identity.source_event_key != f"{expected_prefix}{payload.review_id}":
+    if payload.identity.source_event_key != f"{contract.source_event_key_prefix}{payload.review_id}":
         raise RuntimeError(f"Deferred review-{expected_event_action} artifact source_event_key mismatch")
     return DeferredReviewReplayContext(payload=payload)
 

--- a/scripts/reviewer_bot_lib/reconcile_payloads.py
+++ b/scripts/reviewer_bot_lib/reconcile_payloads.py
@@ -306,6 +306,16 @@ def _validate_identity_contract(identity: DeferredArtifactIdentity) -> None:
         raise RuntimeError("Deferred workflow_run payload source_event_key prefix mismatch")
 
 
+def _canonical_source_event_key(contract: DeferredIdentityContract, source_object_id: int) -> str:
+    return f"{contract.source_event_key_prefix}{source_object_id}"
+
+
+def _validate_identity_object_key(identity: DeferredArtifactIdentity, source_object_id: int) -> None:
+    contract = _DEFERRED_IDENTITY_CONTRACTS[identity.payload_kind]
+    if identity.source_event_key != _canonical_source_event_key(contract, source_object_id):
+        raise RuntimeError("Deferred workflow_run payload source_event_key object mismatch")
+
+
 def recover_deferred_payload_identity(payload: object) -> RecoveredDeferredPayloadIdentity:
     if not isinstance(payload, dict):
         raise RuntimeError("Deferred context payload lacks a recoverable diagnostic target")
@@ -319,8 +329,7 @@ def recover_deferred_payload_identity(payload: object) -> RecoveredDeferredPaylo
         raise RuntimeError("Deferred context payload lacks a supported recoverable event kind")
     source_object_id = _positive_int(payload, contract.object_id_field)
     source_event_key = _nonempty_string(payload, "source_event_key")
-    expected_source_event_key = f"{contract.source_event_key_prefix}{source_object_id}"
-    if source_event_key != expected_source_event_key:
+    if source_event_key != _canonical_source_event_key(contract, source_object_id):
         raise RuntimeError("Deferred context payload source_event_key does not match recoverable object id")
     actor_login = _first_string(payload, contract.actor_fields, "source actor login")
     source_event_created_at = _recoverable_timestamp(payload, contract.timestamp_fields)
@@ -358,7 +367,7 @@ def build_deferred_comment_replay_context(
     contract = _contract_for_event(expected_event_name, "created")
     if contract is None or contract.object_id_field != "comment_id":
         raise RuntimeError("Deferred comment artifact event type is not accepted")
-    if payload.identity.source_event_key != f"{contract.source_event_key_prefix}{payload.comment_id}":
+    if payload.identity.source_event_key != _canonical_source_event_key(contract, payload.comment_id):
         raise RuntimeError("Deferred comment artifact source_event_key mismatch")
     return DeferredCommentReplayContext(
         payload=payload,
@@ -377,7 +386,7 @@ def build_deferred_review_replay_context(
         raise RuntimeError("Deferred review artifact event type is not accepted")
     if payload.identity.source_event_action != expected_event_action:
         raise RuntimeError("Deferred review artifact action mismatch")
-    if payload.identity.source_event_key != f"{contract.source_event_key_prefix}{payload.review_id}":
+    if payload.identity.source_event_key != _canonical_source_event_key(contract, payload.review_id):
         raise RuntimeError(f"Deferred review-{expected_event_action} artifact source_event_key mismatch")
     return DeferredReviewReplayContext(payload=payload)
 
@@ -512,6 +521,8 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
     _validate_identity_contract(identity)
     if identity.payload_kind == DeferredPayloadKind.DEFERRED_COMMENT or identity.payload_kind == DeferredPayloadKind.DEFERRED_REVIEW_COMMENT:
         _validate_deferred_review_comment_artifact(payload)
+        comment_id = int(payload["comment_id"])
+        _validate_identity_object_key(identity, comment_id)
         if identity.schema_version == 2:
             actor_id = payload.get("actor_id")
             try:
@@ -520,7 +531,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
                 comment_author_id = 0
             return DeferredCommentPayload(
                 identity=identity,
-                comment_id=int(payload["comment_id"]),
+                comment_id=comment_id,
                 comment_body="",
                 comment_created_at=str(payload["source_created_at"]),
                 comment_author=str(payload["actor_login"]),
@@ -542,7 +553,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
             raise RuntimeError("Deferred workflow_run payload schema_version is not accepted")
         return DeferredCommentPayload(
             identity=identity,
-            comment_id=int(payload["comment_id"]),
+            comment_id=comment_id,
             comment_body=str(payload["comment_body"]),
             comment_created_at=str(payload["comment_created_at"]),
             comment_author=str(payload["comment_author"]),
@@ -559,9 +570,11 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
         )
     if identity.payload_kind == DeferredPayloadKind.DEFERRED_REVIEW_SUBMITTED or identity.payload_kind == DeferredPayloadKind.DEFERRED_REVIEW_DISMISSED:
         _validate_deferred_review_artifact(payload)
+        review_id = int(payload["review_id"])
+        _validate_identity_object_key(identity, review_id)
         return DeferredReviewPayload(
             identity=identity,
-            review_id=int(payload["review_id"]),
+            review_id=review_id,
             source_submitted_at=(str(payload["source_submitted_at"]) if payload.get("source_submitted_at") is not None else None),
             source_review_state=(str(payload["source_review_state"]) if payload.get("source_review_state") is not None else None),
             source_commit_id=(str(payload["source_commit_id"]) if payload.get("source_commit_id") is not None else None),

--- a/scripts/reviewer_bot_lib/reconcile_payloads.py
+++ b/scripts/reviewer_bot_lib/reconcile_payloads.py
@@ -245,6 +245,25 @@ def _validate_deferred_comment_artifact(payload: dict) -> None:
         raise RuntimeError("Deferred comment artifact comment_installation_id must be a string or null")
     if not isinstance(payload.get("comment_performed_via_github_app"), bool):
         raise RuntimeError("Deferred comment artifact comment_performed_via_github_app must be boolean")
+    if payload.get("payload_kind") == DeferredPayloadKind.DEFERRED_REVIEW_COMMENT.value:
+        source_commit_id = payload.get("source_commit_id")
+        if not isinstance(source_commit_id, str) or not source_commit_id.strip():
+            raise RuntimeError("Deferred review comment artifact source_commit_id must be a non-empty string")
+
+
+def _legacy_optional_bool(payload: dict, field_name: str, *, default: bool = False) -> bool:
+    if field_name not in payload or payload.get(field_name) is None:
+        return default
+    value = payload[field_name]
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise RuntimeError(f"Deferred legacy comment artifact {field_name} must be boolean")
 
 
 def _validate_legacy_deferred_comment_artifact(payload: dict) -> None:
@@ -281,6 +300,7 @@ def _validate_legacy_deferred_comment_artifact(payload: dict) -> None:
         raise RuntimeError("Deferred legacy comment artifact classification is malformed")
     if not isinstance(payload.get("actor_login"), str) or not payload["actor_login"].strip():
         raise RuntimeError("Deferred legacy comment artifact actor login is unavailable")
+    _legacy_optional_bool(payload, "comment_performed_via_github_app")
 
 
 def _validate_deferred_review_artifact(payload: dict) -> None:
@@ -331,7 +351,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
                 comment_user_type=str(payload.get("actor_user_type") or "User"),
                 comment_sender_type=str(payload.get("actor_sender_type") or "User"),
                 comment_installation_id=(str(payload["comment_installation_id"]) if payload.get("comment_installation_id") else None),
-                comment_performed_via_github_app=bool(payload.get("comment_performed_via_github_app", False)),
+                comment_performed_via_github_app=_legacy_optional_bool(payload, "comment_performed_via_github_app"),
                 issue_author=str(payload.get("issue_author") or ""),
                 issue_state=str(payload.get("issue_state") or "open"),
                 issue_labels=tuple(str(label) for label in payload.get("issue_labels", ())),

--- a/scripts/reviewer_bot_lib/reconcile_payloads.py
+++ b/scripts/reviewer_bot_lib/reconcile_payloads.py
@@ -119,6 +119,26 @@ class DeferredReviewReplayContext:
         return self.payload.actor_login or ""
 
 
+_EXPECTED_IDENTITY_CONTRACTS: dict[DeferredPayloadKind, tuple[str, str, str]] = {
+    DeferredPayloadKind.DEFERRED_COMMENT: ("issue_comment", "created", "issue_comment:"),
+    DeferredPayloadKind.DEFERRED_REVIEW_COMMENT: (
+        "pull_request_review_comment",
+        "created",
+        "pull_request_review_comment:",
+    ),
+    DeferredPayloadKind.DEFERRED_REVIEW_SUBMITTED: (
+        "pull_request_review",
+        "submitted",
+        "pull_request_review:",
+    ),
+    DeferredPayloadKind.DEFERRED_REVIEW_DISMISSED: (
+        "pull_request_review",
+        "dismissed",
+        "pull_request_review_dismissed:",
+    ),
+}
+
+
 def _build_deferred_identity(payload: dict) -> DeferredArtifactIdentity:
     payload_kind = payload.get("payload_kind")
     if payload_kind is None and payload.get("schema_version") == 2:
@@ -142,6 +162,19 @@ def _build_deferred_identity(payload: dict) -> DeferredArtifactIdentity:
         source_event_key=str(payload["source_event_key"]),
         pr_number=int(payload["pr_number"]),
     )
+
+
+def _validate_identity_contract(identity: DeferredArtifactIdentity) -> None:
+    expected_event_name, expected_event_action, expected_key_prefix = _EXPECTED_IDENTITY_CONTRACTS[
+        identity.payload_kind
+    ]
+    if (
+        identity.source_event_name != expected_event_name
+        or identity.source_event_action != expected_event_action
+    ):
+        raise RuntimeError("Deferred workflow_run payload kind/event mismatch")
+    if not identity.source_event_key.startswith(expected_key_prefix):
+        raise RuntimeError("Deferred workflow_run payload source_event_key prefix mismatch")
 
 
 def build_deferred_comment_replay_context(
@@ -279,6 +312,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
     if not isinstance(payload, dict):
         raise RuntimeError("Deferred context payload must be a JSON object")
     identity = _build_deferred_identity(payload)
+    _validate_identity_contract(identity)
     if identity.payload_kind == DeferredPayloadKind.DEFERRED_COMMENT or identity.payload_kind == DeferredPayloadKind.DEFERRED_REVIEW_COMMENT:
         _validate_deferred_review_comment_artifact(payload)
         if identity.schema_version == 2:

--- a/scripts/reviewer_bot_lib/sweeper.py
+++ b/scripts/reviewer_bot_lib/sweeper.py
@@ -108,6 +108,7 @@ def _diagnose_deferred_event(
     workflow_file: str,
     source_event_kind: str,
     workflow_runs: list[dict] | None,
+    source_evidence: dict | None = None,
 ) -> None:
     existing_gap = gap_bookkeeping.get_deferred_gap(review_data, source_event_key)
     run_correlation = deferred_gap_diagnosis.correlate_candidate_observer_runs(
@@ -159,6 +160,7 @@ def _diagnose_deferred_event(
         artifact_correlation=artifact_correlation,
         reason=reason,
         diagnostic_reason=diagnostic_reason,
+        source_evidence=source_evidence,
     )
 
 
@@ -220,6 +222,79 @@ def _is_automation_comment(comment: dict) -> bool:
     if comment.get("performed_via_github_app"):
         return True
     return False
+
+
+def _performed_via_github_app_truth(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, dict):
+        app_id = value.get("id")
+        if app_id is None or not str(app_id).strip():
+            return None
+        try:
+            return int(app_id) > 0
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _source_actor_fields_from_user(user: object) -> dict:
+    if not isinstance(user, dict):
+        return {}
+    fields = {}
+    login = user.get("login")
+    if isinstance(login, str) and login.strip():
+        fields["source_actor_login"] = login.strip()
+    actor_id = user.get("id")
+    if actor_id is not None:
+        fields["source_actor_id"] = actor_id
+    user_type = user.get("type")
+    if isinstance(user_type, str) and user_type.strip():
+        fields["source_actor_user_type"] = user_type.strip()
+    return fields
+
+
+def _comment_source_evidence(comment: object) -> dict:
+    if not isinstance(comment, dict):
+        return {}
+    fields = _source_actor_fields_from_user(comment.get("user"))
+    comment_id = comment.get("id")
+    if comment_id is not None:
+        fields["source_comment_id"] = comment_id
+    review_id = comment.get("pull_request_review_id")
+    if review_id is not None:
+        fields["source_review_id"] = review_id
+    commit_id = comment.get("commit_id") or comment.get("original_commit_id")
+    if isinstance(commit_id, str) and commit_id.strip():
+        fields["source_commit_id"] = commit_id.strip()
+    sender = comment.get("sender")
+    sender_type = sender.get("type") if isinstance(sender, dict) else None
+    if isinstance(sender_type, str) and sender_type.strip():
+        fields["source_actor_sender_type"] = sender_type.strip()
+    installation = comment.get("installation")
+    installation_id = installation.get("id") if isinstance(installation, dict) else None
+    if installation_id is not None and str(installation_id).strip():
+        fields["source_actor_installation_id"] = str(installation_id).strip()
+    performed_via_app = _performed_via_github_app_truth(comment.get("performed_via_github_app"))
+    if performed_via_app is not None:
+        fields["source_actor_performed_via_github_app"] = performed_via_app
+    return fields
+
+
+def _review_source_evidence(review: object) -> dict:
+    if not isinstance(review, dict):
+        return {}
+    fields = _source_actor_fields_from_user(review.get("user"))
+    review_id = review.get("id")
+    if review_id is not None:
+        fields["source_review_id"] = review_id
+    commit_id = review.get("commit_id")
+    if isinstance(commit_id, str) and commit_id.strip():
+        fields["source_commit_id"] = commit_id.strip()
+    state = review.get("state")
+    if isinstance(state, str) and state.strip():
+        fields["source_review_state"] = state.strip()
+    return fields
 
 
 def _fetch_live_issue_comment(bot, comment_id: str) -> dict | None:
@@ -393,20 +468,23 @@ def _record_gap_diagnostics(
     artifact_correlation: dict | None,
     reason: str,
     diagnostic_reason: str,
+    source_evidence: dict | None = None,
 ) -> None:
+    payload = {
+        **(source_evidence or {}),
+        "source_event_key": source_event_key,
+        "source_event_name": source_event_name,
+        "source_event_action": source_event_action,
+        "pr_number": issue_number,
+        "source_created_at": source_created_at,
+        "source_workflow_file": workflow_file,
+        "source_run_id": run_correlation.get("correlated_run"),
+        "source_run_attempt": run_detail.get("run_attempt") if isinstance(run_detail, dict) else None,
+    }
     gap_bookkeeping.record_deferred_gap_diagnostic(
         bot,
         review_data,
-        {
-            "source_event_key": source_event_key,
-            "source_event_name": source_event_name,
-            "source_event_action": source_event_action,
-            "pr_number": issue_number,
-            "source_created_at": source_created_at,
-            "source_workflow_file": workflow_file,
-            "source_run_id": run_correlation.get("correlated_run"),
-            "source_run_attempt": run_detail.get("run_attempt") if isinstance(run_detail, dict) else None,
-        },
+        payload,
         reason,
         f"Trusted sweeper diagnostics for {source_event_key}: {diagnostic_reason}. See {bot.REVIEW_FRESHNESS_RUNBOOK_PATH}.",
     )
@@ -483,6 +561,7 @@ def sweep_deferred_gaps(bot, state: dict) -> bool:
                     workflow_file=workflow_file,
                     source_event_kind="issue_comment:created",
                     workflow_runs=workflow_runs,
+                    source_evidence=_comment_source_evidence(discovered.get("comment")),
                 )
                 changed = True
             _complete_surface_scan(bot, review_data, "comments", discovered_comments)
@@ -556,6 +635,7 @@ def sweep_deferred_gaps(bot, state: dict) -> bool:
                     artifact_correlation=artifact_correlation,
                     reason=reason,
                     diagnostic_reason=diagnostic_reason,
+                    source_evidence=_review_source_evidence(review_payload),
                 )
                 if visible_review_diagnostic is not None:
                     gap_bookkeeping.update_deferred_gap_fields(
@@ -588,6 +668,7 @@ def sweep_deferred_gaps(bot, state: dict) -> bool:
                     workflow_file=workflow_file,
                     source_event_kind="pull_request_review_comment:created",
                     workflow_runs=workflow_runs,
+                    source_evidence=_comment_source_evidence(discovered.get("comment")),
                 )
                 changed = True
             _complete_surface_scan(bot, review_data, "review_comments", discovered_review_comments)

--- a/tests/contract/reviewer_bot/test_preview_workflow_contracts.py
+++ b/tests/contract/reviewer_bot/test_preview_workflow_contracts.py
@@ -34,6 +34,8 @@ def test_preview_workflow_remains_sole_retained_owner_of_preview_actions():
     sweeper_action_input = sweeper_on_block["workflow_dispatch"]["inputs"]["action"]
 
     assert "preview-reviewer-board" not in sweeper_action_input["options"]
+    assert "REVIEWER_BOARD_ENABLED" not in sweeper_text
+    assert "REVIEWER_BOARD_TOKEN" not in sweeper_text
 
 
 def test_preview_workflow_run_name_and_env_contract_are_frozen():

--- a/tests/contract/reviewer_bot/test_reviewer_board_workflow_contracts.py
+++ b/tests/contract/reviewer_bot/test_reviewer_board_workflow_contracts.py
@@ -17,17 +17,11 @@ def test_sweeper_repair_workflow_removes_reviewer_board_preview_dispatch():
     assert issue_number_input["required"] is False
     assert issue_number_input["type"] == "string"
 
-def test_sweeper_repair_workflow_retains_reviewer_board_env_wiring_without_dispatch_option():
+def test_sweeper_repair_workflow_removes_reviewer_board_preview_env_wiring():
     workflow_text = Path(".github/workflows/reviewer-bot-sweeper-repair.yml").read_text(encoding="utf-8")
     assert "ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}" in workflow_text
-    assert (
-        "REVIEWER_BOARD_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && 'true' || 'false' }}"
-        in workflow_text
-    )
-    assert (
-        "REVIEWER_BOARD_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'preview-reviewer-board' && secrets.REVIEWER_BOARD_TOKEN || '' }}"
-        in workflow_text
-    )
+    assert "REVIEWER_BOARD_ENABLED" not in workflow_text
+    assert "REVIEWER_BOARD_TOKEN" not in workflow_text
 
 
 def test_sweeper_repair_workflow_exports_retained_manual_dispatch_env_contract():

--- a/tests/contract/reviewer_bot/test_stage2_final_state_negative.py
+++ b/tests/contract/reviewer_bot/test_stage2_final_state_negative.py
@@ -16,26 +16,29 @@ def test_legacy_reconcile_compatibility_surfaces_are_removed():
     assert not hasattr(reconcile_replay_policy, "decide_observer_noop")
 
 
-def test_parse_deferred_context_payload_rejects_legacy_schema_versions_and_observer_noop():
-    with pytest.raises(RuntimeError, match="schema_version is not accepted"):
-        reconcile_payloads.parse_deferred_context_payload(
-            {
-                "schema_version": 2,
-                "source_event_name": "issue_comment",
-                "source_event_action": "created",
-                "source_event_key": "issue_comment:210",
-                "pr_number": 42,
-                "comment_id": 210,
-                "comment_class": "command_only",
-                "has_non_command_text": False,
-                "source_body_digest": "digest",
-                "source_created_at": "2026-03-17T10:00:00Z",
-                "actor_login": "alice",
-                "source_run_id": 1,
-                "source_run_attempt": 1,
-            }
-        )
-    with pytest.raises(RuntimeError, match="schema_version is not accepted"):
+def test_parse_deferred_context_payload_accepts_legacy_comment_but_rejects_observer_noop():
+    parsed = reconcile_payloads.parse_deferred_context_payload(
+        {
+            "schema_version": 2,
+            "source_event_name": "issue_comment",
+            "source_event_action": "created",
+            "source_event_key": "issue_comment:210",
+            "pr_number": 42,
+            "comment_id": 210,
+            "comment_class": "command_only",
+            "has_non_command_text": False,
+            "source_body_digest": "digest",
+            "source_created_at": "2026-03-17T10:00:00Z",
+            "actor_login": "alice",
+            "source_run_id": 1,
+            "source_run_attempt": 1,
+        }
+    )
+
+    assert isinstance(parsed, reconcile_payloads.DeferredCommentPayload)
+    assert parsed.source_body_digest == "digest"
+
+    with pytest.raises(RuntimeError, match="Unsupported deferred workflow_run payload"):
         reconcile_payloads.parse_deferred_context_payload(
             {
                 "schema_version": 1,

--- a/tests/contract/reviewer_bot/test_workflow_artifact_contracts.py
+++ b/tests/contract/reviewer_bot/test_workflow_artifact_contracts.py
@@ -27,6 +27,14 @@ def _payload_and_upload_steps(job: dict) -> tuple[dict, dict]:
     return build_step, upload_step
 
 
+def _extract_python_heredoc(run_script: str) -> str:
+    start = "python - <<'PY'\n"
+    if start not in run_script:
+        raise AssertionError("workflow step does not contain a single-quoted Python heredoc")
+    body = run_script.split(start, 1)[1]
+    return body.rsplit("\nPY", 1)[0]
+
+
 @pytest.mark.parametrize(
     ("workflow_path",),
     [
@@ -85,6 +93,42 @@ def test_deferred_comment_payload_parses_without_artifact_name_field():
     parsed = reconcile_payloads.parse_deferred_context_payload(payload)
 
     assert parsed.identity.source_event_name == "issue_comment"
+
+
+def test_review_comment_workflow_payload_builder_emits_parseable_contract(monkeypatch, tmp_path):
+    workflow_path = ".github/workflows/reviewer-bot-pr-review-comment-observer.yml"
+    build_step, _ = _payload_and_upload_steps(_load_workflow_job(workflow_path))
+    payload_path = tmp_path / "deferred-review-comment.json"
+    env_values = {
+        "PAYLOAD_PATH": str(payload_path),
+        "GITHUB_RUN_ID": "404",
+        "GITHUB_RUN_ATTEMPT": "6",
+        "COMMENT_BODY": "@guidelines-bot /queue",
+        "PR_NUMBER": "42",
+        "ISSUE_AUTHOR": "dana",
+        "ISSUE_STATE": "open",
+        "ISSUE_LABELS": '["coding guideline"]',
+        "COMMENT_ID": "701",
+        "COMMENT_CREATED_AT": "2026-03-20T21:00:00Z",
+        "COMMENT_AUTHOR": "reviewer2",
+        "COMMENT_AUTHOR_ID": "7004",
+        "COMMENT_USER_TYPE": "User",
+        "COMMENT_COMMIT_ID": "abc123def456",
+        "COMMENT_SENDER_TYPE": "User",
+        "COMMENT_INSTALLATION_ID": "",
+        "COMMENT_PERFORMED_VIA_GITHUB_APP": "false",
+    }
+    for name, value in env_values.items():
+        monkeypatch.setenv(name, value)
+
+    exec(compile(_extract_python_heredoc(build_step["run"]), workflow_path, "exec"), {})
+
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    parsed = reconcile_payloads.parse_deferred_context_payload(payload)
+    fixture_payload = _load_fixture_payload("tests/fixtures/observer_payloads/workflow_pr_review_comment_deferred.json")
+
+    assert payload == fixture_payload
+    assert parsed.source_commit_id == "abc123def456"
 
 
 def test_dismissed_review_payload_does_not_fabricate_source_dismissal_time_contract():

--- a/tests/contract/reviewer_bot/test_workflow_artifact_contracts.py
+++ b/tests/contract/reviewer_bot/test_workflow_artifact_contracts.py
@@ -1,4 +1,6 @@
+import io
 import json
+import urllib.request
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -28,11 +30,27 @@ def _payload_and_upload_steps(job: dict) -> tuple[dict, dict]:
 
 
 def _extract_python_heredoc(run_script: str) -> str:
-    start = "python - <<'PY'\n"
-    if start not in run_script:
+    lines = run_script.splitlines()
+    for index, line in enumerate(lines):
+        if line.rstrip().endswith("python - <<'PY'"):
+            body_lines = lines[index + 1 :]
+            break
+    else:
         raise AssertionError("workflow step does not contain a single-quoted Python heredoc")
-    body = run_script.split(start, 1)[1]
-    return body.rsplit("\nPY", 1)[0]
+    for index, line in enumerate(body_lines):
+        if line == "PY":
+            return "\n".join(body_lines[:index])
+    raise AssertionError("workflow step Python heredoc is not terminated")
+
+
+def _execute_payload_builder(workflow_path: str, env_values: dict[str, str], monkeypatch) -> dict:
+    build_step, _ = _payload_and_upload_steps(_load_workflow_job(workflow_path))
+    for name, value in env_values.items():
+        monkeypatch.setenv(name, value)
+
+    exec(compile(_extract_python_heredoc(build_step["run"]), workflow_path, "exec"), {})
+
+    return json.loads(Path(env_values["PAYLOAD_PATH"]).read_text(encoding="utf-8"))
 
 
 @pytest.mark.parametrize(
@@ -95,40 +113,140 @@ def test_deferred_comment_payload_parses_without_artifact_name_field():
     assert parsed.identity.source_event_name == "issue_comment"
 
 
-def test_review_comment_workflow_payload_builder_emits_parseable_contract(monkeypatch, tmp_path):
-    workflow_path = ".github/workflows/reviewer-bot-pr-review-comment-observer.yml"
-    build_step, _ = _payload_and_upload_steps(_load_workflow_job(workflow_path))
-    payload_path = tmp_path / "deferred-review-comment.json"
-    env_values = {
-        "PAYLOAD_PATH": str(payload_path),
-        "GITHUB_RUN_ID": "404",
-        "GITHUB_RUN_ATTEMPT": "6",
-        "COMMENT_BODY": "@guidelines-bot /queue",
-        "PR_NUMBER": "42",
-        "ISSUE_AUTHOR": "dana",
-        "ISSUE_STATE": "open",
-        "ISSUE_LABELS": '["coding guideline"]',
-        "COMMENT_ID": "701",
-        "COMMENT_CREATED_AT": "2026-03-20T21:00:00Z",
-        "COMMENT_AUTHOR": "reviewer2",
-        "COMMENT_AUTHOR_ID": "7004",
-        "COMMENT_USER_TYPE": "User",
-        "COMMENT_COMMIT_ID": "abc123def456",
-        "COMMENT_SENDER_TYPE": "User",
-        "COMMENT_INSTALLATION_ID": "",
-        "COMMENT_PERFORMED_VIA_GITHUB_APP": "false",
-    }
-    for name, value in env_values.items():
-        monkeypatch.setenv(name, value)
+def test_pr_comment_router_workflow_payload_builder_emits_parseable_contract(monkeypatch, tmp_path):
+    workflow_path = ".github/workflows/reviewer-bot-pr-comment-router.yml"
+    payload_path = tmp_path / "deferred-comment.json"
+    event_path = tmp_path / "event.json"
+    output_path = tmp_path / "github-output.txt"
+    event_path.write_text(
+        json.dumps(
+            {
+                "issue": {
+                    "number": 42,
+                    "state": "open",
+                    "user": {"login": "dana"},
+                    "labels": [{"name": "triage"}],
+                },
+                "comment": {
+                    "id": 501,
+                    "body": "hello\n@guidelines-bot /queue",
+                    "created_at": "2026-03-20T20:48:25Z",
+                    "user": {"login": "contributor", "id": 7001, "type": "User"},
+                    "author_association": "CONTRIBUTOR",
+                    "performed_via_github_app": None,
+                },
+                "sender": {"type": "User"},
+                "installation": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda _request: io.StringIO(
+            json.dumps(
+                {
+                    "head": {"repo": {"full_name": "rustfoundation/safety-critical-rust-coding-guidelines"}},
+                    "user": {"login": "dana"},
+                }
+            )
+        ),
+    )
 
-    exec(compile(_extract_python_heredoc(build_step["run"]), workflow_path, "exec"), {})
+    payload = _execute_payload_builder(
+        workflow_path,
+        {
+            "PAYLOAD_PATH": str(payload_path),
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_OUTPUT": str(output_path),
+            "GITHUB_REPOSITORY": "rustfoundation/safety-critical-rust-coding-guidelines",
+            "GITHUB_RUN_ID": "401",
+            "GITHUB_RUN_ATTEMPT": "3",
+            "GITHUB_TOKEN": "token",
+        },
+        monkeypatch,
+    )
 
-    payload = json.loads(payload_path.read_text(encoding="utf-8"))
-    parsed = reconcile_payloads.parse_deferred_context_payload(payload)
-    fixture_payload = _load_fixture_payload("tests/fixtures/observer_payloads/workflow_pr_review_comment_deferred.json")
+    fixture_payload = _load_fixture_payload("tests/fixtures/observer_payloads/workflow_pr_comment_deferred.json")
 
     assert payload == fixture_payload
-    assert parsed.source_commit_id == "abc123def456"
+    assert reconcile_payloads.parse_deferred_context_payload(payload).identity.source_event_key == "issue_comment:501"
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "fixture_path", "env_values"),
+    [
+        (
+            ".github/workflows/reviewer-bot-pr-review-submitted-observer.yml",
+            "tests/fixtures/observer_payloads/workflow_pr_review_submitted_deferred.json",
+            {
+                "GITHUB_RUN_ID": "402",
+                "GITHUB_RUN_ATTEMPT": "4",
+                "PR_NUMBER": "42",
+                "REVIEW_ID": "601",
+                "SUBMITTED_AT": "2026-03-20T20:50:00Z",
+                "REVIEW_STATE": "approved",
+                "COMMIT_ID": "abc123def456",
+                "REVIEW_AUTHOR": "reviewer1",
+                "REVIEW_AUTHOR_ID": "7002",
+            },
+        ),
+        (
+            ".github/workflows/reviewer-bot-pr-review-dismissed-observer.yml",
+            "tests/fixtures/observer_payloads/workflow_pr_review_dismissed_deferred.json",
+            {
+                "GITHUB_RUN_ID": "403",
+                "GITHUB_RUN_ATTEMPT": "5",
+                "PR_NUMBER": "42",
+                "REVIEW_ID": "602",
+                "COMMIT_ID": "fedcba654321",
+                "REVIEW_AUTHOR": "maintainer1",
+                "REVIEW_AUTHOR_ID": "7003",
+            },
+        ),
+        (
+            ".github/workflows/reviewer-bot-pr-review-comment-observer.yml",
+            "tests/fixtures/observer_payloads/workflow_pr_review_comment_deferred.json",
+            {
+                "GITHUB_RUN_ID": "404",
+                "GITHUB_RUN_ATTEMPT": "6",
+                "COMMENT_BODY": "@guidelines-bot /queue",
+                "PR_NUMBER": "42",
+                "ISSUE_AUTHOR": "dana",
+                "ISSUE_STATE": "open",
+                "ISSUE_LABELS": '["coding guideline"]',
+                "COMMENT_ID": "701",
+                "COMMENT_CREATED_AT": "2026-03-20T21:00:00Z",
+                "COMMENT_AUTHOR": "reviewer2",
+                "COMMENT_AUTHOR_ID": "7004",
+                "COMMENT_USER_TYPE": "User",
+                "COMMENT_COMMIT_ID": "abc123def456",
+                "COMMENT_SENDER_TYPE": "User",
+                "COMMENT_INSTALLATION_ID": "",
+                "COMMENT_PERFORMED_VIA_GITHUB_APP": "false",
+            },
+        ),
+    ],
+)
+def test_observer_workflow_payload_builders_emit_parseable_contracts(
+    workflow_path,
+    fixture_path,
+    env_values,
+    monkeypatch,
+    tmp_path,
+):
+    payload_path = tmp_path / Path(_payload_and_upload_steps(_load_workflow_job(workflow_path))[0]["env"]["PAYLOAD_PATH"]).name
+    payload = _execute_payload_builder(
+        workflow_path,
+        {"PAYLOAD_PATH": str(payload_path), **env_values},
+        monkeypatch,
+    )
+    parsed = reconcile_payloads.parse_deferred_context_payload(payload)
+    fixture_payload = _load_fixture_payload(fixture_path)
+
+    assert payload == fixture_payload
+    assert parsed.raw_payload == fixture_payload
 
 
 def test_dismissed_review_payload_does_not_fabricate_source_dismissal_time_contract():

--- a/tests/fixtures/observer_payloads/workflow_pr_review_comment_deferred.json
+++ b/tests/fixtures/observer_payloads/workflow_pr_review_comment_deferred.json
@@ -22,6 +22,7 @@
     "comment_author": "reviewer2",
     "comment_author_id": 7004,
     "comment_user_type": "User",
+    "source_commit_id": "abc123def456",
     "comment_sender_type": "User",
     "comment_installation_id": null,
     "comment_performed_via_github_app": false,

--- a/tests/fixtures/reconcile_harness.py
+++ b/tests/fixtures/reconcile_harness.py
@@ -128,9 +128,10 @@ def review_comment_payload(
     in_reply_to_id: int,
     source_run_id: int,
     source_run_attempt: int,
+    source_commit_id: str | None = None,
 ) -> dict:
     del comment_class, has_non_command_text, actor_class, pull_request_review_id, in_reply_to_id
-    return {
+    payload = {
         "payload_kind": "deferred_review_comment",
         "schema_version": 3,
         "source_workflow_name": "Reviewer Bot PR Review Comment Observer",
@@ -154,6 +155,9 @@ def review_comment_payload(
         "issue_state": "open",
         "issue_labels": ["coding guideline"],
     }
+    if source_commit_id is not None:
+        payload["source_commit_id"] = source_commit_id
+    return payload
 
 
 @dataclass

--- a/tests/fixtures/reconcile_harness.py
+++ b/tests/fixtures/reconcile_harness.py
@@ -283,19 +283,23 @@ class ReconcileHarness:
         author: str,
         author_type: str,
         author_association: str,
+        commit_id: str | None = None,
         performed_via_github_app=None,
         status_code: int = 200,
     ) -> None:
+        payload = {
+            "body": body,
+            "user": {"login": author, "type": author_type},
+            "author_association": author_association,
+            "performed_via_github_app": performed_via_github_app,
+        }
+        if commit_id is not None:
+            payload["commit_id"] = commit_id
         self.github.add_request(
             "GET",
             f"pulls/comments/{comment_id}",
             status_code=status_code,
-            payload={
-                "body": body,
-                "user": {"login": author, "type": author_type},
-                "author_association": author_association,
-                "performed_via_github_app": performed_via_github_app,
-            },
+            payload=payload,
         )
 
     def add_request_failure(

--- a/tests/fixtures/reconcile_harness.py
+++ b/tests/fixtures/reconcile_harness.py
@@ -128,7 +128,7 @@ def review_comment_payload(
     in_reply_to_id: int,
     source_run_id: int,
     source_run_attempt: int,
-    source_commit_id: str | None = None,
+    source_commit_id: str | None = "head-1",
 ) -> dict:
     del comment_class, has_non_command_text, actor_class, pull_request_review_id, in_reply_to_id
     payload = {

--- a/tests/fixtures/reviewer_bot_sweeper_builders.py
+++ b/tests/fixtures/reviewer_bot_sweeper_builders.py
@@ -1,17 +1,40 @@
-def issue_comment_event(comment_id: int, *, created_at: str, login: str = "alice", user_type: str = "User") -> dict:
+def issue_comment_event(
+    comment_id: int,
+    *,
+    created_at: str,
+    login: str = "alice",
+    user_id: int = 7001,
+    user_type: str = "User",
+) -> dict:
     return {
         "id": comment_id,
         "created_at": created_at,
-        "user": {"login": login, "type": user_type},
+        "user": {"login": login, "id": user_id, "type": user_type},
+        "performed_via_github_app": False,
     }
 
 
-def review_comment_event(comment_id: int, *, created_at: str, login: str = "dana", user_type: str = "User") -> dict:
-    return {
+def review_comment_event(
+    comment_id: int,
+    *,
+    created_at: str,
+    login: str = "dana",
+    user_id: int = 7002,
+    user_type: str = "User",
+    review_id: int | None = None,
+    commit_id: str | None = None,
+) -> dict:
+    payload = {
         "id": comment_id,
         "created_at": created_at,
-        "user": {"login": login, "type": user_type},
+        "user": {"login": login, "id": user_id, "type": user_type},
+        "performed_via_github_app": False,
     }
+    if review_id is not None:
+        payload["pull_request_review_id"] = review_id
+    if commit_id is not None:
+        payload["commit_id"] = commit_id
+    return payload
 
 
 def pull_request_review_event(
@@ -28,7 +51,7 @@ def pull_request_review_event(
         "id": review_id,
         "submitted_at": submitted_at,
         "state": state,
-        "user": {"login": login},
+        "user": {"login": login, "id": 7003, "type": "User"},
     }
     if commit_id is not None:
         payload["commit_id"] = commit_id

--- a/tests/fixtures/workflow_contracts/observer_payload_contract_matrix.json
+++ b/tests/fixtures/workflow_contracts/observer_payload_contract_matrix.json
@@ -126,6 +126,7 @@
         "comment_author",
         "comment_author_id",
         "comment_user_type",
+        "source_commit_id",
         "comment_sender_type",
         "comment_installation_id",
         "comment_performed_via_github_app",

--- a/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
+++ b/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
@@ -163,15 +163,6 @@ def test_execute_run_preview_reviewer_board_is_read_only(monkeypatch, capsys):
     assert payload["head_sha"] == "workflow-head"
     assert payload["board_attention"] == "No"
     assert payload["board_waiting_since"] == "2026-05-20"
-    assert payload["board_projection"] == {
-        "review_state": "Awaiting Reviewer",
-        "reviewer": "alice",
-        "assigned_at": "2026-05-20",
-        "waiting_since": "2026-05-20",
-        "needs_attention": "No",
-        "archive": False,
-        "ensure_membership": True,
-    }
     assert payload["lock_attempted"] is False
     assert payload["state_save_attempted"] is False
     assert payload["tracked_state_mutations_attempted"] is False
@@ -262,13 +253,4 @@ def test_execute_run_preview_reviewer_board_keeps_pr264_alternate_approval_proje
         "touched_projection_attempted": False,
         "board_attention": "No",
         "board_waiting_since": None,
-        "board_projection": {
-            "review_state": "Awaiting Contributor",
-            "reviewer": "iglesias",
-            "assigned_at": "2026-02-10",
-            "waiting_since": None,
-            "needs_attention": "No",
-            "archive": False,
-            "ensure_membership": True,
-        },
     }

--- a/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
+++ b/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
@@ -163,6 +163,15 @@ def test_execute_run_preview_reviewer_board_is_read_only(monkeypatch, capsys):
     assert payload["head_sha"] == "workflow-head"
     assert payload["board_attention"] == "No"
     assert payload["board_waiting_since"] == "2026-05-20"
+    assert payload["board_projection"] == {
+        "review_state": "Awaiting Reviewer",
+        "reviewer": "alice",
+        "assigned_at": "2026-05-20",
+        "waiting_since": "2026-05-20",
+        "needs_attention": "No",
+        "archive": False,
+        "ensure_membership": True,
+    }
     assert payload["lock_attempted"] is False
     assert payload["state_save_attempted"] is False
     assert payload["tracked_state_mutations_attempted"] is False
@@ -253,4 +262,13 @@ def test_execute_run_preview_reviewer_board_keeps_pr264_alternate_approval_proje
         "touched_projection_attempted": False,
         "board_attention": "No",
         "board_waiting_since": None,
+        "board_projection": {
+            "review_state": "Awaiting Contributor",
+            "reviewer": "iglesias",
+            "assigned_at": "2026-02-10",
+            "waiting_since": None,
+            "needs_attention": "No",
+            "archive": False,
+            "ensure_membership": True,
+        },
     }

--- a/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
+++ b/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
@@ -198,6 +198,8 @@ def test_execute_run_preview_reviewer_board_keeps_pr264_alternate_approval_proje
         actor="iglesias",
         reviewed_head_sha="head-old",
     )
+    review["transition_warning_sent"] = "2026-03-18T00:00:00Z"
+    review["transition_notice_sent_at"] = "2026-04-01T00:00:00Z"
 
     routes = RouteGitHubApi().add_request(
         "GET",

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -516,7 +516,15 @@ def test_deferred_comment_missing_live_object_preserves_source_time_freshness(mo
 
     assert harness.run(state) is True
     assert state["active_reviews"]["42"]["reviewer_comment"]["accepted"]["semantic_key"] == "issue_comment:99"
-    assert state["active_reviews"]["42"]["sidecars"]["deferred_gaps"]["issue_comment:99"]["reason"] == "reconcile_failed_closed"
+    gap = state["active_reviews"]["42"]["sidecars"]["deferred_gaps"]["issue_comment:99"]
+    assert gap["reason"] == "reconcile_failed_closed"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_actor_login"] == "alice"
+    assert gap["source_actor_id"] == 7001
+    assert gap["source_actor_user_type"] == "User"
+    assert gap["source_actor_sender_type"] == "User"
+    assert gap["source_actor_performed_via_github_app"] is False
+    assert gap["source_comment_id"] == 99
 
 
 def test_handle_workflow_run_event_rebuilds_completion_from_live_review_commit_id(monkeypatch):
@@ -745,7 +753,15 @@ def test_deferred_review_comment_missing_live_object_preserves_source_time_fresh
 
     assert harness.run(state) is True
     assert review["reviewer_comment"]["accepted"]["semantic_key"] == "pull_request_review_comment:303"
-    assert _deferred_gaps(review)["pull_request_review_comment:303"]["reason"] == "reconcile_failed_closed"
+    gap = _deferred_gaps(review)["pull_request_review_comment:303"]
+    assert gap["reason"] == "reconcile_failed_closed"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_actor_login"] == "alice"
+    assert gap["source_actor_id"] == 6
+    assert gap["source_actor_user_type"] == "User"
+    assert gap["source_actor_sender_type"] == "User"
+    assert gap["source_actor_performed_via_github_app"] is False
+    assert gap["source_comment_id"] == 303
 
 
 def test_deferred_comment_reconcile_fails_closed_when_command_replay_is_ambiguous(monkeypatch):

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import pytest
 
 from scripts.reviewer_bot_lib import reconcile
+from scripts.reviewer_bot_lib.comment_application import digest_comment_body
 from tests.fixtures.reconcile_harness import (
     ReconcileHarness,
     issue_comment_payload,
@@ -848,6 +849,44 @@ def test_deferred_comment_reconcile_hydrates_pr_author_context_for_contributor_f
 
     assert harness.run(state) is True
     assert state["active_reviews"]["42"]["contributor_comment"]["accepted"]["semantic_key"] == "issue_comment:199"
+    assert state["active_reviews"]["42"]["reviewer_comment"]["accepted"] is None
+
+
+def test_deferred_legacy_comment_reconcile_hydrates_live_pr_context_for_contributor_freshness(monkeypatch):
+    state = make_state()
+    make_tracked_review_state(state, 42, reviewer="alice")
+    live_body = "reviewer-bot validation: legacy contributor plain text comment"
+    harness = ReconcileHarness(
+        monkeypatch,
+        {
+            "schema_version": 2,
+            "source_workflow_name": "Reviewer Bot PR Comment Router",
+            "source_run_id": 621,
+            "source_run_attempt": 1,
+            "source_event_name": "issue_comment",
+            "source_event_action": "created",
+            "source_event_key": "issue_comment:211",
+            "pr_number": 42,
+            "comment_id": 211,
+            "comment_class": "plain_text",
+            "has_non_command_text": True,
+            "source_body_digest": digest_comment_body(live_body),
+            "source_created_at": "2026-03-17T10:00:00Z",
+            "actor_login": "dana",
+        },
+    )
+    harness.add_pull_request(pr_number=42, author="dana", labels=["coding guideline"])
+    harness.add_issue_comment(
+        comment_id=211,
+        body=live_body,
+        author="dana",
+        author_type="User",
+        author_association="CONTRIBUTOR",
+    )
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="push": "granted"
+
+    assert harness.run(state) is True
+    assert state["active_reviews"]["42"]["contributor_comment"]["accepted"]["semantic_key"] == "issue_comment:211"
     assert state["active_reviews"]["42"]["reviewer_comment"]["accepted"] is None
 
 

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -29,6 +29,37 @@ def _reconciled_source_events(review: dict) -> dict:
     return review["sidecars"]["reconciled_source_events"]
 
 
+def _legacy_review_comment_payload(
+    *,
+    pr_number: int = 42,
+    comment_id: int,
+    source_event_key: str,
+    source_body_digest: str,
+    source_created_at: str = "2026-03-17T10:00:00Z",
+    actor_login: str = "alice",
+    actor_id: int = 6,
+    source_run_id: int,
+    source_run_attempt: int = 1,
+) -> dict:
+    return {
+        "schema_version": 2,
+        "source_workflow_name": "Reviewer Bot PR Review Comment Observer",
+        "source_run_id": source_run_id,
+        "source_run_attempt": source_run_attempt,
+        "source_event_name": "pull_request_review_comment",
+        "source_event_action": "created",
+        "source_event_key": source_event_key,
+        "pr_number": pr_number,
+        "comment_id": comment_id,
+        "comment_class": "plain_text",
+        "has_non_command_text": True,
+        "source_body_digest": source_body_digest,
+        "source_created_at": source_created_at,
+        "actor_login": actor_login,
+        "actor_id": actor_id,
+    }
+
+
 C4C_DELETION_MANIFEST = [
     "inline comment classification drift decision text in reconcile.py",
     "inline non-command text drift decision text in reconcile.py",
@@ -790,6 +821,7 @@ def test_deferred_review_comment_parse_failure_records_artifact_invalid_gap(monk
             source_commit_id=None,
         ),
     )
+    harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
 
     assert harness.run(state) is True
     assert review["reviewer_comment"]["accepted"] is None
@@ -800,6 +832,158 @@ def test_deferred_review_comment_parse_failure_records_artifact_invalid_gap(monk
     assert "source_commit_id" not in gap
 
 
+def test_deferred_review_comment_parse_failure_validates_triggering_run_before_diagnostic(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    harness = ReconcileHarness(
+        monkeypatch,
+        review_comment_payload(
+            pr_number=42,
+            comment_id=307,
+            source_event_key="pull_request_review_comment:307",
+            body="review comment without head evidence",
+            comment_class="plain_text",
+            has_non_command_text=True,
+            source_created_at="2026-03-17T10:00:00Z",
+            actor_login="alice",
+            actor_id=6,
+            actor_class="repo_user_principal",
+            pull_request_review_id=10,
+            in_reply_to_id=200,
+            source_run_id=707,
+            source_run_attempt=1,
+            source_commit_id=None,
+        ),
+    )
+    harness.runtime.set_config_value("WORKFLOW_RUN_TRIGGERING_ID", "999")
+
+    with pytest.raises(RuntimeError, match="run_id mismatch"):
+        harness.run(state)
+
+    assert _deferred_gaps(review) == {}
+
+
+def test_deferred_review_comment_parse_failure_validates_triggering_attempt_before_diagnostic(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    harness = ReconcileHarness(
+        monkeypatch,
+        review_comment_payload(
+            pr_number=42,
+            comment_id=308,
+            source_event_key="pull_request_review_comment:308",
+            body="review comment without head evidence",
+            comment_class="plain_text",
+            has_non_command_text=True,
+            source_created_at="2026-03-17T10:00:00Z",
+            actor_login="alice",
+            actor_id=6,
+            actor_class="repo_user_principal",
+            pull_request_review_id=10,
+            in_reply_to_id=200,
+            source_run_id=708,
+            source_run_attempt=1,
+            source_commit_id=None,
+        ),
+    )
+    harness.runtime.set_config_value("WORKFLOW_RUN_TRIGGERING_ATTEMPT", "2")
+
+    with pytest.raises(RuntimeError, match="run_attempt mismatch"):
+        harness.run(state)
+
+    assert _deferred_gaps(review) == {}
+
+
+def test_deferred_review_comment_parse_failure_closed_live_pr_is_safe_noop(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    harness = ReconcileHarness(
+        monkeypatch,
+        review_comment_payload(
+            pr_number=42,
+            comment_id=309,
+            source_event_key="pull_request_review_comment:309",
+            body="review comment without head evidence",
+            comment_class="plain_text",
+            has_non_command_text=True,
+            source_created_at="2026-03-17T10:00:00Z",
+            actor_login="alice",
+            actor_id=6,
+            actor_class="repo_user_principal",
+            pull_request_review_id=10,
+            in_reply_to_id=200,
+            source_run_id=709,
+            source_run_attempt=1,
+            source_commit_id=None,
+        ),
+    )
+    harness.add_pull_request(pr_number=42, author="dana", state="closed")
+
+    result = harness.handle_workflow_run_event_result(state)
+
+    assert result == reconcile.WorkflowRunHandlerResult(False, [])
+    assert _deferred_gaps(review) == {}
+
+
+def test_deferred_review_comment_parse_failure_requires_recoverable_event_kind(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    payload = review_comment_payload(
+        pr_number=42,
+        comment_id=310,
+        source_event_key="pull_request_review_comment:310",
+        body="review comment without head evidence",
+        comment_class="plain_text",
+        has_non_command_text=True,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="alice",
+        actor_id=6,
+        actor_class="repo_user_principal",
+        pull_request_review_id=10,
+        in_reply_to_id=200,
+        source_run_id=710,
+        source_run_attempt=1,
+        source_commit_id=None,
+    )
+    payload.pop("source_event_name")
+    harness = ReconcileHarness(monkeypatch, payload)
+
+    with pytest.raises(RuntimeError, match="source_event_name"):
+        harness.run(state)
+
+    assert _deferred_gaps(review) == {}
+
+
+def test_deferred_review_comment_parse_failure_rejects_unsupported_event_kind(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    payload = review_comment_payload(
+        pr_number=42,
+        comment_id=311,
+        source_event_key="pull_request:42",
+        body="review comment without head evidence",
+        comment_class="plain_text",
+        has_non_command_text=True,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="alice",
+        actor_id=6,
+        actor_class="repo_user_principal",
+        pull_request_review_id=10,
+        in_reply_to_id=200,
+        source_run_id=711,
+        source_run_attempt=1,
+        source_commit_id=None,
+    )
+    payload["source_event_name"] = "pull_request"
+    payload["source_event_action"] = "closed"
+    harness = ReconcileHarness(monkeypatch, payload)
+
+    with pytest.raises(RuntimeError, match="supported recoverable event kind"):
+        harness.run(state)
+
+    assert _deferred_gaps(review) == {}
+
+
 def test_deferred_legacy_review_comment_hydrates_source_commit_id_from_live_comment(monkeypatch):
     state = make_state()
     review = make_tracked_review_state(state, 42, reviewer="alice")
@@ -807,23 +991,12 @@ def test_deferred_legacy_review_comment_hydrates_source_commit_id_from_live_comm
     live_body = "legacy review comment edited body"
     harness = ReconcileHarness(
         monkeypatch,
-        {
-            "schema_version": 2,
-            "source_workflow_name": "Reviewer Bot PR Review Comment Observer",
-            "source_run_id": 705,
-            "source_run_attempt": 1,
-            "source_event_name": "pull_request_review_comment",
-            "source_event_action": "created",
-            "source_event_key": "pull_request_review_comment:305",
-            "pr_number": 42,
-            "comment_id": 305,
-            "comment_class": "plain_text",
-            "has_non_command_text": True,
-            "source_body_digest": digest_comment_body(original_body),
-            "source_created_at": "2026-03-17T10:00:00Z",
-            "actor_login": "alice",
-            "actor_id": 6,
-        },
+        _legacy_review_comment_payload(
+            comment_id=305,
+            source_event_key="pull_request_review_comment:305",
+            source_body_digest=digest_comment_body(original_body),
+            source_run_id=705,
+        ),
     )
     harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
     harness.add_review_comment(
@@ -848,23 +1021,12 @@ def test_deferred_legacy_review_comment_without_live_commit_id_records_artifact_
     live_body = "legacy review comment body"
     harness = ReconcileHarness(
         monkeypatch,
-        {
-            "schema_version": 2,
-            "source_workflow_name": "Reviewer Bot PR Review Comment Observer",
-            "source_run_id": 706,
-            "source_run_attempt": 1,
-            "source_event_name": "pull_request_review_comment",
-            "source_event_action": "created",
-            "source_event_key": "pull_request_review_comment:306",
-            "pr_number": 42,
-            "comment_id": 306,
-            "comment_class": "plain_text",
-            "has_non_command_text": True,
-            "source_body_digest": digest_comment_body(live_body),
-            "source_created_at": "2026-03-17T10:00:00Z",
-            "actor_login": "alice",
-            "actor_id": 6,
-        },
+        _legacy_review_comment_payload(
+            comment_id=306,
+            source_event_key="pull_request_review_comment:306",
+            source_body_digest=digest_comment_body(live_body),
+            source_run_id=706,
+        ),
     )
     harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
     harness.add_review_comment(

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -1044,6 +1044,72 @@ def test_deferred_review_comment_parse_failure_rejects_invalid_recoverable_times
     assert _deferred_gaps(review) == {}
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        issue_comment_payload(
+            pr_number=42,
+            comment_id=214,
+            source_event_key="issue_comment:999",
+            body="@guidelines-bot /queue",
+            comment_class="command_only",
+            has_non_command_text=False,
+            source_created_at="2026-03-17T10:00:00Z",
+            actor_login="bob",
+            source_run_id=718,
+            source_run_attempt=1,
+        ),
+        review_comment_payload(
+            pr_number=42,
+            comment_id=314,
+            source_event_key="pull_request_review_comment:999",
+            body="review comment with mismatched key",
+            comment_class="plain_text",
+            has_non_command_text=True,
+            source_created_at="2026-03-17T10:00:00Z",
+            actor_login="alice",
+            actor_id=6,
+            actor_class="repo_user_principal",
+            pull_request_review_id=10,
+            in_reply_to_id=200,
+            source_run_id=719,
+            source_run_attempt=1,
+            source_commit_id="head-1",
+        ),
+        review_submitted_payload(
+            pr_number=42,
+            review_id=15,
+            source_event_key="pull_request_review:999",
+            source_submitted_at="2026-03-17T10:00:00Z",
+            source_review_state="COMMENTED",
+            source_commit_id="head-1",
+            actor_login="alice",
+            source_run_id=720,
+            source_run_attempt=1,
+        ),
+        review_dismissed_payload(
+            pr_number=42,
+            review_id=16,
+            source_event_key="pull_request_review_dismissed:999",
+            source_dismissed_at="2026-03-17T10:10:00Z",
+            source_commit_id="head-1",
+            actor_login="alice",
+            source_run_id=721,
+            source_run_attempt=1,
+        ),
+    ],
+)
+def test_strict_parse_rejects_source_object_key_mismatch_before_diagnostic(monkeypatch, payload):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    harness = ReconcileHarness(monkeypatch, payload)
+
+    with pytest.raises(RuntimeError, match="source_event_key does not match recoverable object id"):
+        harness.run(state)
+
+    assert _deferred_gaps(review) == {}
+
+
 def test_deferred_issue_comment_parse_failure_records_artifact_invalid_gap(monkeypatch):
     state = make_state()
     review = make_tracked_review_state(state, 42, reviewer="alice")

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -740,6 +740,7 @@ def test_deferred_review_comment_missing_live_object_preserves_source_time_fresh
             in_reply_to_id=200,
             source_run_id=703,
             source_run_attempt=1,
+            source_commit_id="head-1",
         ),
     )
     harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
@@ -762,6 +763,7 @@ def test_deferred_review_comment_missing_live_object_preserves_source_time_fresh
     assert gap["source_actor_sender_type"] == "User"
     assert gap["source_actor_performed_via_github_app"] is False
     assert gap["source_comment_id"] == 303
+    assert gap["source_commit_id"] == "head-1"
 
 
 def test_deferred_comment_reconcile_fails_closed_when_command_replay_is_ambiguous(monkeypatch):

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -767,6 +767,123 @@ def test_deferred_review_comment_missing_live_object_preserves_source_time_fresh
     assert gap["source_commit_id"] == "head-1"
 
 
+def test_deferred_review_comment_parse_failure_records_artifact_invalid_gap(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    harness = ReconcileHarness(
+        monkeypatch,
+        review_comment_payload(
+            pr_number=42,
+            comment_id=304,
+            source_event_key="pull_request_review_comment:304",
+            body="review comment without head evidence",
+            comment_class="plain_text",
+            has_non_command_text=True,
+            source_created_at="2026-03-17T10:00:00Z",
+            actor_login="alice",
+            actor_id=6,
+            actor_class="repo_user_principal",
+            pull_request_review_id=10,
+            in_reply_to_id=200,
+            source_run_id=704,
+            source_run_attempt=1,
+            source_commit_id=None,
+        ),
+    )
+
+    assert harness.run(state) is True
+    assert review["reviewer_comment"]["accepted"] is None
+    gap = _deferred_gaps(review)["pull_request_review_comment:304"]
+    assert gap["reason"] == "artifact_invalid"
+    assert gap["failure_kind"] == "invalid_payload"
+    assert "source_commit_id must be a non-empty string" in gap["diagnostic_summary"]
+    assert "source_commit_id" not in gap
+
+
+def test_deferred_legacy_review_comment_hydrates_source_commit_id_from_live_comment(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    original_body = "legacy review comment original body"
+    live_body = "legacy review comment edited body"
+    harness = ReconcileHarness(
+        monkeypatch,
+        {
+            "schema_version": 2,
+            "source_workflow_name": "Reviewer Bot PR Review Comment Observer",
+            "source_run_id": 705,
+            "source_run_attempt": 1,
+            "source_event_name": "pull_request_review_comment",
+            "source_event_action": "created",
+            "source_event_key": "pull_request_review_comment:305",
+            "pr_number": 42,
+            "comment_id": 305,
+            "comment_class": "plain_text",
+            "has_non_command_text": True,
+            "source_body_digest": digest_comment_body(original_body),
+            "source_created_at": "2026-03-17T10:00:00Z",
+            "actor_login": "alice",
+            "actor_id": 6,
+        },
+    )
+    harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
+    harness.add_review_comment(
+        comment_id=305,
+        body=live_body,
+        author="alice",
+        author_type="User",
+        author_association="MEMBER",
+        commit_id="head-1",
+    )
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="push": "granted"
+
+    assert harness.run(state) is True
+    gap = _deferred_gaps(review)["pull_request_review_comment:305"]
+    assert gap["reason"] == "reconcile_failed_closed"
+    assert gap["source_commit_id"] == "head-1"
+
+
+def test_deferred_legacy_review_comment_without_live_commit_id_records_artifact_invalid(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    live_body = "legacy review comment body"
+    harness = ReconcileHarness(
+        monkeypatch,
+        {
+            "schema_version": 2,
+            "source_workflow_name": "Reviewer Bot PR Review Comment Observer",
+            "source_run_id": 706,
+            "source_run_attempt": 1,
+            "source_event_name": "pull_request_review_comment",
+            "source_event_action": "created",
+            "source_event_key": "pull_request_review_comment:306",
+            "pr_number": 42,
+            "comment_id": 306,
+            "comment_class": "plain_text",
+            "has_non_command_text": True,
+            "source_body_digest": digest_comment_body(live_body),
+            "source_created_at": "2026-03-17T10:00:00Z",
+            "actor_login": "alice",
+            "actor_id": 6,
+        },
+    )
+    harness.add_pull_request(pr_number=42, author="dana", requested_reviewers=["alice"])
+    harness.add_review_comment(
+        comment_id=306,
+        body=live_body,
+        author="alice",
+        author_type="User",
+        author_association="MEMBER",
+    )
+
+    assert harness.run(state) is True
+    assert review["reviewer_comment"]["accepted"] is None
+    gap = _deferred_gaps(review)["pull_request_review_comment:306"]
+    assert gap["reason"] == "artifact_invalid"
+    assert gap["failure_kind"] == "invalid_payload"
+    assert "source_commit_id could not be recovered" in gap["diagnostic_summary"]
+    assert "source_commit_id" not in gap
+
+
 def test_deferred_comment_reconcile_fails_closed_when_command_replay_is_ambiguous(monkeypatch):
     state = make_state()
     make_tracked_review_state(state, 42, reviewer="alice")

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -984,6 +984,165 @@ def test_deferred_review_comment_parse_failure_rejects_unsupported_event_kind(mo
     assert _deferred_gaps(review) == {}
 
 
+def test_deferred_review_comment_parse_failure_rejects_mismatched_source_object_key(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    harness = ReconcileHarness(
+        monkeypatch,
+        review_comment_payload(
+            pr_number=42,
+            comment_id=312,
+            source_event_key="pull_request_review_comment:999",
+            body="review comment without head evidence",
+            comment_class="plain_text",
+            has_non_command_text=True,
+            source_created_at="2026-03-17T10:00:00Z",
+            actor_login="alice",
+            actor_id=6,
+            actor_class="repo_user_principal",
+            pull_request_review_id=10,
+            in_reply_to_id=200,
+            source_run_id=712,
+            source_run_attempt=1,
+            source_commit_id=None,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="source_event_key does not match recoverable object id"):
+        harness.run(state)
+
+    assert _deferred_gaps(review) == {}
+
+
+def test_deferred_review_comment_parse_failure_rejects_invalid_recoverable_timestamp(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    harness = ReconcileHarness(
+        monkeypatch,
+        review_comment_payload(
+            pr_number=42,
+            comment_id=313,
+            source_event_key="pull_request_review_comment:313",
+            body="review comment without head evidence",
+            comment_class="plain_text",
+            has_non_command_text=True,
+            source_created_at="not-a-timestamp",
+            actor_login="alice",
+            actor_id=6,
+            actor_class="repo_user_principal",
+            pull_request_review_id=10,
+            in_reply_to_id=200,
+            source_run_id=713,
+            source_run_attempt=1,
+            source_commit_id=None,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="timestamp is not parseable"):
+        harness.run(state)
+
+    assert _deferred_gaps(review) == {}
+
+
+def test_deferred_issue_comment_parse_failure_records_artifact_invalid_gap(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=212,
+        source_event_key="issue_comment:212",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="bob",
+        source_run_id=714,
+        source_run_attempt=1,
+    )
+    payload["comment_sender_type"] = ""
+    harness = ReconcileHarness(monkeypatch, payload)
+    harness.add_pull_request(pr_number=42, author="dana")
+
+    assert harness.run(state) is True
+    gap = _deferred_gaps(review)["issue_comment:212"]
+    assert gap["reason"] == "artifact_invalid"
+    assert gap["source_comment_id"] == 212
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+
+
+def test_deferred_issue_comment_parse_failure_rejects_mismatched_source_object_key(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=213,
+        source_event_key="issue_comment:999",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="bob",
+        source_run_id=715,
+        source_run_attempt=1,
+    )
+    payload["comment_sender_type"] = ""
+    harness = ReconcileHarness(monkeypatch, payload)
+
+    with pytest.raises(RuntimeError, match="source_event_key does not match recoverable object id"):
+        harness.run(state)
+
+    assert _deferred_gaps(review) == {}
+
+
+def test_deferred_review_submitted_parse_failure_records_artifact_invalid_gap(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    payload = review_submitted_payload(
+        pr_number=42,
+        review_id=13,
+        source_event_key="pull_request_review:13",
+        source_submitted_at="2026-03-17T10:00:00Z",
+        source_review_state="COMMENTED",
+        source_commit_id="head-1",
+        actor_login="alice",
+        source_run_id=716,
+        source_run_attempt=1,
+    )
+    payload["schema_version"] = 4
+    harness = ReconcileHarness(monkeypatch, payload)
+    harness.add_pull_request(pr_number=42, author="dana")
+
+    assert harness.run(state) is True
+    gap = _deferred_gaps(review)["pull_request_review:13"]
+    assert gap["reason"] == "artifact_invalid"
+    assert gap["source_review_id"] == 13
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+
+
+def test_deferred_review_dismissed_parse_failure_records_artifact_invalid_gap(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(state, 42, reviewer="alice")
+    payload = review_dismissed_payload(
+        pr_number=42,
+        review_id=14,
+        source_event_key="pull_request_review_dismissed:14",
+        source_dismissed_at="2026-03-17T10:10:00Z",
+        source_commit_id="head-1",
+        actor_login="alice",
+        source_run_id=717,
+        source_run_attempt=1,
+    )
+    payload["schema_version"] = 4
+    harness = ReconcileHarness(monkeypatch, payload)
+    harness.add_pull_request(pr_number=42, author="dana")
+
+    assert harness.run(state) is True
+    gap = _deferred_gaps(review)["pull_request_review_dismissed:14"]
+    assert gap["reason"] == "artifact_invalid"
+    assert gap["source_review_id"] == 14
+    assert gap["source_event_created_at"] == "2026-03-17T10:10:00Z"
+
+
 def test_deferred_legacy_review_comment_hydrates_source_commit_id_from_live_comment(monkeypatch):
     state = make_state()
     review = make_tracked_review_state(state, 42, reviewer="alice")

--- a/tests/unit/reviewer_bot/test_deferred_gap_bookkeeping.py
+++ b/tests/unit/reviewer_bot/test_deferred_gap_bookkeeping.py
@@ -269,6 +269,62 @@ def test_update_deferred_gap_preserves_existing_workflow_artifact_provenance_whe
     assert gap["source_artifact_name"] == "reviewer-bot-comment-context-700-attempt-1"
 
 
+def test_deferred_gap_diagnostic_retains_normalized_comment_source_evidence(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    review = review_state.ensure_review_entry(make_state(), 42, create=True)
+    assert review is not None
+    runtime.clock.now = lambda: runtime.datetime(2026, 3, 18, tzinfo=runtime.timezone.utc)
+
+    changed = deferred_gap_bookkeeping.record_deferred_gap_diagnostic(
+        runtime,
+        review,
+        {
+            "source_event_key": "issue_comment:210",
+            "source_event_name": "issue_comment",
+            "source_event_action": "created",
+            "pr_number": 42,
+            "comment_created_at": "2026-03-17T10:00:00Z",
+            "comment_id": 210,
+            "comment_author": "alice",
+            "comment_author_id": 7001,
+            "comment_user_type": "User",
+            "comment_sender_type": "User",
+            "comment_installation_id": "12345",
+            "comment_performed_via_github_app": False,
+        },
+        "reconcile_failed_closed",
+        "comment replay failed closed",
+    )
+
+    assert changed is True
+    gap = review["sidecars"]["deferred_gaps"]["issue_comment:210"]
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_actor_login"] == "alice"
+    assert gap["source_actor_id"] == 7001
+    assert gap["source_actor_user_type"] == "User"
+    assert gap["source_actor_sender_type"] == "User"
+    assert gap["source_actor_installation_id"] == "12345"
+    assert gap["source_actor_performed_via_github_app"] is False
+    assert gap["source_comment_id"] == 210
+
+    deferred_gap_bookkeeping.record_deferred_gap_diagnostic(
+        runtime,
+        review,
+        {
+            "source_event_key": "issue_comment:210",
+            "source_event_name": "issue_comment",
+            "source_event_action": "created",
+            "pr_number": 42,
+        },
+        "artifact_missing",
+        "later diagnostic omitted actor fields",
+    )
+
+    gap = review["sidecars"]["deferred_gaps"]["issue_comment:210"]
+    assert gap["source_actor_login"] == "alice"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+
+
 def test_update_deferred_gap_preserves_source_dismissed_at_diagnostics(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     review = review_state.ensure_review_entry(make_state(), 42, create=True)

--- a/tests/unit/reviewer_bot/test_project_board.py
+++ b/tests/unit/reviewer_bot/test_project_board.py
@@ -33,6 +33,30 @@ def _runtime(monkeypatch, routes=None):
     return runtime
 
 
+def _fail_closed_review_gap(
+    *,
+    author="alice",
+    commit_id="head-1",
+    timestamp="2026-03-18T10:00:00Z",
+    operator_action_required=True,
+):
+    return {
+        "source_event_key": "pull_request_review:501",
+        "source_event_kind": "pull_request_review:submitted",
+        "source_event_created_at": timestamp,
+        "reason": "reconcile_failed_closed",
+        "operator_action_required": operator_action_required,
+        "visible_review_diagnostic": {
+            "category": "visible_review_without_replay_artifact",
+            "payload": {
+                "author": author,
+                "submitted_at": timestamp,
+                "commit_id": commit_id,
+            },
+        },
+    }
+
+
 def test_reviewer_board_preflight_validates_manifest(monkeypatch):
     runtime = _runtime(monkeypatch)
     runtime.set_config_value("REVIEWER_BOARD_ENABLED", "true")
@@ -261,21 +285,7 @@ def test_preview_board_projection_marks_fail_closed_current_scope_gap_as_attenti
         assigned_at="2026-03-17T09:00:00Z",
         active_cycle_started_at="2026-03-17T09:00:00Z",
     )
-    review["sidecars"]["deferred_gaps"]["pull_request_review:501"] = {
-        "source_event_key": "pull_request_review:501",
-        "source_event_kind": "pull_request_review:submitted",
-        "source_event_created_at": "2026-03-18T10:00:00Z",
-        "reason": "reconcile_failed_closed",
-        "operator_action_required": True,
-        "visible_review_diagnostic": {
-            "category": "visible_review_without_replay_artifact",
-            "payload": {
-                "author": "alice",
-                "submitted_at": "2026-03-18T10:00:00Z",
-                "commit_id": "head-1",
-            },
-        },
-    }
+    review["sidecars"]["deferred_gaps"]["pull_request_review:501"] = _fail_closed_review_gap()
     runtime = _runtime(monkeypatch)
     runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
     runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
@@ -289,6 +299,65 @@ def test_preview_board_projection_marks_fail_closed_current_scope_gap_as_attenti
 
     assert preview.desired is not None
     assert preview.desired.needs_attention == REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED
+
+
+def test_preview_board_projection_ignores_fail_closed_gaps_outside_current_scope(monkeypatch):
+    cases = [
+        ("wrong reviewer", _fail_closed_review_gap(author="bob")),
+        ("wrong head", _fail_closed_review_gap(commit_id="head-2")),
+        ("before anchor", _fail_closed_review_gap(timestamp="2026-03-16T10:00:00Z")),
+        ("missing operator action", _fail_closed_review_gap(operator_action_required=False)),
+        ("bad timestamp", _fail_closed_review_gap(timestamp="not-a-timestamp")),
+    ]
+    for _name, gap in cases:
+        state = make_state()
+        review = make_tracked_review_state(
+            state,
+            42,
+            reviewer="alice",
+            assigned_at="2026-03-17T09:00:00Z",
+            active_cycle_started_at="2026-03-17T09:00:00Z",
+        )
+        review["sidecars"]["deferred_gaps"]["pull_request_review:501"] = gap
+        runtime = _runtime(monkeypatch)
+        runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+        runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+            "state": "awaiting_reviewer_response",
+            "anchor_timestamp": "2026-03-17T09:00:00Z",
+            "reason": "no_reviewer_activity",
+            "current_head_sha": "head-1",
+        }
+
+        preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+        assert preview.desired is not None
+        assert preview.desired.needs_attention == "No", _name
+
+
+def test_preview_board_projection_ignores_raw_reminders_outside_reviewer_wait(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["transition_warning_sent"] = "2026-03-18T00:00:00Z"
+    review["transition_notice_sent_at"] = "2026-04-01T00:00:00Z"
+    runtime = _runtime(monkeypatch)
+    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+    runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+        "state": "done",
+        "anchor_timestamp": "2026-03-18T10:00:00Z",
+        "reason": "write_approval_present",
+        "current_head_sha": "head-1",
+    }
+
+    preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+    assert preview.desired is not None
+    assert preview.desired.needs_attention == "No"
 
 
 def test_preview_board_projection_marks_projection_repair_as_attention(monkeypatch):

--- a/tests/unit/reviewer_bot/test_project_board.py
+++ b/tests/unit/reviewer_bot/test_project_board.py
@@ -233,6 +233,8 @@ def test_preview_board_projection_keeps_pr264_alternate_approval_boundary(monkey
         reviewed_head_sha="head-old",
         source_precedence=1,
     )
+    review["transition_warning_sent"] = "2026-03-18T00:00:00Z"
+    review["transition_notice_sent_at"] = "2026-04-01T00:00:00Z"
     routes = RouteGitHubApi().add_pull_request_snapshot(264, pull_request_payload(264, head_sha="head-live", author="manhatsu")).add_pull_request_reviews(
         264,
         [review_payload(501, state="APPROVED", submitted_at="2026-03-18T12:10:42Z", commit_id="head-live", author="plaindocs")],
@@ -248,6 +250,45 @@ def test_preview_board_projection_keeps_pr264_alternate_approval_boundary(monkey
     assert preview.desired.review_state == REVIEWER_BOARD_OPTION_AWAITING_CONTRIBUTOR
     assert preview.desired.waiting_since is None
     assert preview.desired.needs_attention == "No"
+
+
+def test_preview_board_projection_marks_fail_closed_current_scope_gap_as_attention(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["sidecars"]["deferred_gaps"]["pull_request_review:501"] = {
+        "source_event_key": "pull_request_review:501",
+        "source_event_kind": "pull_request_review:submitted",
+        "source_event_created_at": "2026-03-18T10:00:00Z",
+        "reason": "reconcile_failed_closed",
+        "operator_action_required": True,
+        "visible_review_diagnostic": {
+            "category": "visible_review_without_replay_artifact",
+            "payload": {
+                "author": "alice",
+                "submitted_at": "2026-03-18T10:00:00Z",
+                "commit_id": "head-1",
+            },
+        },
+    }
+    runtime = _runtime(monkeypatch)
+    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+    runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+        "state": "awaiting_reviewer_response",
+        "anchor_timestamp": "2026-03-17T09:00:00Z",
+        "reason": "no_reviewer_activity",
+        "current_head_sha": "head-1",
+    }
+
+    preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+    assert preview.desired is not None
+    assert preview.desired.needs_attention == REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED
 
 
 def test_preview_board_projection_marks_projection_repair_as_attention(monkeypatch):

--- a/tests/unit/reviewer_bot/test_project_board.py
+++ b/tests/unit/reviewer_bot/test_project_board.py
@@ -57,6 +57,42 @@ def _fail_closed_review_gap(
     }
 
 
+def _fail_closed_normalized_review_gap(
+    *,
+    author="alice",
+    commit_id="head-1",
+    timestamp="2026-03-18T10:00:00Z",
+    operator_action_required=True,
+):
+    return {
+        "source_event_key": "pull_request_review:501",
+        "source_event_kind": "pull_request_review:submitted",
+        "source_event_created_at": timestamp,
+        "source_actor_login": author,
+        "source_commit_id": commit_id,
+        "reason": "reconcile_failed_closed",
+        "operator_action_required": operator_action_required,
+    }
+
+
+def _fail_closed_comment_gap(
+    source_event_key: str,
+    source_event_kind: str,
+    *,
+    author="alice",
+    timestamp="2026-03-18T10:00:00Z",
+    operator_action_required=True,
+):
+    return {
+        "source_event_key": source_event_key,
+        "source_event_kind": source_event_kind,
+        "source_event_created_at": timestamp,
+        "source_actor_login": author,
+        "reason": "reconcile_failed_closed",
+        "operator_action_required": operator_action_required,
+    }
+
+
 def test_reviewer_board_preflight_validates_manifest(monkeypatch):
     runtime = _runtime(monkeypatch)
     runtime.set_config_value("REVIEWER_BOARD_ENABLED", "true")
@@ -299,6 +335,93 @@ def test_preview_board_projection_marks_fail_closed_current_scope_gap_as_attenti
 
     assert preview.desired is not None
     assert preview.desired.needs_attention == REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED
+
+
+def test_preview_board_projection_marks_normalized_review_gap_as_attention(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["sidecars"]["deferred_gaps"]["pull_request_review:501"] = _fail_closed_normalized_review_gap()
+    runtime = _runtime(monkeypatch)
+    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+    runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+        "state": "awaiting_reviewer_response",
+        "anchor_timestamp": "2026-03-17T09:00:00Z",
+        "reason": "no_reviewer_activity",
+        "current_head_sha": "head-1",
+    }
+
+    preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+    assert preview.desired is not None
+    assert preview.desired.needs_attention == REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED
+
+
+def test_preview_board_projection_marks_fail_closed_comment_gaps_with_source_actor_as_attention(monkeypatch):
+    cases = [
+        ("issue_comment:210", "issue_comment:created"),
+        ("pull_request_review_comment:404", "pull_request_review_comment:created"),
+    ]
+    for source_event_key, source_event_kind in cases:
+        state = make_state()
+        review = make_tracked_review_state(
+            state,
+            42,
+            reviewer="alice",
+            assigned_at="2026-03-17T09:00:00Z",
+            active_cycle_started_at="2026-03-17T09:00:00Z",
+        )
+        review["sidecars"]["deferred_gaps"][source_event_key] = _fail_closed_comment_gap(
+            source_event_key,
+            source_event_kind,
+        )
+        runtime = _runtime(monkeypatch)
+        runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+        runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+            "state": "awaiting_reviewer_response",
+            "anchor_timestamp": "2026-03-17T09:00:00Z",
+            "reason": "no_reviewer_activity",
+            "current_head_sha": "head-1",
+        }
+
+        preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+        assert preview.desired is not None
+        assert preview.desired.needs_attention == REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED
+
+
+def test_preview_board_projection_ignores_comment_gap_for_wrong_source_actor(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["sidecars"]["deferred_gaps"]["issue_comment:210"] = _fail_closed_comment_gap(
+        "issue_comment:210",
+        "issue_comment:created",
+        author="bob",
+    )
+    runtime = _runtime(monkeypatch)
+    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+    runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+        "state": "awaiting_reviewer_response",
+        "anchor_timestamp": "2026-03-17T09:00:00Z",
+        "reason": "no_reviewer_activity",
+        "current_head_sha": "head-1",
+    }
+
+    preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+    assert preview.desired is not None
+    assert preview.desired.needs_attention == "No"
 
 
 def test_preview_board_projection_ignores_fail_closed_gaps_outside_current_scope(monkeypatch):

--- a/tests/unit/reviewer_bot/test_project_board.py
+++ b/tests/unit/reviewer_bot/test_project_board.py
@@ -368,6 +368,32 @@ def test_preview_board_projection_marks_normalized_review_gap_as_attention(monke
     assert preview.desired.needs_attention == REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED
 
 
+def test_preview_board_projection_marks_fail_closed_gap_as_attention_outside_reviewer_wait(monkeypatch):
+    for state_name in ["done", "awaiting_contributor_response", "awaiting_write_approval"]:
+        state = make_state()
+        review = make_tracked_review_state(
+            state,
+            42,
+            reviewer="alice",
+            assigned_at="2026-03-17T09:00:00Z",
+            active_cycle_started_at="2026-03-17T09:00:00Z",
+        )
+        review["sidecars"]["deferred_gaps"]["pull_request_review:501"] = _fail_closed_normalized_review_gap()
+        runtime = _runtime(monkeypatch)
+        runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+        runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+            "state": state_name,
+            "anchor_timestamp": "2026-03-17T09:00:00Z",
+            "reason": "current_scope_repair_required",
+            "current_head_sha": "head-1",
+        }
+
+        preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+        assert preview.desired is not None
+        assert preview.desired.needs_attention == REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED, state_name
+
+
 def test_preview_board_projection_marks_fail_closed_comment_gaps_with_source_actor_as_attention(monkeypatch):
     cases = [
         ("issue_comment:210", "issue_comment:created", None),

--- a/tests/unit/reviewer_bot/test_project_board.py
+++ b/tests/unit/reviewer_bot/test_project_board.py
@@ -6,6 +6,8 @@ from scripts.reviewer_bot_lib import project_board, reviews
 from scripts.reviewer_bot_lib.config import (
     REVIEWER_BOARD_FIELD_NEEDS_ATTENTION,
     REVIEWER_BOARD_OPTION_ATTENTION_PROJECTION_REPAIR_REQUIRED,
+    REVIEWER_BOARD_OPTION_ATTENTION_TRANSITION_NOTICE_SENT,
+    REVIEWER_BOARD_OPTION_ATTENTION_WARNING_SENT,
     REVIEWER_BOARD_OPTION_AWAITING_CONTRIBUTOR,
     STATUS_AWAITING_CONTRIBUTOR_RESPONSE_LABEL,
 )
@@ -81,9 +83,10 @@ def _fail_closed_comment_gap(
     *,
     author="alice",
     timestamp="2026-03-18T10:00:00Z",
+    source_commit_id: str | None = None,
     operator_action_required=True,
 ):
-    return {
+    gap = {
         "source_event_key": source_event_key,
         "source_event_kind": source_event_kind,
         "source_event_created_at": timestamp,
@@ -91,6 +94,9 @@ def _fail_closed_comment_gap(
         "reason": "reconcile_failed_closed",
         "operator_action_required": operator_action_required,
     }
+    if source_commit_id is not None:
+        gap["source_commit_id"] = source_commit_id
+    return gap
 
 
 def test_reviewer_board_preflight_validates_manifest(monkeypatch):
@@ -364,10 +370,10 @@ def test_preview_board_projection_marks_normalized_review_gap_as_attention(monke
 
 def test_preview_board_projection_marks_fail_closed_comment_gaps_with_source_actor_as_attention(monkeypatch):
     cases = [
-        ("issue_comment:210", "issue_comment:created"),
-        ("pull_request_review_comment:404", "pull_request_review_comment:created"),
+        ("issue_comment:210", "issue_comment:created", None),
+        ("pull_request_review_comment:404", "pull_request_review_comment:created", "head-1"),
     ]
-    for source_event_key, source_event_kind in cases:
+    for source_event_key, source_event_kind, source_commit_id in cases:
         state = make_state()
         review = make_tracked_review_state(
             state,
@@ -379,6 +385,7 @@ def test_preview_board_projection_marks_fail_closed_comment_gaps_with_source_act
         review["sidecars"]["deferred_gaps"][source_event_key] = _fail_closed_comment_gap(
             source_event_key,
             source_event_kind,
+            source_commit_id=source_commit_id,
         )
         runtime = _runtime(monkeypatch)
         runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
@@ -422,6 +429,40 @@ def test_preview_board_projection_ignores_comment_gap_for_wrong_source_actor(mon
 
     assert preview.desired is not None
     assert preview.desired.needs_attention == "No"
+
+
+def test_preview_board_projection_ignores_review_comment_gap_without_current_head_evidence(monkeypatch):
+    cases = [
+        ("missing head evidence", None),
+        ("wrong head", "head-2"),
+    ]
+    for _name, source_commit_id in cases:
+        state = make_state()
+        review = make_tracked_review_state(
+            state,
+            42,
+            reviewer="alice",
+            assigned_at="2026-03-17T09:00:00Z",
+            active_cycle_started_at="2026-03-17T09:00:00Z",
+        )
+        review["sidecars"]["deferred_gaps"]["pull_request_review_comment:404"] = _fail_closed_comment_gap(
+            "pull_request_review_comment:404",
+            "pull_request_review_comment:created",
+            source_commit_id=source_commit_id,
+        )
+        runtime = _runtime(monkeypatch)
+        runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+        runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+            "state": "awaiting_reviewer_response",
+            "anchor_timestamp": "2026-03-17T09:00:00Z",
+            "reason": "no_reviewer_activity",
+            "current_head_sha": "head-1",
+        }
+
+        preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+        assert preview.desired is not None
+        assert preview.desired.needs_attention == "No", _name
 
 
 def test_preview_board_projection_ignores_fail_closed_gaps_outside_current_scope(monkeypatch):
@@ -481,6 +522,62 @@ def test_preview_board_projection_ignores_raw_reminders_outside_reviewer_wait(mo
 
     assert preview.desired is not None
     assert preview.desired.needs_attention == "No"
+
+
+def test_preview_board_projection_ignores_raw_reminders_before_reviewer_wait_anchor(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-03-17T09:00:00Z",
+        active_cycle_started_at="2026-03-17T09:00:00Z",
+    )
+    review["transition_warning_sent"] = "2026-03-18T00:00:00Z"
+    review["transition_notice_sent_at"] = "2026-03-18T01:00:00Z"
+    runtime = _runtime(monkeypatch)
+    runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+    runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+        "state": "awaiting_reviewer_response",
+        "anchor_timestamp": "2026-03-18T10:00:00Z",
+        "reason": "contributor_comment_newer",
+        "current_head_sha": "head-1",
+    }
+
+    preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+    assert preview.desired is not None
+    assert preview.desired.needs_attention == "No"
+
+
+def test_preview_board_projection_maps_raw_reminders_at_or_after_reviewer_wait_anchor(monkeypatch):
+    cases = [
+        ("transition_notice_sent_at", REVIEWER_BOARD_OPTION_ATTENTION_TRANSITION_NOTICE_SENT),
+        ("transition_warning_sent", REVIEWER_BOARD_OPTION_ATTENTION_WARNING_SENT),
+    ]
+    for field_name, expected_attention in cases:
+        state = make_state()
+        review = make_tracked_review_state(
+            state,
+            42,
+            reviewer="alice",
+            assigned_at="2026-03-17T09:00:00Z",
+            active_cycle_started_at="2026-03-17T09:00:00Z",
+        )
+        review[field_name] = "2026-03-18T10:00:00Z"
+        runtime = _runtime(monkeypatch)
+        runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+        runtime.adapters.review_state.compute_reviewer_response_state = lambda issue_number, review_data, **kwargs: {
+            "state": "awaiting_reviewer_response",
+            "anchor_timestamp": "2026-03-18T10:00:00Z",
+            "reason": "contributor_comment_newer",
+            "current_head_sha": "head-1",
+        }
+
+        preview = project_board.preview_board_projection_for_item(runtime, state, 42)
+
+        assert preview.desired is not None
+        assert preview.desired.needs_attention == expected_attention
 
 
 def test_preview_board_projection_marks_projection_repair_as_attention(monkeypatch):

--- a/tests/unit/reviewer_bot/test_reconcile_artifacts.py
+++ b/tests/unit/reviewer_bot/test_reconcile_artifacts.py
@@ -114,6 +114,8 @@ def test_deferred_payload_parsing_does_not_require_artifact_name_helpers(fixture
     assert parsed.identity.source_run_id == payload["source_run_id"]
     assert parsed.identity.source_run_attempt == payload["source_run_attempt"]
     assert parsed.identity.source_event_key == payload["source_event_key"]
+    if payload["payload_kind"] == "deferred_review_comment":
+        assert parsed.source_commit_id == payload["source_commit_id"]
 
 
 def test_read_reconcile_object_fails_closed_for_unavailable(monkeypatch):

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -251,12 +251,42 @@ def test_reconcile_active_review_entry_uses_explicit_head_repair_changed_field(m
 
 
 def test_parse_deferred_context_payload_rejects_unsupported_payload():
-    with pytest.raises(RuntimeError, match="schema_version is not accepted"):
+    with pytest.raises(RuntimeError, match="Unsupported deferred workflow_run payload"):
         reconcile.parse_deferred_context_payload({"schema_version": 2})
 
 
+def test_parse_deferred_context_payload_accepts_legacy_comment_payload():
+    payload = {
+        "schema_version": 2,
+        "source_event_name": "issue_comment",
+        "source_event_action": "created",
+        "source_event_key": "issue_comment:210",
+        "pr_number": 42,
+        "comment_id": 210,
+        "comment_class": "plain_text",
+        "has_non_command_text": True,
+        "source_body_digest": "digest",
+        "source_created_at": "2026-03-17T10:00:00Z",
+        "actor_login": "alice",
+        "actor_id": 7001,
+        "source_run_id": 1,
+        "source_run_attempt": 1,
+    }
+
+    parsed = reconcile.parse_deferred_context_payload(payload)
+
+    assert isinstance(parsed, reconcile.DeferredCommentPayload)
+    assert parsed.identity.payload_kind == reconcile_payloads.DeferredPayloadKind.DEFERRED_COMMENT
+    assert parsed.comment_created_at == "2026-03-17T10:00:00Z"
+    assert parsed.comment_author == "alice"
+    assert parsed.comment_author_id == 7001
+    assert parsed.source_body_digest == "digest"
+    assert parsed.source_comment_class == "plain_text"
+    assert parsed.source_has_non_command_text is True
+
+
 def test_parse_deferred_context_payload_rejects_observer_noop_payload():
-    with pytest.raises(RuntimeError, match="schema_version is not accepted"):
+    with pytest.raises(RuntimeError, match="Unsupported deferred workflow_run payload"):
         reconcile.parse_deferred_context_payload(
             {
                 "schema_version": 1,

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -99,6 +99,43 @@ def test_parse_deferred_context_payload_rejects_non_boolean_performed_via_app():
         reconcile.parse_deferred_context_payload(payload)
 
 
+def test_parse_deferred_context_payload_rejects_kind_event_mismatch():
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=210,
+        source_event_key="issue_comment:210",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="bob",
+        source_run_id=610,
+        source_run_attempt=1,
+    )
+    payload["payload_kind"] = "deferred_review_submitted"
+
+    with pytest.raises(RuntimeError, match="kind/event mismatch"):
+        reconcile.parse_deferred_context_payload(payload)
+
+
+def test_parse_deferred_context_payload_rejects_source_event_key_prefix_mismatch():
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=210,
+        source_event_key="pull_request_review_comment:210",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="bob",
+        source_run_id=610,
+        source_run_attempt=1,
+    )
+
+    with pytest.raises(RuntimeError, match="source_event_key prefix mismatch"):
+        reconcile.parse_deferred_context_payload(payload)
+
+
 def test_build_deferred_comment_replay_context_returns_typed_context():
     payload = reconcile.DeferredCommentPayload(
         identity=reconcile.DeferredArtifactIdentity(

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -99,6 +99,29 @@ def test_parse_deferred_context_payload_rejects_non_boolean_performed_via_app():
         reconcile.parse_deferred_context_payload(payload)
 
 
+def test_parse_deferred_context_payload_rejects_review_comment_without_source_commit_id():
+    payload = review_comment_payload(
+        pr_number=42,
+        comment_id=310,
+        source_event_key="pull_request_review_comment:310",
+        body="plain text review comment",
+        comment_class="plain_text",
+        has_non_command_text=True,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="alice",
+        actor_id=11,
+        actor_class="repo_user_principal",
+        pull_request_review_id=77,
+        in_reply_to_id=0,
+        source_run_id=711,
+        source_run_attempt=1,
+        source_commit_id=None,
+    )
+
+    with pytest.raises(RuntimeError, match="source_commit_id must be a non-empty string"):
+        reconcile.parse_deferred_context_payload(payload)
+
+
 def test_parse_deferred_context_payload_rejects_kind_event_mismatch():
     payload = issue_comment_payload(
         pr_number=42,
@@ -320,6 +343,52 @@ def test_parse_deferred_context_payload_accepts_legacy_comment_payload():
     assert parsed.source_body_digest == "digest"
     assert parsed.source_comment_class == "plain_text"
     assert parsed.source_has_non_command_text is True
+
+
+def test_parse_deferred_context_payload_normalizes_legacy_app_flag_strings():
+    payload = {
+        "schema_version": 2,
+        "source_event_name": "issue_comment",
+        "source_event_action": "created",
+        "source_event_key": "issue_comment:210",
+        "pr_number": 42,
+        "comment_id": 210,
+        "comment_class": "plain_text",
+        "has_non_command_text": True,
+        "source_body_digest": "digest",
+        "source_created_at": "2026-03-17T10:00:00Z",
+        "actor_login": "alice",
+        "source_run_id": 1,
+        "source_run_attempt": 1,
+        "comment_performed_via_github_app": "false",
+    }
+
+    parsed = reconcile.parse_deferred_context_payload(payload)
+
+    assert isinstance(parsed, reconcile.DeferredCommentPayload)
+    assert parsed.comment_performed_via_github_app is False
+
+
+def test_parse_deferred_context_payload_rejects_invalid_legacy_app_flag():
+    payload = {
+        "schema_version": 2,
+        "source_event_name": "issue_comment",
+        "source_event_action": "created",
+        "source_event_key": "issue_comment:210",
+        "pr_number": 42,
+        "comment_id": 210,
+        "comment_class": "plain_text",
+        "has_non_command_text": True,
+        "source_body_digest": "digest",
+        "source_created_at": "2026-03-17T10:00:00Z",
+        "actor_login": "alice",
+        "source_run_id": 1,
+        "source_run_attempt": 1,
+        "comment_performed_via_github_app": "not-a-bool",
+    }
+
+    with pytest.raises(RuntimeError, match="comment_performed_via_github_app must be boolean"):
+        reconcile.parse_deferred_context_payload(payload)
 
 
 def test_parse_deferred_context_payload_rejects_observer_noop_payload():

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -345,6 +345,38 @@ def test_parse_deferred_context_payload_accepts_legacy_comment_payload():
     assert parsed.source_has_non_command_text is True
 
 
+def test_legacy_review_comment_commit_hydration_updates_typed_payload():
+    payload = {
+        "schema_version": 2,
+        "source_event_name": "pull_request_review_comment",
+        "source_event_action": "created",
+        "source_event_key": "pull_request_review_comment:310",
+        "pr_number": 42,
+        "comment_id": 310,
+        "comment_class": "plain_text",
+        "has_non_command_text": True,
+        "source_body_digest": "digest",
+        "source_created_at": "2026-03-17T10:00:00Z",
+        "actor_login": "alice",
+        "actor_id": 7001,
+        "source_run_id": 1,
+        "source_run_attempt": 1,
+    }
+    parsed = reconcile.parse_deferred_context_payload(payload)
+    assert isinstance(parsed, reconcile.DeferredCommentPayload)
+    context = reconcile.build_deferred_comment_replay_context(
+        parsed,
+        expected_event_name="pull_request_review_comment",
+        live_comment_endpoint="pulls/comments/310",
+    )
+
+    hydrated = reconcile._hydrate_live_review_comment_commit_id(context, {"commit_id": " head-1 "})
+
+    assert hydrated is not None
+    assert hydrated.payload.source_commit_id == "head-1"
+    assert parsed.raw_payload["source_commit_id"] == "head-1"
+
+
 def test_parse_deferred_context_payload_normalizes_legacy_app_flag_strings():
     payload = {
         "schema_version": 2,

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -377,6 +377,48 @@ def test_legacy_review_comment_commit_hydration_updates_typed_payload():
     assert parsed.raw_payload["source_commit_id"] == "head-1"
 
 
+def test_recover_deferred_payload_identity_builds_sanitized_payload_without_mutating_source():
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=210,
+        source_event_key="issue_comment:210",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="bob",
+        source_run_id=610,
+        source_run_attempt=1,
+    )
+    before = dict(payload)
+
+    recovered = reconcile_payloads.recover_deferred_payload_identity(payload)
+
+    assert payload == before
+    assert recovered.source_event_key == "issue_comment:210"
+    assert recovered.source_object_id == 210
+    assert recovered.diagnostic_payload["source_comment_id"] == 210
+    assert recovered.diagnostic_payload["source_event_created_at"] == "2026-03-17T10:00:00Z"
+
+
+def test_recover_deferred_payload_identity_rejects_invalid_timestamp():
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=210,
+        source_event_key="issue_comment:210",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="not-a-timestamp",
+        actor_login="bob",
+        source_run_id=610,
+        source_run_attempt=1,
+    )
+
+    with pytest.raises(RuntimeError, match="timestamp is not parseable"):
+        reconcile_payloads.recover_deferred_payload_identity(payload)
+
+
 def test_parse_deferred_context_payload_normalizes_legacy_app_flag_strings():
     payload = {
         "schema_version": 2,

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -159,6 +159,24 @@ def test_parse_deferred_context_payload_rejects_source_event_key_prefix_mismatch
         reconcile.parse_deferred_context_payload(payload)
 
 
+def test_parse_deferred_context_payload_rejects_source_event_key_object_mismatch():
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=210,
+        source_event_key="issue_comment:999",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="2026-03-17T10:00:00Z",
+        actor_login="bob",
+        source_run_id=610,
+        source_run_attempt=1,
+    )
+
+    with pytest.raises(RuntimeError, match="source_event_key object mismatch"):
+        reconcile.parse_deferred_context_payload(payload)
+
+
 def test_build_deferred_comment_replay_context_returns_typed_context():
     payload = reconcile.DeferredCommentPayload(
         identity=reconcile.DeferredArtifactIdentity(

--- a/tests/unit/reviewer_bot/test_sweeper_logic.py
+++ b/tests/unit/reviewer_bot/test_sweeper_logic.py
@@ -82,13 +82,19 @@ def test_sweeper_creates_keyed_deferred_gaps_for_visible_comments_reviews_and_di
     )
     runtime.github.stub(routes)
     runtime.github.get_pull_request_reviews = lambda issue_number: [
-        pull_request_review_event(202, submitted_at="2026-03-25T11:00:00Z", state="APPROVED"),
+        pull_request_review_event(202, submitted_at="2026-03-25T11:00:00Z", state="APPROVED", commit_id="head-1"),
     ]
 
     assert sweeper.sweep_deferred_gaps(runtime, state) is True
     gaps = state["active_reviews"]["42"]["sidecars"]["deferred_gaps"]
     assert "issue_comment:101" in gaps
+    assert gaps["issue_comment:101"]["source_actor_login"] == "alice"
+    assert gaps["issue_comment:101"]["source_actor_user_type"] == "User"
+    assert gaps["issue_comment:101"]["source_comment_id"] == 101
     assert "pull_request_review:202" in gaps
+    assert gaps["pull_request_review:202"]["source_actor_login"] == "alice"
+    assert gaps["pull_request_review:202"]["source_commit_id"] == "head-1"
+    assert gaps["pull_request_review:202"]["source_review_state"] == "APPROVED"
     assert "pull_request_review_dismissed:303" in gaps
     assert gaps["pull_request_review_dismissed:303"]["source_event_kind"] == "pull_request_review:dismissed"
 
@@ -132,6 +138,9 @@ def test_sweeper_creates_keyed_deferred_gap_for_visible_review_comments(monkeypa
     gaps = state["active_reviews"]["42"]["sidecars"]["deferred_gaps"]
     assert "pull_request_review_comment:404" in gaps
     assert gaps["pull_request_review_comment:404"]["source_event_kind"] == "pull_request_review_comment:created"
+    assert gaps["pull_request_review_comment:404"]["source_actor_login"] == "dana"
+    assert gaps["pull_request_review_comment:404"]["source_actor_user_type"] == "User"
+    assert gaps["pull_request_review_comment:404"]["source_comment_id"] == 404
 
 
 def test_discover_visible_review_comment_events_paginates_past_page_one(monkeypatch, freeze_sweeper_now):

--- a/tests/unit/reviewer_bot/test_sweeper_logic.py
+++ b/tests/unit/reviewer_bot/test_sweeper_logic.py
@@ -89,10 +89,14 @@ def test_sweeper_creates_keyed_deferred_gaps_for_visible_comments_reviews_and_di
     gaps = state["active_reviews"]["42"]["sidecars"]["deferred_gaps"]
     assert "issue_comment:101" in gaps
     assert gaps["issue_comment:101"]["source_actor_login"] == "alice"
+    assert gaps["issue_comment:101"]["source_actor_id"] == 7001
     assert gaps["issue_comment:101"]["source_actor_user_type"] == "User"
+    assert gaps["issue_comment:101"]["source_actor_performed_via_github_app"] is False
     assert gaps["issue_comment:101"]["source_comment_id"] == 101
     assert "pull_request_review:202" in gaps
     assert gaps["pull_request_review:202"]["source_actor_login"] == "alice"
+    assert gaps["pull_request_review:202"]["source_actor_id"] == 7003
+    assert gaps["pull_request_review:202"]["source_actor_user_type"] == "User"
     assert gaps["pull_request_review:202"]["source_commit_id"] == "head-1"
     assert gaps["pull_request_review:202"]["source_review_state"] == "APPROVED"
     assert "pull_request_review_dismissed:303" in gaps
@@ -121,7 +125,7 @@ def test_sweeper_creates_keyed_deferred_gap_for_visible_review_comments(monkeypa
             "GET",
             "pulls/42/comments?per_page=100&page=1",
             status_code=200,
-            payload=[review_comment_event(404, created_at="2026-03-25T10:30:00Z", login="dana")],
+            payload=[review_comment_event(404, created_at="2026-03-25T10:30:00Z", login="dana", review_id=202, commit_id="head-1")],
         )
         .add_request(
             "GET",
@@ -139,8 +143,12 @@ def test_sweeper_creates_keyed_deferred_gap_for_visible_review_comments(monkeypa
     assert "pull_request_review_comment:404" in gaps
     assert gaps["pull_request_review_comment:404"]["source_event_kind"] == "pull_request_review_comment:created"
     assert gaps["pull_request_review_comment:404"]["source_actor_login"] == "dana"
+    assert gaps["pull_request_review_comment:404"]["source_actor_id"] == 7002
     assert gaps["pull_request_review_comment:404"]["source_actor_user_type"] == "User"
+    assert gaps["pull_request_review_comment:404"]["source_actor_performed_via_github_app"] is False
     assert gaps["pull_request_review_comment:404"]["source_comment_id"] == 404
+    assert gaps["pull_request_review_comment:404"]["source_review_id"] == 202
+    assert gaps["pull_request_review_comment:404"]["source_commit_id"] == "head-1"
 
 
 def test_discover_visible_review_comment_events_paginates_past_page_one(monkeypatch, freeze_sweeper_now):


### PR DESCRIPTION
## Summary
- align retained reviewer board attention and waiting-since behavior with the frozen post-incident reminder truth
- keep the retained preview-reviewer-board owner and board artifact contract stable while closing the remaining post-hardening parity gap

## Verification
- board parity verification floor from the v19 board-attention plan
- artifact: $OPENCODE_CONFIG_DIR/reviewer-bot/pr264-post-hardening-board-attention-parity-v19/board-parity-local-proof.json
