### PR TITLE
fix: normalize reviewer-bot timestamps

### DIFF
--- a/scripts/reviewer_bot_core/deferred_gap_diagnosis.py
+++ b/scripts/reviewer_bot_core/deferred_gap_diagnosis.py
@@ -24,9 +24,12 @@ def parse_timestamp(value: Any) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
 
 
 def observer_run_reason_from_details(run_details: dict, runbook_signature: dict | None) -> str:

--- a/scripts/reviewer_bot_core/live_review_support.py
+++ b/scripts/reviewer_bot_core/live_review_support.py
@@ -75,9 +75,12 @@ def parse_github_timestamp(value: Any) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
 
 
 def projection_failure_result(reason: str, failure_kind: str | None = None) -> dict[str, object]:
@@ -174,7 +177,9 @@ def normalize_reviews_with_parsed_timestamps(reviews: list[dict], *, parse_times
 
 def _timestamp_value(value: object) -> datetime | None:
     if isinstance(value, datetime):
-        return value
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
     return parse_github_timestamp(value)
 
 

--- a/scripts/reviewer_bot_lib/deferred_gap_bookkeeping.py
+++ b/scripts/reviewer_bot_lib/deferred_gap_bookkeeping.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
+from .timestamps import normalize_iso8601_utc_string, parse_iso8601_utc
+
 
 @dataclass(frozen=True)
 class DeferredGap:
@@ -216,15 +218,7 @@ def _observer_now_iso(bot) -> str:
 
 
 def _parse_observer_timestamp(value: object) -> datetime | None:
-    if not isinstance(value, str) or not value.strip():
-        return None
-    try:
-        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if timestamp.tzinfo is None:
-        return timestamp.replace(tzinfo=timezone.utc)
-    return timestamp
+    return parse_iso8601_utc(value)
 
 
 def _configured_seconds(bot, name: str, default: int) -> int:
@@ -247,6 +241,8 @@ def begin_observer_surface_scan(
     scan_started_at = now or bot.clock.now()
     if scan_started_at.tzinfo is None:
         scan_started_at = scan_started_at.replace(tzinfo=timezone.utc)
+    else:
+        scan_started_at = scan_started_at.astimezone(timezone.utc)
     lookback_seconds = _configured_seconds(bot, "DEFERRED_DISCOVERY_OVERLAP_SECONDS", 3600)
     bootstrap_window_seconds = _configured_seconds(bot, "DEFERRED_DISCOVERY_BOOTSTRAP_WINDOW_SECONDS", 604800)
     watermark.update(
@@ -266,11 +262,12 @@ def begin_observer_surface_scan(
 def record_observer_watermark_event(bot, review_data: dict, surface: str, event_time: str, event_id: str) -> None:
     current = _ensure_observer_discovery_watermark(review_data, surface)
     now = _observer_now_iso(bot)
+    safe_event_time = normalize_iso8601_utc_string(event_time) or event_time
     current.update(
         {
             "last_scan_started_at": current.get("last_scan_started_at") or now,
             "last_scan_completed_at": now,
-            "last_safe_event_time": event_time,
+            "last_safe_event_time": safe_event_time,
             "last_safe_event_id": event_id,
             "lookback_seconds": _configured_seconds(bot, "DEFERRED_DISCOVERY_OVERLAP_SECONDS", 3600),
             "bootstrap_window_seconds": _configured_seconds(bot, "DEFERRED_DISCOVERY_BOOTSTRAP_WINDOW_SECONDS", 604800),
@@ -304,7 +301,8 @@ def get_deferred_gap_reason(review_data: dict, source_event_key: str) -> str | N
 
 
 def _now_iso(bot) -> str:
-    return bot.clock.now().isoformat()
+    now = bot.clock.now()
+    return normalize_iso8601_utc_string(now) or now.isoformat()
 
 
 def _reconciled_at_now() -> str:
@@ -360,7 +358,7 @@ def mark_reconciled_source_event(
     reconciled_at: str | None = None,
 ) -> bool:
     reconciled = _reconciled_source_events(review_data)
-    timestamp = reconciled_at or _reconciled_at_now()
+    timestamp = normalize_iso8601_utc_string(reconciled_at) or reconciled_at or _reconciled_at_now()
     existing = reconciled.get(source_event_key)
     if isinstance(existing, dict):
         if not _is_valid_reconciled_source_event(existing, source_event_key):
@@ -424,7 +422,7 @@ def _copy_source_evidence(fields: dict, payload: dict, existing: dict) -> None:
 
 
 def _source_event_created_at(payload: dict, existing: dict):
-    return (
+    value = (
         payload.get("source_created_at")
         or payload.get("comment_created_at")
         or payload.get("source_submitted_at")
@@ -432,6 +430,7 @@ def _source_event_created_at(payload: dict, existing: dict):
         or payload.get("source_event_created_at")
         or existing.get("source_event_created_at")
     )
+    return normalize_iso8601_utc_string(value) or value
 
 
 def record_deferred_gap_diagnostic(
@@ -469,7 +468,7 @@ def record_deferred_gap_diagnostic(
     }
     source_dismissed_at = _payload_or_existing(payload, existing, "source_dismissed_at")
     if source_dismissed_at is not None:
-        fields["source_dismissed_at"] = source_dismissed_at
+        fields["source_dismissed_at"] = normalize_iso8601_utc_string(source_dismissed_at) or source_dismissed_at
     _copy_source_evidence(fields, payload, existing)
     existing.update(fields)
     changed = previous != existing

--- a/scripts/reviewer_bot_lib/event_inputs.py
+++ b/scripts/reviewer_bot_lib/event_inputs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from scripts.reviewer_bot_core.comment_routing_policy import PrCommentRouterOutcome
@@ -79,14 +79,15 @@ def derive_lifecycle_event_timestamp(
         selected = source_updated_at
         kind = "explicit_action_proxy"
         reason = f"{event_action}_uses_updated_at_proxy"
-    authoritative = isinstance(selected, str) and selected.strip() and _is_parseable_iso8601(selected)
+    normalized = _normalize_iso8601_timestamp(selected) if isinstance(selected, str) else None
+    authoritative = normalized is not None
     return LifecycleEventTimestampEvidence(
         event_name=event_name,
         event_action=event_action,
         source_created_at=source_created_at,
         source_updated_at=source_updated_at,
         source_closed_at=source_closed_at,
-        selected_timestamp=selected if authoritative else None,
+        selected_timestamp=normalized if authoritative else None,
         selection_kind=kind if authoritative else "blocked",
         selection_reason=reason if authoritative else "invalid_or_missing_timestamp",
         is_authoritative=bool(authoritative),
@@ -135,12 +136,21 @@ def parse_issue_labels(bot: EventInputsContext) -> list[str]:
     return list(_parse_labels(bot.get_config_value("ISSUE_LABELS", "[]")))
 
 
-def _is_parseable_iso8601(value: str) -> bool:
+def _normalize_iso8601_timestamp(value: str) -> str | None:
+    value = value.strip()
+    if not value:
+        return None
     try:
-        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
-        return False
-    return True
+        return None
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc).isoformat()
+    return value
+
+
+def _is_parseable_iso8601(value: str) -> bool:
+    return _normalize_iso8601_timestamp(value) is not None
 
 
 def _raise_invalid(builder: str, problems: list[str]) -> None:
@@ -311,8 +321,12 @@ def build_comment_event_request(bot: EventInputsContext, *, issue_number: int | 
     comment_created_at = bot.get_config_value("COMMENT_CREATED_AT").strip()
     if not comment_created_at:
         problems.append("COMMENT_CREATED_AT must be non-empty")
-    elif not _is_parseable_iso8601(comment_created_at):
-        problems.append("COMMENT_CREATED_AT must be parseable ISO-8601")
+    else:
+        normalized_comment_created_at = _normalize_iso8601_timestamp(comment_created_at)
+        if normalized_comment_created_at is None:
+            problems.append("COMMENT_CREATED_AT must be parseable ISO-8601")
+        else:
+            comment_created_at = normalized_comment_created_at
     comment_source_event_key = bot.get_config_value("COMMENT_SOURCE_EVENT_KEY").strip()
     if not comment_source_event_key and comment_id > 0:
         comment_source_event_key = _derive_comment_source_event_key(bot, comment_id) or ""

--- a/scripts/reviewer_bot_lib/event_inputs.py
+++ b/scripts/reviewer_bot_lib/event_inputs.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 
 from scripts.reviewer_bot_core.comment_routing_policy import PrCommentRouterOutcome
@@ -21,6 +20,7 @@ from .context import (
     PullRequestSyncRequest,
 )
 from .runtime_protocols import EventInputsContext
+from .timestamps import normalize_iso8601_utc_string
 
 
 class InvalidEventInput(RuntimeError):
@@ -137,16 +137,7 @@ def parse_issue_labels(bot: EventInputsContext) -> list[str]:
 
 
 def _normalize_iso8601_timestamp(value: str) -> str | None:
-    value = value.strip()
-    if not value:
-        return None
-    try:
-        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if timestamp.tzinfo is None:
-        return timestamp.replace(tzinfo=timezone.utc).isoformat()
-    return value
+    return normalize_iso8601_utc_string(value)
 
 
 def _is_parseable_iso8601(value: str) -> bool:

--- a/scripts/reviewer_bot_lib/overdue.py
+++ b/scripts/reviewer_bot_lib/overdue.py
@@ -605,10 +605,7 @@ def _find_existing_marker_comment(
 ) -> dict[str, object]:
     earliest = None
     if isinstance(not_before, str) and not_before:
-        try:
-            earliest = bot.datetime.fromisoformat(not_before.replace("Z", "+00:00"))
-        except (ValueError, AttributeError):
-            earliest = None
+        earliest = _parse_reminder_timestamp(not_before)
     page = 1
     while True:
         try:
@@ -634,9 +631,8 @@ def _find_existing_marker_comment(
                 continue
             if login not in authors:
                 continue
-            try:
-                created_dt = bot.datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-            except (ValueError, AttributeError):
+            created_dt = _parse_reminder_timestamp(created_at)
+            if created_dt is None:
                 continue
             if earliest is not None and created_dt < earliest:
                 continue
@@ -785,9 +781,8 @@ def _find_existing_warning_comment(
             if second_line.startswith(scope_prefix):
                 if scope_marker is None or second_line != scope_marker:
                     continue
-            try:
-                created_dt = bot.datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-            except (ValueError, AttributeError):
+            created_dt = _parse_reminder_timestamp(created_at)
+            if created_dt is None:
                 continue
             if first_match is None or created_dt < first_match[0]:
                 first_match = (created_dt, created_at, comment.get("id"))
@@ -961,9 +956,8 @@ def check_overdue_reviews(bot, state: dict) -> list[dict]:
         if not last_activity:
             continue
 
-        try:
-            last_activity_dt = bot.datetime.fromisoformat(last_activity.replace("Z", "+00:00"))
-        except (ValueError, AttributeError):
+        last_activity_dt = _parse_reminder_timestamp(last_activity)
+        if last_activity_dt is None:
             continue
 
         days_since_activity = (now - last_activity_dt).days

--- a/scripts/reviewer_bot_lib/overdue.py
+++ b/scripts/reviewer_bot_lib/overdue.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 
 from . import assignment_flow
 from .config import TRANSITION_NOTICE_MARKER_PREFIX, TRANSITION_WARNING_MARKER_PREFIX
 from .reminder_comments import ReminderCommentScan, scan_reviewer_reminder_comments
 from .repair_records import clear_repair_marker, store_repair_marker
+from .timestamps import parse_iso8601_utc
 
 _TRANSITION_NOTICE_AUTHORS = {"github-actions[bot]", "guidelines-bot"}
 
@@ -418,15 +419,7 @@ def build_reminder_delivery_persistence_result(
 
 
 def _parse_reminder_timestamp(value: object) -> datetime | None:
-    if isinstance(value, datetime):
-        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
-    if not isinstance(value, str) or not value.strip():
-        return None
-    try:
-        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    return timestamp if timestamp.tzinfo is not None else timestamp.replace(tzinfo=timezone.utc)
+    return parse_iso8601_utc(value)
 
 
 def derive_reminder_cadence_decision(

--- a/scripts/reviewer_bot_lib/reconcile_payloads.py
+++ b/scripts/reviewer_bot_lib/reconcile_payloads.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from enum import StrEnum
+
+from .timestamps import normalize_iso8601_utc_string
 
 
 class DeferredPayloadKind(StrEnum):
@@ -520,13 +521,10 @@ def _first_string(payload: dict, field_names: tuple[str, ...], diagnostic_name: 
 
 def _recoverable_timestamp(payload: dict, field_names: tuple[str, ...]) -> str:
     timestamp = _first_string(payload, field_names, "source event timestamp")
-    try:
-        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-    except ValueError as exc:
-        raise RuntimeError("Deferred context payload source event timestamp is not parseable ISO-8601") from exc
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc).isoformat()
-    return timestamp
+    normalized = normalize_iso8601_utc_string(timestamp)
+    if normalized is None:
+        raise RuntimeError("Deferred context payload source event timestamp is not parseable ISO-8601")
+    return normalized
 
 
 def _optional_nonempty_string(payload: dict, field_name: str) -> str | None:
@@ -534,6 +532,19 @@ def _optional_nonempty_string(payload: dict, field_name: str) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
+
+
+def _timestamp_string(value: object, diagnostic_name: str) -> str:
+    normalized = normalize_iso8601_utc_string(value)
+    if normalized is None:
+        raise RuntimeError(f"Deferred context payload {diagnostic_name} is not parseable ISO-8601")
+    return normalized
+
+
+def _optional_timestamp_string(value: object) -> str | None:
+    if value is None:
+        return None
+    return normalize_iso8601_utc_string(value) or str(value)
 
 
 def _diagnostic_payload(payload: dict, contract: DeferredIdentityContract, *, source_run_id: int, source_run_attempt: int, pr_number: int, source_event_key: str, source_object_id: int, actor_login: str, source_event_created_at: str) -> dict:
@@ -556,6 +567,8 @@ def _diagnostic_payload(payload: dict, contract: DeferredIdentityContract, *, so
         "source_dismissed_at",
     ):
         value = _optional_nonempty_string(payload, field_name)
+        if value is not None and field_name == "source_dismissed_at":
+            value = normalize_iso8601_utc_string(value) or value
         if value is not None:
             diagnostic[field_name] = value
     actor_id = payload.get("source_actor_id", payload.get("comment_author_id", payload.get("actor_id")))
@@ -831,7 +844,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
                 identity=identity,
                 comment_id=comment_id,
                 comment_body="",
-                comment_created_at=str(payload["source_created_at"]),
+                comment_created_at=_timestamp_string(payload["source_created_at"], "source_created_at"),
                 comment_author=str(payload["actor_login"]),
                 comment_author_id=comment_author_id,
                 comment_user_type=str(payload.get("actor_user_type") or "User"),
@@ -853,7 +866,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
             identity=identity,
             comment_id=comment_id,
             comment_body=str(payload["comment_body"]),
-            comment_created_at=str(payload["comment_created_at"]),
+            comment_created_at=_timestamp_string(payload["comment_created_at"], "comment_created_at"),
             comment_author=str(payload["comment_author"]),
             comment_author_id=int(payload["comment_author_id"]),
             comment_user_type=str(payload["comment_user_type"]),
@@ -873,7 +886,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
         common = dict(
             identity=identity,
             review_id=review_id,
-            source_submitted_at=(str(payload["source_submitted_at"]) if payload.get("source_submitted_at") is not None else None),
+            source_submitted_at=_optional_timestamp_string(payload.get("source_submitted_at")),
             source_review_state=(str(payload["source_review_state"]) if payload.get("source_review_state") is not None else None),
             source_commit_id=(str(payload["source_commit_id"]) if payload.get("source_commit_id") is not None else None),
             actor_login=(str(payload["actor_login"]) if payload.get("actor_login") is not None else None),
@@ -883,7 +896,7 @@ def parse_deferred_context_payload(payload: dict) -> DeferredReviewPayload | Def
             return DeferredReviewSubmittedPayload(**common)
         return DeferredReviewDismissedPayload(
             **common,
-            source_dismissed_at=(str(payload["source_dismissed_at"]) if payload.get("source_dismissed_at") is not None else None),
+            source_dismissed_at=_optional_timestamp_string(payload.get("source_dismissed_at")),
         )
     raise RuntimeError("Unsupported deferred workflow_run payload")
 

--- a/scripts/reviewer_bot_lib/reconcile_payloads.py
+++ b/scripts/reviewer_bot_lib/reconcile_payloads.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import StrEnum
 
 
@@ -525,7 +525,7 @@ def _recoverable_timestamp(payload: dict, field_names: tuple[str, ...]) -> str:
     except ValueError as exc:
         raise RuntimeError("Deferred context payload source event timestamp is not parseable ISO-8601") from exc
     if parsed.tzinfo is None:
-        raise RuntimeError("Deferred context payload source event timestamp must include timezone")
+        return parsed.replace(tzinfo=timezone.utc).isoformat()
     return timestamp
 
 

--- a/scripts/reviewer_bot_lib/reconcile_reads.py
+++ b/scripts/reviewer_bot_lib/reconcile_reads.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+
+from .timestamps import normalize_iso8601_utc_string
 
 
 class ReconcileReadError(RuntimeError):
@@ -48,13 +49,7 @@ def _valid_exact_timestamp(value: object) -> str | None:
     timestamp = value.strip()
     if "T" not in timestamp:
         return None
-    try:
-        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc).isoformat()
-    return timestamp
+    return normalize_iso8601_utc_string(timestamp)
 
 
 def _dismissed_review_source_time(payload: dict | None) -> DismissalTimeResolution | None:

--- a/scripts/reviewer_bot_lib/reconcile_reads.py
+++ b/scripts/reviewer_bot_lib/reconcile_reads.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class ReconcileReadError(RuntimeError):
@@ -53,7 +53,7 @@ def _valid_exact_timestamp(value: object) -> str | None:
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        return None
+        return parsed.replace(tzinfo=timezone.utc).isoformat()
     return timestamp
 
 

--- a/scripts/reviewer_bot_lib/sweeper.py
+++ b/scripts/reviewer_bot_lib/sweeper.py
@@ -37,9 +37,12 @@ def parse_timestamp(value: Any) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
 
 
 def _read_api_payload(bot: SweeperContext, endpoint: str) -> tuple[Any | None, str | None]:

--- a/scripts/reviewer_bot_lib/timestamps.py
+++ b/scripts/reviewer_bot_lib/timestamps.py
@@ -1,0 +1,26 @@
+"""Reviewer-bot timestamp normalization helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def parse_iso8601_utc(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        timestamp = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            timestamp = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
+
+
+def normalize_iso8601_utc_string(value: Any) -> str | None:
+    timestamp = parse_iso8601_utc(value)
+    return timestamp.isoformat() if timestamp is not None else None

--- a/tests/contract/reviewer_bot/test_adapter_contract.py
+++ b/tests/contract/reviewer_bot/test_adapter_contract.py
@@ -436,20 +436,20 @@ def test_event_inputs_build_issue_lifecycle_request_from_runtime_config(monkeypa
     assert request.previous_title == "Old title"
     assert request.previous_body == "old body"
     assert request.pr_head_sha == "head-2"
-    assert request.event_created_at == "2026-03-17T10:00:00Z"
+    assert request.event_created_at == "2026-03-17T10:00:00+00:00"
 
 
 @pytest.mark.parametrize(
     ("event_action", "expected_timestamp"),
     [
-        ("opened", "2026-03-17T09:00:00Z"),
-        ("edited", "2026-03-17T10:00:00Z"),
-        ("assigned", "2026-03-17T10:00:00Z"),
-        ("unassigned", "2026-03-17T10:00:00Z"),
-        ("labeled", "2026-03-17T10:00:00Z"),
-        ("unlabeled", "2026-03-17T10:00:00Z"),
-        ("reopened", "2026-03-17T10:00:00Z"),
-        ("closed", "2026-03-17T11:00:00Z"),
+        ("opened", "2026-03-17T09:00:00+00:00"),
+        ("edited", "2026-03-17T10:00:00+00:00"),
+        ("assigned", "2026-03-17T10:00:00+00:00"),
+        ("unassigned", "2026-03-17T10:00:00+00:00"),
+        ("labeled", "2026-03-17T10:00:00+00:00"),
+        ("unlabeled", "2026-03-17T10:00:00+00:00"),
+        ("reopened", "2026-03-17T10:00:00+00:00"),
+        ("closed", "2026-03-17T11:00:00+00:00"),
     ],
 )
 def test_event_inputs_derives_issue_lifecycle_timestamp_from_action_fields(
@@ -470,12 +470,12 @@ def test_event_inputs_derives_issue_lifecycle_timestamp_from_action_fields(
 @pytest.mark.parametrize(
     ("event_action", "expected_timestamp"),
     [
-        ("opened", "2026-03-17T09:30:00Z"),
-        ("labeled", "2026-03-17T10:30:00Z"),
-        ("unlabeled", "2026-03-17T10:30:00Z"),
-        ("reopened", "2026-03-17T10:30:00Z"),
-        ("synchronize", "2026-03-17T10:30:00Z"),
-        ("closed", "2026-03-17T11:30:00Z"),
+        ("opened", "2026-03-17T09:30:00+00:00"),
+        ("labeled", "2026-03-17T10:30:00+00:00"),
+        ("unlabeled", "2026-03-17T10:30:00+00:00"),
+        ("reopened", "2026-03-17T10:30:00+00:00"),
+        ("synchronize", "2026-03-17T10:30:00+00:00"),
+        ("closed", "2026-03-17T11:30:00+00:00"),
     ],
 )
 def test_event_inputs_derives_pr_lifecycle_timestamp_from_action_fields(
@@ -569,7 +569,7 @@ def test_event_inputs_build_label_and_sync_requests_from_runtime_config(monkeypa
     assert label_request.label_name == "sign-off: create pr"
     assert sync_request.issue_number == 42
     assert sync_request.head_sha == "head-2"
-    assert sync_request.event_created_at == "2026-03-17T10:05:00Z"
+    assert sync_request.event_created_at == "2026-03-17T10:05:00+00:00"
 
 
 def test_bootstrap_runtime_github_exposes_typed_reminder_helpers(monkeypatch):

--- a/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
+++ b/tests/integration/reviewer_bot/test_reconcile_workflow_run.py
@@ -294,7 +294,7 @@ def test_deferred_review_dismissal_replay_uses_source_dismissal_time(monkeypatch
     harness.stub_head_repair(changed=False)
 
     assert harness.run(state) is True
-    assert review["review_dismissal"]["accepted"]["timestamp"] == "2026-03-17T10:10:00Z"
+    assert review["review_dismissal"]["accepted"]["timestamp"] == "2026-03-17T10:10:00+00:00"
     assert "pull_request_review_dismissed:12" in _reconciled_source_events(review)
     assert "pull_request_review_dismissed:12" not in _deferred_gaps(review)
     assert "issues/42/timeline?per_page=100&page=1" not in harness.github.requested_endpoints()
@@ -333,7 +333,7 @@ def test_deferred_review_dismissal_replay_uses_exact_timeline_dismissed_at(monke
     harness.stub_head_repair(changed=False)
 
     assert harness.run(state) is True
-    assert review["review_dismissal"]["accepted"]["timestamp"] == "2026-03-17T10:12:00Z"
+    assert review["review_dismissal"]["accepted"]["timestamp"] == "2026-03-17T10:12:00+00:00"
     assert "pull_request_review_dismissed:12" in _reconciled_source_events(review)
 
 
@@ -385,7 +385,7 @@ def test_deferred_review_dismissal_replay_finds_exact_time_on_paginated_timeline
 
     assert harness.run(state) is True
 
-    assert review["review_dismissal"]["accepted"]["timestamp"] == "2026-03-17T10:12:00Z"
+    assert review["review_dismissal"]["accepted"]["timestamp"] == "2026-03-17T10:12:00+00:00"
     assert "issues/42/timeline?per_page=100&page=1" in harness.github.requested_endpoints()
     assert "issues/42/timeline?per_page=100&page=2" in harness.github.requested_endpoints()
 
@@ -623,7 +623,7 @@ def test_deferred_comment_missing_live_object_preserves_source_time_freshness(mo
     assert state["active_reviews"]["42"]["reviewer_comment"]["accepted"] is None
     gap = state["active_reviews"]["42"]["sidecars"]["deferred_gaps"]["issue_comment:99"]
     assert gap["reason"] == "reconcile_failed_closed"
-    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
     assert gap["source_actor_login"] == "alice"
     assert gap["source_actor_id"] == 7001
     assert gap["source_actor_user_type"] == "User"
@@ -865,7 +865,7 @@ def test_deferred_review_comment_missing_live_object_preserves_source_time_fresh
     assert review["reviewer_comment"]["accepted"] is None
     gap = _deferred_gaps(review)["pull_request_review_comment:303"]
     assert gap["reason"] == "reconcile_failed_closed"
-    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
     assert gap["source_actor_login"] == "alice"
     assert gap["source_actor_id"] == 6
     assert gap["source_actor_user_type"] == "User"
@@ -1210,7 +1210,7 @@ def test_deferred_issue_comment_parse_failure_records_artifact_invalid_gap(monke
     gap = _deferred_gaps(review)["issue_comment:212"]
     assert gap["reason"] == "artifact_invalid"
     assert gap["source_comment_id"] == 212
-    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
 
 
 def test_deferred_issue_comment_parse_failure_rejects_mismatched_source_object_key(monkeypatch):
@@ -1259,7 +1259,7 @@ def test_deferred_review_submitted_parse_failure_records_artifact_invalid_gap(mo
     gap = _deferred_gaps(review)["pull_request_review:13"]
     assert gap["reason"] == "artifact_invalid"
     assert gap["source_review_id"] == 13
-    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
 
 
 def test_deferred_review_dismissed_parse_failure_records_artifact_invalid_gap(monkeypatch):
@@ -1283,7 +1283,7 @@ def test_deferred_review_dismissed_parse_failure_records_artifact_invalid_gap(mo
     gap = _deferred_gaps(review)["pull_request_review_dismissed:14"]
     assert gap["reason"] == "artifact_invalid"
     assert gap["source_review_id"] == 14
-    assert gap["source_event_created_at"] == "2026-03-17T10:10:00Z"
+    assert gap["source_event_created_at"] == "2026-03-17T10:10:00+00:00"
 
 
 def test_deferred_legacy_review_comment_hydrates_source_commit_id_from_live_comment(monkeypatch):

--- a/tests/unit/reviewer_bot/test_deferred_gap_bookkeeping.py
+++ b/tests/unit/reviewer_bot/test_deferred_gap_bookkeeping.py
@@ -160,13 +160,13 @@ def test_bookkeeping_owner_records_observer_watermark_event_and_empty_scan(monke
         runtime,
         review,
         "reviews_dismissed",
-        "2026-03-17T10:00:00Z",
+        "2026-03-17T12:30:00+02:30",
         "12",
     )
     deferred_gap_bookkeeping.record_observer_watermark_empty_scan(runtime, review, "review_comments")
 
     dismissed = review["sidecars"]["observer_discovery_watermarks"]["reviews_dismissed"]
-    assert dismissed["last_safe_event_time"] == "2026-03-17T10:00:00Z"
+    assert dismissed["last_safe_event_time"] == "2026-03-17T10:00:00+00:00"
     assert dismissed["last_safe_event_id"] == "12"
     assert dismissed["last_scan_completed_at"] == "2026-03-18T00:00:00+00:00"
     comments = review["sidecars"]["observer_discovery_watermarks"]["review_comments"]
@@ -298,7 +298,7 @@ def test_deferred_gap_diagnostic_retains_normalized_comment_source_evidence(monk
 
     assert changed is True
     gap = review["sidecars"]["deferred_gaps"]["issue_comment:210"]
-    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
     assert gap["source_actor_login"] == "alice"
     assert gap["source_actor_id"] == 7001
     assert gap["source_actor_user_type"] == "User"
@@ -322,7 +322,7 @@ def test_deferred_gap_diagnostic_retains_normalized_comment_source_evidence(monk
 
     gap = review["sidecars"]["deferred_gaps"]["issue_comment:210"]
     assert gap["source_actor_login"] == "alice"
-    assert gap["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert gap["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
 
 
 def test_update_deferred_gap_preserves_source_dismissed_at_diagnostics(monkeypatch):

--- a/tests/unit/reviewer_bot/test_event_inputs.py
+++ b/tests/unit/reviewer_bot/test_event_inputs.py
@@ -1,4 +1,15 @@
-from scripts.reviewer_bot_lib.event_inputs import derive_lifecycle_event_timestamp
+from scripts.reviewer_bot_lib.event_inputs import (
+    build_comment_event_request,
+    derive_lifecycle_event_timestamp,
+)
+
+
+class _ConfigBot:
+    def __init__(self, values):
+        self.values = values
+
+    def get_config_value(self, name, default=""):
+        return self.values.get(name, default)
 
 
 def test_lifecycle_opened_uses_created_at_authority():
@@ -15,6 +26,20 @@ def test_lifecycle_opened_uses_created_at_authority():
     assert evidence.is_authoritative is True
 
 
+def test_lifecycle_timestamp_normalizes_timezone_less_values_to_utc():
+    evidence = derive_lifecycle_event_timestamp(
+        event_name="issues",
+        event_action="opened",
+        source_created_at="2026-04-01T00:00:00",
+        source_updated_at=None,
+        source_closed_at=None,
+    )
+
+    assert evidence.selected_timestamp == "2026-04-01T00:00:00+00:00"
+    assert evidence.selection_kind == "created_at"
+    assert evidence.is_authoritative is True
+
+
 def test_lifecycle_unknown_action_does_not_use_updated_at_blanket_fallback():
     evidence = derive_lifecycle_event_timestamp(
         event_name="issues",
@@ -26,3 +51,29 @@ def test_lifecycle_unknown_action_does_not_use_updated_at_blanket_fallback():
 
     assert evidence.is_authoritative is False
     assert evidence.selected_timestamp is None
+
+
+def test_comment_event_request_normalizes_timezone_less_created_at_to_utc():
+    request = build_comment_event_request(
+        _ConfigBot(
+            {
+                "ISSUE_NUMBER": "42",
+                "IS_PULL_REQUEST": "true",
+                "ISSUE_STATE": "open",
+                "ISSUE_AUTHOR": "dana",
+                "ISSUE_LABELS": "[]",
+                "COMMENT_ID": "210",
+                "COMMENT_AUTHOR": "alice",
+                "COMMENT_AUTHOR_ID": "7001",
+                "COMMENT_BODY": "LGTM",
+                "COMMENT_CREATED_AT": "2026-04-01T00:00:00",
+                "COMMENT_SOURCE_EVENT_KEY": "issue_comment:210",
+                "COMMENT_USER_TYPE": "User",
+                "COMMENT_AUTHOR_ASSOCIATION": "MEMBER",
+                "COMMENT_SENDER_TYPE": "User",
+                "COMMENT_PERFORMED_VIA_GITHUB_APP": "false",
+            }
+        )
+    )
+
+    assert request.comment_created_at == "2026-04-01T00:00:00+00:00"

--- a/tests/unit/reviewer_bot/test_event_inputs.py
+++ b/tests/unit/reviewer_bot/test_event_inputs.py
@@ -21,7 +21,7 @@ def test_lifecycle_opened_uses_created_at_authority():
         source_closed_at=None,
     )
 
-    assert evidence.selected_timestamp == "2026-04-01T00:00:00Z"
+    assert evidence.selected_timestamp == "2026-04-01T00:00:00+00:00"
     assert evidence.selection_kind == "created_at"
     assert evidence.is_authoritative is True
 
@@ -31,6 +31,20 @@ def test_lifecycle_timestamp_normalizes_timezone_less_values_to_utc():
         event_name="issues",
         event_action="opened",
         source_created_at="2026-04-01T00:00:00",
+        source_updated_at=None,
+        source_closed_at=None,
+    )
+
+    assert evidence.selected_timestamp == "2026-04-01T00:00:00+00:00"
+    assert evidence.selection_kind == "created_at"
+    assert evidence.is_authoritative is True
+
+
+def test_lifecycle_timestamp_normalizes_offset_values_to_canonical_utc():
+    evidence = derive_lifecycle_event_timestamp(
+        event_name="issues",
+        event_action="opened",
+        source_created_at="2026-04-01T02:30:00+02:30",
         source_updated_at=None,
         source_closed_at=None,
     )
@@ -67,6 +81,32 @@ def test_comment_event_request_normalizes_timezone_less_created_at_to_utc():
                 "COMMENT_AUTHOR_ID": "7001",
                 "COMMENT_BODY": "LGTM",
                 "COMMENT_CREATED_AT": "2026-04-01T00:00:00",
+                "COMMENT_SOURCE_EVENT_KEY": "issue_comment:210",
+                "COMMENT_USER_TYPE": "User",
+                "COMMENT_AUTHOR_ASSOCIATION": "MEMBER",
+                "COMMENT_SENDER_TYPE": "User",
+                "COMMENT_PERFORMED_VIA_GITHUB_APP": "false",
+            }
+        )
+    )
+
+    assert request.comment_created_at == "2026-04-01T00:00:00+00:00"
+
+
+def test_comment_event_request_normalizes_offset_created_at_to_canonical_utc():
+    request = build_comment_event_request(
+        _ConfigBot(
+            {
+                "ISSUE_NUMBER": "42",
+                "IS_PULL_REQUEST": "true",
+                "ISSUE_STATE": "open",
+                "ISSUE_AUTHOR": "dana",
+                "ISSUE_LABELS": "[]",
+                "COMMENT_ID": "210",
+                "COMMENT_AUTHOR": "alice",
+                "COMMENT_AUTHOR_ID": "7001",
+                "COMMENT_BODY": "LGTM",
+                "COMMENT_CREATED_AT": "2026-04-01T02:30:00+02:30",
                 "COMMENT_SOURCE_EVENT_KEY": "issue_comment:210",
                 "COMMENT_USER_TYPE": "User",
                 "COMMENT_AUTHOR_ASSOCIATION": "MEMBER",

--- a/tests/unit/reviewer_bot/test_lifecycle.py
+++ b/tests/unit/reviewer_bot/test_lifecycle.py
@@ -479,7 +479,7 @@ def test_handle_issue_or_pr_opened_adopts_existing_single_live_assignee(monkeypa
     review = review_state.ensure_review_entry(state, 42)
     assert review is not None
     assert review["current_reviewer"] == "alice"
-    assert review["assigned_at"] == "2026-03-17T10:00:00Z"
+    assert review["assigned_at"] == "2026-03-17T10:00:00+00:00"
 
 
 def test_handle_assigned_event_clears_reviewer_authority_on_multiple_live_assignees(monkeypatch):

--- a/tests/unit/reviewer_bot/test_live_review_support.py
+++ b/tests/unit/reviewer_bot/test_live_review_support.py
@@ -46,3 +46,25 @@ def test_classify_stale_head_review_rejects_current_scope():
 
     assert result.classified_scope == "stale_head"
     assert result.is_current_head is False
+
+
+def test_classify_review_freshness_normalizes_timezone_less_submitted_at():
+    snapshot = build_review_snapshot_record(
+        {
+            "id": 3,
+            "state": "APPROVED",
+            "submitted_at": "2026-04-02T00:00:00",
+            "commit_id": "head-a",
+            "user": {"login": "iglesias"},
+        }
+    )
+
+    result = classify_review_freshness(
+        snapshot,
+        current_head_sha="head-a",
+        cycle_boundary="2026-04-01T00:00:00Z",
+        assigned_reviewer="iglesias",
+    )
+
+    assert result.classified_scope == "current_head_assigned_reviewer"
+    assert result.is_after_cycle_boundary is True

--- a/tests/unit/reviewer_bot/test_overdue.py
+++ b/tests/unit/reviewer_bot/test_overdue.py
@@ -53,7 +53,7 @@ def test_check_overdue_reviews_skips_pr_with_current_head_reviewer_review(monkey
 def test_check_overdue_reviews_consumes_only_stable_reviewer_response_fields(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     now = runtime.datetime.now(runtime.timezone.utc)
-    anchor_timestamp = iso_z(now - timedelta(days=runtime.REVIEW_DEADLINE_DAYS + 1))
+    anchor_timestamp = (now - timedelta(days=runtime.REVIEW_DEADLINE_DAYS + 1)).replace(tzinfo=None).isoformat()
     state = make_state()
     make_tracked_review_state(state, 42, reviewer="alice", assigned_at=anchor_timestamp, active_cycle_started_at=anchor_timestamp)
     runtime.github.get_issue_or_pr_snapshot_result = lambda issue_number: runtime.GitHubApiResult(

--- a/tests/unit/reviewer_bot/test_overdue.py
+++ b/tests/unit/reviewer_bot/test_overdue.py
@@ -1,9 +1,10 @@
 from datetime import timedelta
+from types import SimpleNamespace
 
 import pytest
 
 from scripts.reviewer_bot_core import approval_policy
-from scripts.reviewer_bot_lib import maintenance, review_state
+from scripts.reviewer_bot_lib import maintenance, overdue, review_state
 from scripts.reviewer_bot_lib.repair_records import load_repair_marker
 from tests.fixtures.fake_runtime import FakeReviewerBotRuntime
 from tests.fixtures.reviewer_bot import (
@@ -37,6 +38,42 @@ def _approval_incomplete_result(*_args, **_kwargs):
         "write_approval": {"has_write_approval": False},
         "current_head_sha": "head-1",
     }
+
+
+def test_reminder_cadence_normalizes_timezone_less_anchor_to_utc():
+    decision = overdue.derive_reminder_cadence_decision(
+        SimpleNamespace(
+            scope=SimpleNamespace(issue_number=42, reviewer="alice"),
+            response_state="awaiting_reviewer_response",
+            anchor_timestamp="2026-03-01T00:00:00",
+        ),
+        receipt=None,
+        reminder_scan=None,
+        now="2026-03-08T00:00:00+00:00",
+        review_deadline_days=7,
+        transition_period_days=14,
+    )
+
+    assert decision.cadence_state == "warning_due"
+    assert decision.may_post_warning is True
+
+
+def test_reminder_cadence_normalizes_offset_anchor_to_canonical_utc():
+    decision = overdue.derive_reminder_cadence_decision(
+        SimpleNamespace(
+            scope=SimpleNamespace(issue_number=42, reviewer="alice"),
+            response_state="awaiting_reviewer_response",
+            anchor_timestamp="2026-03-01T02:30:00+02:30",
+        ),
+        receipt=None,
+        reminder_scan=None,
+        now="2026-03-08T00:00:00+00:00",
+        review_deadline_days=7,
+        transition_period_days=14,
+    )
+
+    assert decision.cadence_state == "warning_due"
+    assert decision.may_post_warning is True
 
 
 def test_check_overdue_reviews_skips_pr_with_current_head_reviewer_review(monkeypatch):

--- a/tests/unit/reviewer_bot/test_reconcile_payloads.py
+++ b/tests/unit/reviewer_bot/test_reconcile_payloads.py
@@ -69,7 +69,7 @@ def test_deferred_review_dismissed_payload_keeps_canonical_dismissed_at():
         "source_event_key": "pull_request_review_dismissed:20",
         "pr_number": 264,
         "review_id": 20,
-        "source_dismissed_at": "2026-04-01T00:10:00Z",
+        "source_dismissed_at": "2026-04-01T02:40:00+02:30",
     }
     contract = deferred_workflow_source_contract_for_payload_kind("deferred_review_dismissed")
 
@@ -82,6 +82,6 @@ def test_deferred_review_dismissed_payload_keeps_canonical_dismissed_at():
     )
 
     assert isinstance(parsed, DeferredReviewDismissedPayload)
-    assert parsed.source_dismissed_at == "2026-04-01T00:10:00Z"
-    assert parsed.raw_payload["source_dismissed_at"] == "2026-04-01T00:10:00Z"
+    assert parsed.source_dismissed_at == "2026-04-01T00:10:00+00:00"
+    assert parsed.raw_payload["source_dismissed_at"] == "2026-04-01T02:40:00+02:30"
     assert authority.authority_status == "trusted_exact_identity"

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -355,7 +355,7 @@ def test_parse_deferred_context_payload_accepts_legacy_comment_payload():
 
     assert isinstance(parsed, reconcile.DeferredCommentPayload)
     assert parsed.identity.payload_kind == reconcile_payloads.DeferredPayloadKind.DEFERRED_COMMENT
-    assert parsed.comment_created_at == "2026-03-17T10:00:00Z"
+    assert parsed.comment_created_at == "2026-03-17T10:00:00+00:00"
     assert parsed.comment_author == "alice"
     assert parsed.comment_author_id == 7001
     assert parsed.source_body_digest == "digest"
@@ -416,7 +416,7 @@ def test_recover_deferred_payload_identity_builds_sanitized_payload_without_muta
     assert recovered.source_event_key == "issue_comment:210"
     assert recovered.source_object_id == 210
     assert recovered.diagnostic_payload["source_comment_id"] == 210
-    assert recovered.diagnostic_payload["source_event_created_at"] == "2026-03-17T10:00:00Z"
+    assert recovered.diagnostic_payload["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
 
 
 def test_recover_deferred_payload_identity_normalizes_timezone_less_timestamp():
@@ -428,6 +428,26 @@ def test_recover_deferred_payload_identity_normalizes_timezone_less_timestamp():
         comment_class="command_only",
         has_non_command_text=False,
         source_created_at="2026-03-17T10:00:00",
+        actor_login="bob",
+        source_run_id=610,
+        source_run_attempt=1,
+    )
+
+    recovered = reconcile_payloads.recover_deferred_payload_identity(payload)
+
+    assert recovered.source_event_created_at == "2026-03-17T10:00:00+00:00"
+    assert recovered.diagnostic_payload["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
+
+
+def test_recover_deferred_payload_identity_normalizes_offset_timestamp_to_canonical_utc():
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=210,
+        source_event_key="issue_comment:210",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="2026-03-17T12:30:00+02:30",
         actor_login="bob",
         source_run_id=610,
         source_run_attempt=1,

--- a/tests/unit/reviewer_bot/test_reconcile_unit.py
+++ b/tests/unit/reviewer_bot/test_reconcile_unit.py
@@ -419,6 +419,26 @@ def test_recover_deferred_payload_identity_builds_sanitized_payload_without_muta
     assert recovered.diagnostic_payload["source_event_created_at"] == "2026-03-17T10:00:00Z"
 
 
+def test_recover_deferred_payload_identity_normalizes_timezone_less_timestamp():
+    payload = issue_comment_payload(
+        pr_number=42,
+        comment_id=210,
+        source_event_key="issue_comment:210",
+        body="@guidelines-bot /queue",
+        comment_class="command_only",
+        has_non_command_text=False,
+        source_created_at="2026-03-17T10:00:00",
+        actor_login="bob",
+        source_run_id=610,
+        source_run_attempt=1,
+    )
+
+    recovered = reconcile_payloads.recover_deferred_payload_identity(payload)
+
+    assert recovered.source_event_created_at == "2026-03-17T10:00:00+00:00"
+    assert recovered.diagnostic_payload["source_event_created_at"] == "2026-03-17T10:00:00+00:00"
+
+
 def test_recover_deferred_payload_identity_rejects_invalid_timestamp():
     payload = issue_comment_payload(
         pr_number=42,

--- a/tests/unit/reviewer_bot/test_review_read_support.py
+++ b/tests/unit/reviewer_bot/test_review_read_support.py
@@ -1,4 +1,6 @@
 
+from datetime import timezone
+
 from scripts.reviewer_bot_core import live_review_support
 from tests.fixtures.fake_runtime import FakeReviewerBotRuntime
 from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi, github_result
@@ -123,3 +125,11 @@ def test_parse_github_timestamp_rejects_invalid_values():
     assert live_review_support.parse_github_timestamp(None) is None
     assert live_review_support.parse_github_timestamp("") is None
     assert live_review_support.parse_github_timestamp("not-a-timestamp") is None
+
+
+def test_parse_github_timestamp_normalizes_timezone_less_values_to_utc():
+    parsed = live_review_support.parse_github_timestamp("2026-04-02T00:00:00")
+
+    assert parsed is not None
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.isoformat() == "2026-04-02T00:00:00+00:00"

--- a/tests/unit/reviewer_bot/test_review_read_support.py
+++ b/tests/unit/reviewer_bot/test_review_read_support.py
@@ -2,6 +2,7 @@
 from datetime import timezone
 
 from scripts.reviewer_bot_core import live_review_support
+from scripts.reviewer_bot_lib import reconcile_reads
 from tests.fixtures.fake_runtime import FakeReviewerBotRuntime
 from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi, github_result
 
@@ -133,3 +134,40 @@ def test_parse_github_timestamp_normalizes_timezone_less_values_to_utc():
     assert parsed is not None
     assert parsed.tzinfo == timezone.utc
     assert parsed.isoformat() == "2026-04-02T00:00:00+00:00"
+
+
+def test_review_dismissal_resolution_normalizes_timezone_less_payload_time(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+
+    resolution = reconcile_reads.resolve_review_dismissal_time(
+        runtime,
+        42,
+        12,
+        {"source_dismissed_at": "2026-03-17T10:10:00"},
+    )
+
+    assert resolution.timestamp == "2026-03-17T10:10:00+00:00"
+    assert resolution.source == "payload"
+
+
+def test_review_dismissal_resolution_normalizes_timeline_time_to_canonical_utc(monkeypatch):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.github.stub(
+        RouteGitHubApi().add_request(
+            "GET",
+            "issues/42/timeline?per_page=100&page=1",
+            status_code=200,
+            payload=[
+                {
+                    "event": "review_dismissed",
+                    "created_at": "2026-03-17T12:40:00+02:30",
+                    "dismissed_review": {"review_id": 12},
+                }
+            ],
+        )
+    )
+
+    resolution = reconcile_reads.resolve_review_dismissal_time(runtime, 42, 12, {})
+
+    assert resolution.timestamp == "2026-03-17T10:10:00+00:00"
+    assert resolution.source == "timeline"


### PR DESCRIPTION
## Summary
- Normalize timezone-less reviewer-bot timestamps as UTC-aware values across live-review, lifecycle-input, deferred-gap, sweeper, and reconcile paths.
- Add regressions for mixed naive/aware freshness classification and timestamp input normalization.

## Tests
- uv run pytest tests/unit/reviewer_bot/test_review_read_support.py tests/unit/reviewer_bot/test_live_review_support.py tests/unit/reviewer_bot/test_event_inputs.py tests/unit/reviewer_bot/test_reconcile_unit.py
- uv run pytest tests/unit/reviewer_bot
- uv run pytest tests/integration/reviewer_bot/test_reconcile_workflow_run.py tests/integration/reviewer_bot/test_pr264_incident_replay_card.py tests/integration/reviewer_bot/test_pr264_lgtm_replay.py
- uv run ruff check