### PR TITLE
fix: add pr264 projection repair contract

### DIFF
--- a/.github/workflows/reviewer-bot-preview.yml
+++ b/.github/workflows/reviewer-bot-preview.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: preview-check-overdue
         type: choice
-        options: [preview-check-overdue, preview-reviewer-board]
+        options: [preview-check-overdue, preview-status-label-projection, preview-issue314-state-health, preview-reviewer-board]
       issue_number:
         description: PR or issue number to preview
         required: true
@@ -56,6 +56,11 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
+          EVALUATED_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+          EVALUATED_REF: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}

--- a/.github/workflows/reviewer-bot-sweeper-repair.yml
+++ b/.github/workflows/reviewer-bot-sweeper-repair.yml
@@ -1,5 +1,7 @@
 name: Reviewer Bot Sweeper Repair
 
+run-name: repair ${{ github.event.inputs.action }} issue ${{ github.event.inputs.issue_number }} nonce ${{ github.event.inputs.validation_nonce }}
+
 on:
   schedule:
     - cron: '0 * * * *'
@@ -10,9 +12,13 @@ on:
         required: true
         default: check-overdue
         type: choice
-        options: [sync-members, show-state, check-overdue, repair-review-status-labels]
+        options: [sync-members, show-state, check-overdue, repair-review-status-labels, repair-issue314-state-health]
       issue_number:
         description: Optional issue or PR number for targeted actions
+        required: false
+        type: string
+      validation_nonce:
+        description: Validation nonce used to correlate this repair run
         required: false
         type: string
 
@@ -49,14 +55,31 @@ jobs:
           EVENT_ACTION: ${{ github.event.action }}
           MANUAL_ACTION: ${{ github.event.inputs.action }}
           ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+          VALIDATION_NONCE: ${{ github.event.inputs.validation_nonce }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
+          EVALUATED_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+          EVALUATED_REF: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_JOB_NAME: ${{ github.job }}
-        run: uv run --project "$BOT_SRC_ROOT" reviewer-bot
+          REPAIR_SUMMARY_PATH: ${{ runner.temp }}/reviewer-bot-repair-output-${{ github.run_id }}-attempt-${{ github.run_attempt }}/repair-summary.json
+          ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH: ${{ runner.temp }}/reviewer-bot-repair-output-${{ github.run_id }}-attempt-${{ github.run_attempt }}/issue314-state-health-repair-summary.json
+        run: |
+          mkdir -p "$RUNNER_TEMP/reviewer-bot-repair-output-${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"
+          uv run --project "$BOT_SRC_ROOT" reviewer-bot
+      - name: Upload repair artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: reviewer-bot-repair-output-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/reviewer-bot-repair-output-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          retention-days: 7
+          if-no-files-found: error
       - name: Workflow summary
         run: |
           {

--- a/.github/workflows/reviewer-bot-sweeper-repair.yml
+++ b/.github/workflows/reviewer-bot-sweeper-repair.yml
@@ -74,6 +74,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/reviewer-bot-repair-output-${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"
           uv run --project "$BOT_SRC_ROOT" reviewer-bot
       - name: Upload repair artifact
+        if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.action == 'repair-review-status-labels' || github.event.inputs.action == 'repair-issue314-state-health') }}
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: reviewer-bot-repair-output-${{ github.run_id }}-attempt-${{ github.run_attempt }}

--- a/.github/workflows/reviewer-bot-sweeper-repair.yml
+++ b/.github/workflows/reviewer-bot-sweeper-repair.yml
@@ -19,7 +19,7 @@ on:
         type: string
       validation_nonce:
         description: Validation nonce used to correlate this repair run
-        required: false
+        required: true
         type: string
 
 permissions:

--- a/scripts/reviewer_bot_core/approval_policy.py
+++ b/scripts/reviewer_bot_core/approval_policy.py
@@ -415,8 +415,6 @@ def compute_pr_approval_state_result(
         permission_evidence=permission_evidence,
         dismissal_evidence=None,
     )
-    if write_decision.response_state == "projection_failed":
-        return live_review_support.projection_failure_result(write_decision.diagnostic_reason or write_decision.write_approval_state)
     completion = {
         "completed": completion_decision.can_set_review_completed_at,
         "current_head_sha": current_head,
@@ -425,6 +423,20 @@ def compute_pr_approval_state_result(
         ),
         "authority_decision": completion_decision.to_output(),
     }
+    if write_decision.response_state == "projection_failed":
+        result = live_review_support.projection_failure_result(
+            write_decision.diagnostic_reason or write_decision.write_approval_state
+        )
+        result["completion"] = completion
+        result["write_approval"] = {
+            "has_write_approval": False,
+            "write_approvers": [],
+            "current_head_sha": current_head,
+            "response_state": write_decision.response_state,
+            "authority_decision": write_decision.to_output(),
+        }
+        result["current_head_sha"] = current_head
+        return result
     write_approval = {
         "has_write_approval": write_decision.response_state == "done",
         "write_approvers": [write_decision.approving_reviewer] if write_decision.response_state == "done" and write_decision.approving_reviewer else [],

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -475,6 +475,13 @@ def _decorate_response(
     }
 
 
+def _write_approval_authority_payload(write_approval: object) -> dict[str, object] | None:
+    if not isinstance(write_approval, dict):
+        return None
+    authority = write_approval.get("authority_decision")
+    return dict(authority) if isinstance(authority, dict) else None
+
+
 def _record_for_current_reviewer(record: dict | None | object, current_reviewer: str) -> dict | None:
     if not isinstance(record, dict):
         return None
@@ -877,14 +884,19 @@ def derive_reviewer_response_state(
         )
 
     if not isinstance(approval_result, dict) or not approval_result.get("ok"):
+        write_approval_authority = _write_approval_authority_payload(
+            approval_result.get("write_approval") if isinstance(approval_result, dict) else None
+        )
         return _decorate_response(
             state="projection_failed",
             reason="live_review_state_unknown",
             scope_fields=_current_scope_fields(review_data, current_reviewer, current_head, contributor_handoff),
+            write_approval_authority=write_approval_authority,
         )
 
     completion = approval_result["completion"]
     write_approval = approval_result["write_approval"]
+    write_approval_authority = _write_approval_authority_payload(write_approval)
     if not completion.get("completed"):
         return _decorate_response(
             state="awaiting_contributor_response",
@@ -911,6 +923,7 @@ def derive_reviewer_response_state(
             current_cycle_reviewer_handoff=reviewer_handoff,
             contributor_comment=contributor_comment,
             contributor_handoff=contributor_handoff,
+            write_approval_authority=write_approval_authority,
         )
     if authority_response_state == "projection_failed":
         authority = write_approval.get("authority_decision")
@@ -921,6 +934,7 @@ def derive_reviewer_response_state(
             state="projection_failed",
             reason=reason,
             scope_fields=_current_scope_fields(review_data, current_reviewer, current_head, contributor_handoff),
+            write_approval_authority=write_approval_authority,
         )
     if not write_approval.get("has_write_approval"):
         return _decorate_response(
@@ -934,6 +948,7 @@ def derive_reviewer_response_state(
             current_cycle_reviewer_handoff=reviewer_handoff,
             contributor_comment=contributor_comment,
             contributor_handoff=contributor_handoff,
+            write_approval_authority=write_approval_authority,
         )
     return _decorate_response(
         state="done",
@@ -946,6 +961,7 @@ def derive_reviewer_response_state(
         current_cycle_reviewer_handoff=reviewer_handoff,
         contributor_comment=contributor_comment,
         contributor_handoff=contributor_handoff,
+        write_approval_authority=write_approval_authority,
     )
 
 

--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -14,7 +14,7 @@ Old module no longer preferred for these reviewer-response decision changes:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 
 from . import live_review_support, reviewer_review_helpers
@@ -173,11 +173,16 @@ def apply_reminder_cadence_overlay(response: ReviewerResponseDecision, cadence) 
     if response.response_state != "awaiting_reviewer_response":
         return response
     reason = getattr(cadence, "exhaustion_reason", None) or "legacy_duplicate_reminders_exhausted"
+    scope = (
+        replace(response.scope, scope_basis="reminder_cadence_exhausted")
+        if response.scope is not None
+        else None
+    )
     return ReviewerResponseDecision(
         response_state="reviewer_reassignment_needed",
         reason=reason,
         suppression_reason=reason,
-        scope=response.scope,
+        scope=scope,
         current_head_sha=response.current_head_sha,
         anchor_timestamp=response.anchor_timestamp,
         reviewer_authority_outcome=response.reviewer_authority_outcome,

--- a/scripts/reviewer_bot_lib/app.py
+++ b/scripts/reviewer_bot_lib/app.py
@@ -6,7 +6,7 @@ import sys
 from dataclasses import dataclass
 
 from . import maintenance, reconcile
-from .context import EventContext, ExecutionResult
+from .context import EventContext, ExecutionResult, ManualDispatchRequest
 from .event_inputs import build_event_context as decode_event_context
 from .maintenance import (
     collect_status_projection_repair_items,
@@ -249,7 +249,13 @@ def _classify_event_intent_from_context(bot: AppEventContextRuntime, context: Ev
         return bot.EVENT_INTENT_NON_MUTATING_READONLY
 
     if event_name == "workflow_dispatch":
-        if context.manual_action in {"show-state", "preview-check-overdue", "preview-reviewer-board"}:
+        if context.manual_action in {
+            "show-state",
+            "preview-check-overdue",
+            "preview-status-label-projection",
+            "preview-issue314-state-health",
+            "preview-reviewer-board",
+        }:
             return bot.EVENT_INTENT_NON_MUTATING_READONLY
         return bot.EVENT_INTENT_MUTATING
 
@@ -316,6 +322,7 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
     workflow_run_result: reconcile.WorkflowRunHandlerResult | None = None
     schedule_result: maintenance.ScheduleHandlerResult | None = None
     loaded_state_hash: str | None = None
+    manual_projection_policy: maintenance.ManualDispatchProjectionPolicy | None = None
 
     try:
         if (
@@ -352,6 +359,13 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
                 if isinstance(issue_key, str) and issue_key.isdigit()
             }
         loaded_epoch = state.get("freshness_runtime_epoch") if isinstance(state.get("freshness_runtime_epoch"), str) else None
+        if event_name == "workflow_dispatch":
+            manual_projection_policy = maintenance.derive_manual_dispatch_projection_policy(
+                ManualDispatchRequest(
+                    action=context.manual_action or "",
+                    issue_number=context.issue_number,
+                )
+            )
 
         if lock_required:
             state, restored = bot.adapters.workflow.process_pass_until_expirations(state)
@@ -442,7 +456,17 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
             touched_items = schedule_result.touched_items
         else:
             touched_items = bot.drain_touched_items()
-        if lock_required and event_name in {"schedule", "workflow_dispatch"} and status_projection_repair_needed(bot, state):
+        allow_epoch_repair_expansion = (
+            manual_projection_policy.allow_epoch_repair_expansion
+            if manual_projection_policy is not None
+            else True
+        )
+        if (
+            lock_required
+            and event_name in {"schedule", "workflow_dispatch"}
+            and allow_epoch_repair_expansion
+            and status_projection_repair_needed(bot, state)
+        ):
             touched_items = sorted(
                 {
                     *touched_items,
@@ -542,7 +566,7 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
                 )
             _revalidate_epoch(bot, loaded_epoch, "status-label projection")
             try:
-                    status_labels_changed = bot.adapters.workflow.sync_status_labels_for_items(state, touched_items)
+                status_labels_changed = bot.adapters.workflow.sync_status_labels_for_items(state, touched_items)
             except RuntimeError as exc:
                 projection_failure = exc
                 _log(

--- a/scripts/reviewer_bot_lib/app.py
+++ b/scripts/reviewer_bot_lib/app.py
@@ -558,6 +558,8 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
             if touched_items:
                 state = bot.state_store.load_state(fail_on_unavailable=True)
 
+        maintenance.emit_pending_issue314_state_health_repair_summary(bot)
+
         if touched_items:
             if not lock_acquired:
                 raise RuntimeError(

--- a/scripts/reviewer_bot_lib/config.py
+++ b/scripts/reviewer_bot_lib/config.py
@@ -122,11 +122,13 @@ MANDATORY_TRIAGE_APPROVER_LABEL = "triage approver required"
 STATUS_AWAITING_REVIEWER_RESPONSE_LABEL = "status: awaiting reviewer response"
 STATUS_AWAITING_CONTRIBUTOR_RESPONSE_LABEL = "status: awaiting contributor response"
 STATUS_AWAITING_WRITE_APPROVAL_LABEL = "status: awaiting write approval"
+STATUS_REVIEWER_REASSIGNMENT_NEEDED_LABEL = "status: reviewer reassignment needed"
 STATUS_AWAITING_REVIEW_COMPLETION_LABEL = STATUS_AWAITING_REVIEWER_RESPONSE_LABEL
 STATUS_LABELS = {
     STATUS_AWAITING_REVIEWER_RESPONSE_LABEL,
     STATUS_AWAITING_CONTRIBUTOR_RESPONSE_LABEL,
     STATUS_AWAITING_WRITE_APPROVAL_LABEL,
+    STATUS_REVIEWER_REASSIGNMENT_NEEDED_LABEL,
 }
 STATUS_LABEL_CONFIG = {
     STATUS_AWAITING_REVIEWER_RESPONSE_LABEL: {
@@ -140,6 +142,10 @@ STATUS_LABEL_CONFIG = {
     STATUS_AWAITING_WRITE_APPROVAL_LABEL: {
         "color": "1d76db",
         "description": "Assigned review is complete but no visible write+ approval is present",
+    },
+    STATUS_REVIEWER_REASSIGNMENT_NEEDED_LABEL: {
+        "color": "d93f0b",
+        "description": "Reviewer-bot exhausted the active reviewer cycle and reassignment may be needed",
     },
     MANDATORY_TRIAGE_APPROVER_LABEL: {
         "color": "d73a4a",

--- a/scripts/reviewer_bot_lib/issue314_state_health.py
+++ b/scripts/reviewer_bot_lib/issue314_state_health.py
@@ -1,0 +1,582 @@
+"""Issue 314 state-health preview and repair contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.reviewer_bot_core.reviewer_response_policy import (
+    ReviewerResponseDecision,
+    to_reviewer_response_decision,
+)
+
+from . import overdue, reviews
+from .reminder_comments import ReminderCommentScan, scan_reviewer_reminder_comments
+from .reviews_projection import (
+    StatusLabelProjectionResult,
+    actual_status_labels_from_snapshot,
+)
+
+
+@dataclass(frozen=True)
+class Issue314StateHealthClassificationInput:
+    state_issue_number: int
+    validation_nonce: str
+    active_review_rows: tuple[dict[str, object], ...]
+    live_snapshots: dict[int, dict[str, object]]
+    reviewer_responses: dict[int, ReviewerResponseDecision]
+    status_projections: dict[int, StatusLabelProjectionResult]
+    reminder_scans: dict[int, ReminderCommentScan | None]
+    evaluated_repo: str
+    head_sha: str
+    evaluated_ref: str
+    workflow_path: str
+    run_id: str
+    run_attempt: str
+
+
+@dataclass(frozen=True)
+class Issue314StateHealthRepairRequest:
+    repair_action: str
+    state_issue_number: int
+    validation_nonce: str
+    evaluated_repo: str
+    head_sha: str
+    evaluated_ref: str
+    workflow_path: str
+    run_id: str
+    run_attempt: str
+
+
+@dataclass(frozen=True)
+class Issue314StateHealthRow:
+    issue_number: int
+    current_reviewer: str | None
+    active_head_sha: str | None
+    live_state: str | None
+    is_pull_request: bool
+    live_head_sha: str | None
+    live_status_labels: tuple[str, ...]
+    reviewer_response: dict[str, object]
+    status_projection: dict[str, object]
+    reminder_scan: dict[str, object] | None
+    health_classification: str
+    repair_outcome: str
+    classification_reason: str
+    status_label_risk: str
+    automated_reminder_risk: bool | None
+    blockers: tuple[str, ...]
+
+    def to_output(self) -> dict[str, object]:
+        return {
+            "issue_number": self.issue_number,
+            "current_reviewer": self.current_reviewer,
+            "active_head_sha": self.active_head_sha,
+            "live_state": self.live_state,
+            "is_pull_request": self.is_pull_request,
+            "live_head_sha": self.live_head_sha,
+            "live_status_labels": sorted(self.live_status_labels),
+            "reviewer_response": dict(self.reviewer_response),
+            "status_projection": dict(self.status_projection),
+            "reminder_scan": self.reminder_scan,
+            "health_classification": self.health_classification,
+            "repair_outcome": self.repair_outcome,
+            "classification_reason": self.classification_reason,
+            "status_label_risk": self.status_label_risk,
+            "automated_reminder_risk": self.automated_reminder_risk,
+            "blockers": sorted(self.blockers),
+        }
+
+
+@dataclass(frozen=True)
+class Issue314StateHealthSummary:
+    schema_version: int
+    preview_action: str
+    state_issue_number: int
+    issue_number: int
+    validation_nonce: str
+    active_review_row_count: int
+    active_rows_inspected: tuple[int, ...]
+    row_inventory: tuple[Issue314StateHealthRow, ...]
+    row_health_summary: dict[str, int]
+    status_projection_summary: dict[str, object]
+    rows_repairable: tuple[int, ...]
+    rows_operator_action_required: tuple[int, ...]
+    rows_blocked: tuple[int, ...]
+    pr264_no_ping_status: str
+    lock_attempted: bool
+    state_save_attempted: bool
+    tracked_state_mutations_attempted: bool
+    touched_projection_attempted: bool
+    evaluated_repo: str
+    head_sha: str
+    evaluated_ref: str
+    workflow_path: str
+    run_id: str
+    run_attempt: str
+    artifact_name: str
+    artifact_file: str
+    output_keys: tuple[str, ...]
+
+    def to_output(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "preview_action": self.preview_action,
+            "state_issue_number": self.state_issue_number,
+            "issue_number": self.issue_number,
+            "validation_nonce": self.validation_nonce,
+            "active_review_row_count": self.active_review_row_count,
+            "active_rows_inspected": sorted(self.active_rows_inspected),
+            "row_inventory": [
+                row.to_output()
+                for row in sorted(self.row_inventory, key=lambda item: item.issue_number)
+            ],
+            "row_health_summary": dict(self.row_health_summary),
+            "status_projection_summary": dict(self.status_projection_summary),
+            "rows_repairable": sorted(self.rows_repairable),
+            "rows_operator_action_required": sorted(self.rows_operator_action_required),
+            "rows_blocked": sorted(self.rows_blocked),
+            "pr264_no_ping_status": self.pr264_no_ping_status,
+            "lock_attempted": self.lock_attempted,
+            "state_save_attempted": self.state_save_attempted,
+            "tracked_state_mutations_attempted": self.tracked_state_mutations_attempted,
+            "touched_projection_attempted": self.touched_projection_attempted,
+            "evaluated_repo": self.evaluated_repo,
+            "head_sha": self.head_sha,
+            "evaluated_ref": self.evaluated_ref,
+            "workflow_path": self.workflow_path,
+            "run_id": self.run_id,
+            "run_attempt": self.run_attempt,
+            "artifact_name": self.artifact_name,
+            "artifact_file": self.artifact_file,
+            "output_keys": [],
+        }
+        payload["output_keys"] = sorted(payload.keys())
+        return payload
+
+
+@dataclass(frozen=True)
+class Issue314StateHealthRepairSummary:
+    schema_version: int
+    repair_action: str
+    state_issue_number: int
+    issue_number: int
+    validation_nonce: str
+    target_collection_mode: str
+    active_rows_inspected: tuple[int, ...]
+    rows_repaired: tuple[int, ...]
+    rows_removed_closed: tuple[int, ...]
+    rows_operator_action_required: tuple[int, ...]
+    rows_blocked: tuple[int, ...]
+    status_labels_changed: tuple[int, ...]
+    reviewer_facing_reminder_posts_attempted: int
+    manual_issue314_edit_status: str
+    state_store_mutation_mode: str
+    evaluated_repo: str
+    head_sha: str
+    evaluated_ref: str
+    workflow_path: str
+    run_id: str
+    run_attempt: str
+    artifact_name: str
+    artifact_file: str
+    output_keys: tuple[str, ...]
+    result: str
+
+    def to_output(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "repair_action": self.repair_action,
+            "state_issue_number": self.state_issue_number,
+            "issue_number": self.issue_number,
+            "validation_nonce": self.validation_nonce,
+            "target_collection_mode": self.target_collection_mode,
+            "active_rows_inspected": sorted(self.active_rows_inspected),
+            "rows_repaired": sorted(self.rows_repaired),
+            "rows_removed_closed": sorted(self.rows_removed_closed),
+            "rows_operator_action_required": sorted(self.rows_operator_action_required),
+            "rows_blocked": sorted(self.rows_blocked),
+            "status_labels_changed": sorted(self.status_labels_changed),
+            "reviewer_facing_reminder_posts_attempted": self.reviewer_facing_reminder_posts_attempted,
+            "manual_issue314_edit_status": self.manual_issue314_edit_status,
+            "state_store_mutation_mode": self.state_store_mutation_mode,
+            "evaluated_repo": self.evaluated_repo,
+            "head_sha": self.head_sha,
+            "evaluated_ref": self.evaluated_ref,
+            "workflow_path": self.workflow_path,
+            "run_id": self.run_id,
+            "run_attempt": self.run_attempt,
+            "artifact_name": self.artifact_name,
+            "artifact_file": self.artifact_file,
+            "output_keys": [],
+            "result": self.result,
+        }
+        payload["output_keys"] = sorted(payload.keys())
+        return payload
+
+
+def _config(bot, name: str, default: str = "") -> str:
+    return bot.get_config_value(name, default).strip()
+
+
+def _default_request(bot) -> Issue314StateHealthRepairRequest:
+    run_id = _config(bot, "GITHUB_RUN_ID") or _config(bot, "WORKFLOW_RUN_ID")
+    run_attempt = _config(bot, "GITHUB_RUN_ATTEMPT") or "1"
+    head_sha = _config(bot, "HEAD_SHA") or _config(bot, "GITHUB_SHA")
+    return Issue314StateHealthRepairRequest(
+        repair_action=_config(bot, "MANUAL_ACTION") or "preview-issue314-state-health",
+        state_issue_number=bot.state_issue_number(),
+        validation_nonce=_config(bot, "VALIDATION_NONCE"),
+        evaluated_repo=_config(bot, "EVALUATED_REPO") or _config(bot, "GITHUB_REPOSITORY"),
+        head_sha=head_sha,
+        evaluated_ref=_config(bot, "EVALUATED_REF") or head_sha,
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id=run_id,
+        run_attempt=run_attempt,
+    )
+
+
+def _artifact_name(prefix: str, request: Issue314StateHealthRepairRequest) -> str:
+    return f"{prefix}-{request.run_id}-attempt-{request.run_attempt}"
+
+
+def _active_rows(state: dict) -> tuple[dict[str, object], ...]:
+    active_reviews = state.get("active_reviews") if isinstance(state, dict) else None
+    if not isinstance(active_reviews, dict):
+        return ()
+    rows: list[dict[str, object]] = []
+    for issue_key, review_data in active_reviews.items():
+        if not isinstance(review_data, dict):
+            continue
+        try:
+            issue_number = int(issue_key)
+        except (TypeError, ValueError):
+            continue
+        if issue_number > 0:
+            rows.append({"issue_number": issue_number, "review_data": review_data})
+    return tuple(sorted(rows, key=lambda row: int(row["issue_number"])))
+
+
+def _comment_scan(bot, issue_number: int) -> ReminderCommentScan | None:
+    try:
+        response = bot.github.list_issue_comments_result(issue_number, page=1)
+    except (AssertionError, AttributeError, RuntimeError):
+        return None
+    if not response.ok or not isinstance(response.payload, list):
+        return None
+    return scan_reviewer_reminder_comments(response.payload)
+
+
+def _closed_decision(issue_number: int) -> ReviewerResponseDecision:
+    return to_reviewer_response_decision({"issue_number": issue_number, "response_state": "closed"})
+
+
+def _untracked_decision(issue_number: int) -> ReviewerResponseDecision:
+    return to_reviewer_response_decision(
+        {"issue_number": issue_number, "response_state": "untracked", "reason": "no_review_entry"}
+    )
+
+
+def collect_issue314_state_health_input(
+    bot,
+    state: dict,
+    request: Issue314StateHealthRepairRequest | None = None,
+) -> Issue314StateHealthClassificationInput:
+    request = request or _default_request(bot)
+    rows = _active_rows(state)
+    snapshots: dict[int, dict[str, object]] = {}
+    reviewer_responses: dict[int, ReviewerResponseDecision] = {}
+    projections: dict[int, StatusLabelProjectionResult] = {}
+    scans: dict[int, ReminderCommentScan | None] = {}
+    for row in rows:
+        issue_number = int(row["issue_number"])
+        review_data = row["review_data"]
+        snapshot_result = bot.github.get_issue_or_pr_snapshot_result(issue_number)
+        snapshot = snapshot_result.payload if snapshot_result.ok and isinstance(snapshot_result.payload, dict) else None
+        if snapshot is not None:
+            snapshots[issue_number] = snapshot
+        scans[issue_number] = _comment_scan(bot, issue_number)
+        if not isinstance(review_data, dict):
+            continue
+        if snapshot is None:
+            continue
+        try:
+            projection = reviews.project_status_label_projection_for_item(
+                bot,
+                issue_number,
+                state,
+                issue_snapshot=snapshot,
+            )
+        except RuntimeError:
+            if isinstance(snapshot, dict) and str(snapshot.get("state", "")).lower() == "closed":
+                reviewer_responses[issue_number] = _closed_decision(issue_number)
+            elif review_data is None:
+                reviewer_responses[issue_number] = _untracked_decision(issue_number)
+            continue
+        projections[issue_number] = projection
+        decision_output = projection.projection_metadata.get("decision_output")
+        if isinstance(decision_output, dict):
+            reviewer_responses[issue_number] = to_reviewer_response_decision(decision_output)
+        else:
+            response_state = reviews.compute_reviewer_response_state(
+                bot,
+                issue_number,
+                review_data,
+                issue_snapshot=snapshot,
+            )
+            decision, _cadence, _scan = overdue._effective_response_with_cadence(
+                bot,
+                issue_number,
+                review_data,
+                dict(response_state),
+            )
+            reviewer_responses[issue_number] = decision
+    return Issue314StateHealthClassificationInput(
+        state_issue_number=request.state_issue_number,
+        validation_nonce=request.validation_nonce,
+        active_review_rows=rows,
+        live_snapshots=snapshots,
+        reviewer_responses=reviewer_responses,
+        status_projections=projections,
+        reminder_scans=scans,
+        evaluated_repo=request.evaluated_repo,
+        head_sha=request.head_sha,
+        evaluated_ref=request.evaluated_ref,
+        workflow_path=request.workflow_path,
+        run_id=request.run_id,
+        run_attempt=request.run_attempt,
+    )
+
+
+def _live_head_sha(snapshot: dict[str, object], projection: StatusLabelProjectionResult | None) -> str | None:
+    pull_request = snapshot.get("pull_request")
+    if isinstance(pull_request, dict):
+        head = pull_request.get("head")
+        if isinstance(head, dict) and isinstance(head.get("sha"), str):
+            return head["sha"]
+    if projection is not None:
+        decision = projection.projection_metadata.get("decision_output")
+        if isinstance(decision, dict) and isinstance(decision.get("current_head_sha"), str):
+            return decision["current_head_sha"]
+    return None
+
+
+def _row_from_input(input: Issue314StateHealthClassificationInput, row: dict[str, object]) -> Issue314StateHealthRow:
+    issue_number = int(row["issue_number"])
+    review_data = row.get("review_data") if isinstance(row.get("review_data"), dict) else {}
+    snapshot = input.live_snapshots.get(issue_number)
+    projection = input.status_projections.get(issue_number)
+    decision = input.reviewer_responses.get(issue_number)
+    scan = input.reminder_scans.get(issue_number)
+    blockers: list[str] = []
+    if snapshot is None:
+        blockers.append("live_snapshot_unavailable")
+    if decision is None:
+        blockers.append("reviewer_response_unavailable")
+    if projection is None and (snapshot is None or str(snapshot.get("state", "")).lower() != "closed"):
+        blockers.append("status_projection_unavailable")
+    if scan is None:
+        blockers.append("reminder_scan_unavailable")
+
+    if blockers:
+        health = "blocked"
+        repair = "blocked"
+        status_risk = "blocked_unknown"
+        automated_risk = None
+        reason = ",".join(sorted(blockers))
+    else:
+        assert snapshot is not None
+        live_state = str(snapshot.get("state", "")).lower()
+        if live_state == "closed":
+            health = "closed_item_pending_removal"
+            repair = "not_attempted"
+            status_risk = "no_label_required"
+            automated_risk = False
+            reason = "closed_live_item_has_active_issue314_row"
+        else:
+            assert projection is not None
+            delta = projection.delta
+            has_drift = bool(delta.labels_to_add or delta.labels_to_remove)
+            automated_risk = projection.response_state == "awaiting_reviewer_response"
+            if automated_risk:
+                health = "blocked"
+                repair = "blocked"
+                status_risk = "blocked_unknown"
+                reason = "row_can_still_trigger_reviewer_reminder"
+                blockers.append(reason)
+            elif has_drift and issue_number == 264:
+                health = "operator_action_required"
+                repair = "not_attempted"
+                status_risk = "operator_visible_stale"
+                reason = "pr264_status_label_repair_deferred_to_issue_scoped_live_repair"
+            elif has_drift:
+                health = "repairable"
+                repair = "not_attempted"
+                status_risk = "repairable_drift"
+                reason = "status_label_projection_drift"
+            else:
+                health = "healthy"
+                repair = "not_attempted"
+                status_risk = "aligned" if delta.desired_status_labels else "no_label_required"
+                reason = "status_projection_aligned"
+
+    live_status_labels = actual_status_labels_from_snapshot(snapshot or {})
+    return Issue314StateHealthRow(
+        issue_number=issue_number,
+        current_reviewer=review_data.get("current_reviewer") if isinstance(review_data.get("current_reviewer"), str) else None,
+        active_head_sha=review_data.get("active_head_sha") if isinstance(review_data.get("active_head_sha"), str) else None,
+        live_state=str(snapshot.get("state")) if snapshot is not None and snapshot.get("state") is not None else None,
+        is_pull_request=bool(snapshot is not None and isinstance(snapshot.get("pull_request"), dict)),
+        live_head_sha=_live_head_sha(snapshot or {}, projection),
+        live_status_labels=live_status_labels,
+        reviewer_response=decision.to_output() if decision is not None else {},
+        status_projection=projection.to_output() if projection is not None else {},
+        reminder_scan=scan.to_output() if scan is not None else None,
+        health_classification=health,
+        repair_outcome=repair,
+        classification_reason=reason,
+        status_label_risk=status_risk,
+        automated_reminder_risk=automated_risk,
+        blockers=tuple(blockers),
+    )
+
+
+def classify_issue314_state_health(input: Issue314StateHealthClassificationInput) -> Issue314StateHealthSummary:
+    inventory = tuple(_row_from_input(input, row) for row in input.active_review_rows)
+    counts: dict[str, int] = {}
+    for row in inventory:
+        counts[row.health_classification] = counts.get(row.health_classification, 0) + 1
+    rows_repairable = tuple(row.issue_number for row in inventory if row.health_classification == "repairable")
+    rows_operator = tuple(row.issue_number for row in inventory if row.health_classification == "operator_action_required")
+    rows_blocked = tuple(row.issue_number for row in inventory if row.health_classification == "blocked")
+    status_projection_summary = {
+        str(row.issue_number): {
+            "response_state": row.status_projection.get("response_state"),
+            "actual_status_labels": row.status_projection.get("delta", {}).get("actual_status_labels", [])
+            if isinstance(row.status_projection.get("delta"), dict)
+            else [],
+            "desired_status_labels": row.status_projection.get("delta", {}).get("desired_status_labels", [])
+            if isinstance(row.status_projection.get("delta"), dict)
+            else [],
+            "status_label_risk": row.status_label_risk,
+        }
+        for row in inventory
+    }
+    pr264 = next((row for row in inventory if row.issue_number == 264), None)
+    pr264_no_ping_status = "pass"
+    if pr264 is not None and pr264.automated_reminder_risk is not False:
+        pr264_no_ping_status = "blocked"
+    request = Issue314StateHealthRepairRequest(
+        repair_action="preview-issue314-state-health",
+        state_issue_number=input.state_issue_number,
+        validation_nonce=input.validation_nonce,
+        evaluated_repo=input.evaluated_repo,
+        head_sha=input.head_sha,
+        evaluated_ref=input.evaluated_ref,
+        workflow_path=input.workflow_path,
+        run_id=input.run_id,
+        run_attempt=input.run_attempt,
+    )
+    artifact_name = _artifact_name("reviewer-bot-preview-output", request)
+    return Issue314StateHealthSummary(
+        schema_version=1,
+        preview_action="preview-issue314-state-health",
+        state_issue_number=input.state_issue_number,
+        issue_number=input.state_issue_number,
+        validation_nonce=input.validation_nonce,
+        active_review_row_count=len(inventory),
+        active_rows_inspected=tuple(row.issue_number for row in inventory),
+        row_inventory=inventory,
+        row_health_summary=counts,
+        status_projection_summary=status_projection_summary,
+        rows_repairable=rows_repairable,
+        rows_operator_action_required=rows_operator,
+        rows_blocked=rows_blocked,
+        pr264_no_ping_status=pr264_no_ping_status,
+        lock_attempted=False,
+        state_save_attempted=False,
+        tracked_state_mutations_attempted=False,
+        touched_projection_attempted=False,
+        evaluated_repo=input.evaluated_repo,
+        head_sha=input.head_sha,
+        evaluated_ref=input.evaluated_ref,
+        workflow_path=input.workflow_path,
+        run_id=input.run_id,
+        run_attempt=input.run_attempt,
+        artifact_name=artifact_name,
+        artifact_file="preview-output.json",
+        output_keys=(),
+    )
+
+
+def classify_issue314_state_health_rows(bot, state: dict) -> Issue314StateHealthSummary:
+    return classify_issue314_state_health(collect_issue314_state_health_input(bot, state))
+
+
+def run_issue314_state_health_repair(
+    bot,
+    state: dict,
+    request: Issue314StateHealthRepairRequest,
+) -> Issue314StateHealthRepairSummary:
+    classification_input = collect_issue314_state_health_input(bot, state, request)
+    summary = classify_issue314_state_health(classification_input)
+    active_reviews = state.get("active_reviews") if isinstance(state, dict) else None
+    rows_removed_closed: list[int] = []
+    rows_repaired: list[int] = []
+    status_labels_changed: list[int] = []
+    rows_blocked = list(summary.rows_blocked)
+    if isinstance(active_reviews, dict):
+        for row in summary.row_inventory:
+            if row.health_classification == "closed_item_pending_removal":
+                active_reviews.pop(str(row.issue_number), None)
+                rows_removed_closed.append(row.issue_number)
+            elif row.health_classification == "repairable":
+                projection = classification_input.status_projections.get(row.issue_number)
+                if projection is None:
+                    rows_blocked.append(row.issue_number)
+                    continue
+                sync_result = reviews.apply_status_label_delta(bot, row.issue_number, projection.delta)
+                rows_repaired.append(row.issue_number)
+                if sync_result.changed:
+                    status_labels_changed.append(row.issue_number)
+    elif summary.active_review_row_count:
+        rows_blocked.extend(summary.active_rows_inspected)
+    result = "blocked" if rows_blocked or summary.rows_repairable and not rows_repaired else "changed" if rows_removed_closed or rows_repaired else "already_healthy"
+    return Issue314StateHealthRepairSummary(
+        schema_version=1,
+        repair_action=request.repair_action,
+        state_issue_number=request.state_issue_number,
+        issue_number=request.state_issue_number,
+        validation_nonce=request.validation_nonce,
+        target_collection_mode="global_issue314_state_health",
+        active_rows_inspected=summary.active_rows_inspected,
+        rows_repaired=tuple(rows_repaired),
+        rows_removed_closed=tuple(rows_removed_closed),
+        rows_operator_action_required=summary.rows_operator_action_required,
+        rows_blocked=tuple(sorted(set(rows_blocked))),
+        status_labels_changed=tuple(status_labels_changed),
+        reviewer_facing_reminder_posts_attempted=0,
+        manual_issue314_edit_status="not_attempted",
+        state_store_mutation_mode="bot_owned_state_store" if rows_removed_closed else "not_required",
+        evaluated_repo=request.evaluated_repo,
+        head_sha=request.head_sha,
+        evaluated_ref=request.evaluated_ref,
+        workflow_path=request.workflow_path,
+        run_id=request.run_id,
+        run_attempt=request.run_attempt,
+        artifact_name=_artifact_name("reviewer-bot-repair-output", request),
+        artifact_file="issue314-state-health-repair-summary.json",
+        output_keys=(),
+        result=result,
+    )
+
+
+def emit_issue314_state_health_repair_summary(summary: Issue314StateHealthRepairSummary) -> None:
+    path = os.environ.get("ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH", "").strip()
+    if not path:
+        raise RuntimeError("issue314_state_health_repair_summary_path_missing")
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary.to_output(), indent=2) + "\n", encoding="utf-8")

--- a/scripts/reviewer_bot_lib/issue314_state_health.py
+++ b/scripts/reviewer_bot_lib/issue314_state_health.py
@@ -19,6 +19,66 @@ from .reviews_projection import (
     actual_status_labels_from_snapshot,
 )
 
+_REQUIRED_IDENTITY_FIELDS = (
+    "validation_nonce",
+    "evaluated_repo",
+    "head_sha",
+    "evaluated_ref",
+    "workflow_path",
+    "run_id",
+    "run_attempt",
+)
+_SUPPORTED_ACTION_WORKFLOWS = {
+    "preview-issue314-state-health": ".github/workflows/reviewer-bot-preview.yml",
+    "repair-issue314-state-health": ".github/workflows/reviewer-bot-sweeper-repair.yml",
+}
+_SUPPORTED_REPAIR_RESULTS = frozenset({"already_healthy", "changed", "blocked"})
+
+
+def _missing_identity_fields(values: dict[str, object]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            name
+            for name in _REQUIRED_IDENTITY_FIELDS
+            if not isinstance(values.get(name), str) or not str(values.get(name)).strip()
+        )
+    )
+
+
+def _require_identity(values: dict[str, object], *, reason: str) -> None:
+    missing = _missing_identity_fields(values)
+    if missing:
+        raise RuntimeError(f"issue314_state_health_identity_blocked:{reason}:" + ",".join(missing))
+
+
+def _require_request_identity(request: "Issue314StateHealthRepairRequest") -> None:
+    expected_workflow = _SUPPORTED_ACTION_WORKFLOWS.get(request.repair_action)
+    if expected_workflow is None:
+        raise RuntimeError("issue314_state_health_request_blocked:unsupported_action")
+    _require_identity(request.__dict__, reason="missing")
+    if request.workflow_path != expected_workflow:
+        raise RuntimeError("issue314_state_health_request_blocked:workflow_path")
+
+
+def _require_repair_summary_contract(summary: "Issue314StateHealthRepairSummary") -> None:
+    _require_identity(summary.__dict__, reason="missing")
+    if summary.target_collection_mode != "global_issue314_state_health":
+        raise RuntimeError("issue314_state_health_repair_summary_blocked:target_collection_mode")
+    if summary.result not in _SUPPORTED_REPAIR_RESULTS:
+        raise RuntimeError("issue314_state_health_repair_summary_blocked:result")
+    if summary.reviewer_facing_reminder_posts_attempted != 0:
+        raise RuntimeError("issue314_state_health_repair_summary_blocked:reviewer_reminder_attempt")
+    if summary.manual_issue314_edit_status != "not_attempted":
+        raise RuntimeError("issue314_state_health_repair_summary_blocked:manual_issue314_edit")
+    if summary.rows_blocked and summary.result != "blocked":
+        raise RuntimeError("issue314_state_health_repair_summary_blocked:blocked_rows_success")
+    if set(summary.status_labels_changed) - set(summary.rows_repaired):
+        raise RuntimeError("issue314_state_health_repair_summary_blocked:final_label_only_status")
+    if summary.result == "already_healthy" and (
+        summary.rows_repaired or summary.rows_removed_closed or summary.status_labels_changed
+    ):
+        raise RuntimeError("issue314_state_health_repair_summary_blocked:changed_rows_marked_healthy")
+
 
 @dataclass(frozen=True)
 class Issue314StateHealthClassificationInput:
@@ -121,6 +181,7 @@ class Issue314StateHealthSummary:
     output_keys: tuple[str, ...]
 
     def to_output(self) -> dict[str, object]:
+        _require_identity(self.__dict__, reason="preview_output")
         payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "preview_action": self.preview_action,
@@ -186,6 +247,7 @@ class Issue314StateHealthRepairSummary:
     result: str
 
     def to_output(self) -> dict[str, object]:
+        _require_repair_summary_contract(self)
         payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "repair_action": self.repair_action,
@@ -285,6 +347,7 @@ def collect_issue314_state_health_input(
     request: Issue314StateHealthRepairRequest | None = None,
 ) -> Issue314StateHealthClassificationInput:
     request = request or _default_request(bot)
+    _require_request_identity(request)
     rows = _active_rows(state)
     snapshots: dict[int, dict[str, object]] = {}
     reviewer_responses: dict[int, ReviewerResponseDecision] = {}
@@ -293,8 +356,17 @@ def collect_issue314_state_health_input(
     for row in rows:
         issue_number = int(row["issue_number"])
         review_data = row["review_data"]
-        snapshot_result = bot.github.get_issue_or_pr_snapshot_result(issue_number)
-        snapshot = snapshot_result.payload if snapshot_result.ok and isinstance(snapshot_result.payload, dict) else None
+        try:
+            snapshot_result = bot.github.get_issue_or_pr_snapshot_result(issue_number)
+        except (AssertionError, AttributeError, RuntimeError):
+            snapshot_result = None
+        snapshot = (
+            snapshot_result.payload
+            if snapshot_result is not None
+            and snapshot_result.ok
+            and isinstance(snapshot_result.payload, dict)
+            else None
+        )
         if snapshot is not None:
             snapshots[issue_number] = snapshot
         scans[issue_number] = _comment_scan(bot, issue_number)
@@ -444,6 +516,7 @@ def _row_from_input(input: Issue314StateHealthClassificationInput, row: dict[str
 
 
 def classify_issue314_state_health(input: Issue314StateHealthClassificationInput) -> Issue314StateHealthSummary:
+    _require_identity(input.__dict__, reason="classification_input")
     inventory = tuple(_row_from_input(input, row) for row in input.active_review_rows)
     counts: dict[str, int] = {}
     for row in inventory:
@@ -520,6 +593,8 @@ def run_issue314_state_health_repair(
     state: dict,
     request: Issue314StateHealthRepairRequest,
 ) -> Issue314StateHealthRepairSummary:
+    _require_request_identity(request)
+    bot.assert_lock_held("run_issue314_state_health_repair")
     classification_input = collect_issue314_state_health_input(bot, state, request)
     summary = classify_issue314_state_health(classification_input)
     active_reviews = state.get("active_reviews") if isinstance(state, dict) else None

--- a/scripts/reviewer_bot_lib/maintenance.py
+++ b/scripts/reviewer_bot_lib/maintenance.py
@@ -250,6 +250,8 @@ def derive_manual_dispatch_projection_policy(request) -> ManualDispatchProjectio
         return ManualDispatchProjectionPolicy(action, issue_number, False, True, "targeted_status_label_repair")
     if action == "repair-review-status-labels":
         return ManualDispatchProjectionPolicy(action, issue_number, True, True, "broad_status_label_repair")
+    if action == "repair-issue314-state-health":
+        return ManualDispatchProjectionPolicy(action, issue_number, False, True, "issue314_state_health_repair")
     if action in {"preview-check-overdue", "preview-status-label-projection", "preview-issue314-state-health"}:
         return ManualDispatchProjectionPolicy(action, issue_number, False, False, "read_only_preview")
     return ManualDispatchProjectionPolicy(action, issue_number, True, True, "normal_manual_mutation")

--- a/scripts/reviewer_bot_lib/maintenance.py
+++ b/scripts/reviewer_bot_lib/maintenance.py
@@ -3,15 +3,25 @@
 from __future__ import annotations
 
 import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
 
 import yaml
 
-from . import maintenance_privileged, maintenance_schedule, overdue, reviews
+from . import (
+    issue314_state_health,
+    maintenance_privileged,
+    maintenance_schedule,
+    overdue,
+    reviews,
+)
 from .event_inputs import build_manual_dispatch_request
 from .project_board import (
     preview_board_projection_for_item,
     reviewer_board_preflight,
 )
+from .reviews_projection import status_label_projection_output
 
 ScheduleHandlerResult = maintenance_schedule.ScheduleHandlerResult
 SCHEDULE_LIKE_MANUAL_ACTIONS = frozenset({"check-overdue"})
@@ -37,16 +47,356 @@ def collect_status_projection_repair_items(bot, state: dict) -> list[int]:
     return maintenance_schedule.collect_status_projection_repair_items(bot, state)
 
 
+@dataclass(frozen=True)
+class ManualDispatchProjectionPolicy:
+    action: str
+    issue_number: int | None
+    allow_epoch_repair_expansion: bool
+    allow_status_label_sync: bool
+    reason: str
+
+    def to_output(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "issue_number": self.issue_number,
+            "allow_epoch_repair_expansion": self.allow_epoch_repair_expansion,
+            "allow_status_label_sync": self.allow_status_label_sync,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class StatusLabelRepairRequest:
+    action: str
+    issue_number: int | None
+    validation_nonce: str
+    evaluated_repo: str
+    head_sha: str
+    evaluated_ref: str
+    workflow_path: str
+    run_id: str
+    run_attempt: str
+
+    def to_output(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "issue_number": self.issue_number,
+            "validation_nonce": self.validation_nonce,
+            "evaluated_repo": self.evaluated_repo,
+            "head_sha": self.head_sha,
+            "evaluated_ref": self.evaluated_ref,
+            "workflow_path": self.workflow_path,
+            "run_id": self.run_id,
+            "run_attempt": self.run_attempt,
+        }
+
+
+@dataclass(frozen=True)
+class StatusLabelRepairItemResult:
+    issue_number: int
+    before_status_labels: tuple[str, ...]
+    desired_status_labels: tuple[str, ...]
+    labels_added: tuple[str, ...]
+    labels_removed: tuple[str, ...]
+    result: str
+
+    def to_output(self) -> dict[str, object]:
+        return {
+            "issue_number": self.issue_number,
+            "before_status_labels": sorted(self.before_status_labels),
+            "desired_status_labels": sorted(self.desired_status_labels),
+            "labels_added": sorted(self.labels_added),
+            "labels_removed": sorted(self.labels_removed),
+            "result": self.result,
+        }
+
+
+@dataclass(frozen=True)
+class StatusLabelRepairSummary:
+    schema_version: int
+    repair_action: str
+    issue_number: int | None
+    issue_numbers: tuple[int, ...]
+    validation_nonce: str
+    evaluated_repo: str
+    head_sha: str
+    evaluated_ref: str
+    workflow_path: str
+    run_id: str
+    run_attempt: str
+    artifact_name: str
+    artifact_file: str
+    output_keys: tuple[str, ...]
+    status_projection_epoch: str | None
+    before: tuple[StatusLabelRepairItemResult, ...]
+    after: tuple[StatusLabelRepairItemResult, ...]
+    labels_added: tuple[str, ...]
+    labels_removed: tuple[str, ...]
+    state_save_attempted: bool
+    tracked_state_mutations_attempted: bool
+    touched_projection_attempted: bool
+    target_collection_mode: str
+    result: str
+
+    def to_output(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "repair_action": self.repair_action,
+            "issue_number": self.issue_number,
+            "issue_numbers": sorted(self.issue_numbers),
+            "validation_nonce": self.validation_nonce,
+            "evaluated_repo": self.evaluated_repo,
+            "head_sha": self.head_sha,
+            "evaluated_ref": self.evaluated_ref,
+            "workflow_path": self.workflow_path,
+            "run_id": self.run_id,
+            "run_attempt": self.run_attempt,
+            "artifact_name": self.artifact_name,
+            "artifact_file": self.artifact_file,
+            "output_keys": [],
+            "status_projection_epoch": self.status_projection_epoch,
+            "before": [item.to_output() for item in sorted(self.before, key=lambda item: item.issue_number)],
+            "after": [item.to_output() for item in sorted(self.after, key=lambda item: item.issue_number)],
+            "labels_added": sorted(self.labels_added),
+            "labels_removed": sorted(self.labels_removed),
+            "state_save_attempted": self.state_save_attempted,
+            "tracked_state_mutations_attempted": self.tracked_state_mutations_attempted,
+            "touched_projection_attempted": self.touched_projection_attempted,
+            "target_collection_mode": self.target_collection_mode,
+            "result": self.result,
+        }
+        payload["output_keys"] = sorted(payload.keys())
+        return payload
+
+
+def _config(bot, name: str, default: str = "") -> str:
+    return bot.get_config_value(name, default).strip()
+
+
+def _run_id(bot) -> str:
+    return _config(bot, "GITHUB_RUN_ID") or _config(bot, "WORKFLOW_RUN_ID")
+
+
+def _run_attempt(bot) -> str:
+    return _config(bot, "GITHUB_RUN_ATTEMPT") or "1"
+
+
+def _evaluated_repo(bot) -> str:
+    return _config(bot, "EVALUATED_REPO") or _config(bot, "GITHUB_REPOSITORY")
+
+
+def _head_sha(bot) -> str:
+    return _config(bot, "HEAD_SHA") or _config(bot, "GITHUB_SHA")
+
+
+def _evaluated_ref(bot) -> str:
+    return _config(bot, "EVALUATED_REF") or _head_sha(bot)
+
+
+def _artifact_name(prefix: str, bot) -> str:
+    return f"{prefix}-{_run_id(bot)}-attempt-{_run_attempt(bot)}"
+
+
+def _preview_identity(bot) -> dict[str, str]:
+    run_id = _run_id(bot)
+    run_attempt = _run_attempt(bot)
+    return {
+        "evaluated_repo": _evaluated_repo(bot),
+        "head_sha": _head_sha(bot),
+        "evaluated_ref": _evaluated_ref(bot),
+        "workflow_path": ".github/workflows/reviewer-bot-preview.yml",
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "artifact_name": f"reviewer-bot-preview-output-{run_id}-attempt-{run_attempt}",
+        "artifact_file": "preview-output.json",
+    }
+
+
+def _repair_artifact_fields(request: StatusLabelRepairRequest) -> dict[str, str]:
+    return {
+        "artifact_name": f"reviewer-bot-repair-output-{request.run_id}-attempt-{request.run_attempt}",
+        "artifact_file": "repair-summary.json",
+    }
+
+
+def _issue314_request(bot, request) -> issue314_state_health.Issue314StateHealthRepairRequest:
+    state_issue_number = bot.state_issue_number()
+    return issue314_state_health.Issue314StateHealthRepairRequest(
+        repair_action=request.action,
+        state_issue_number=state_issue_number,
+        validation_nonce=request.validation_nonce,
+        evaluated_repo=_evaluated_repo(bot),
+        head_sha=_head_sha(bot),
+        evaluated_ref=_evaluated_ref(bot),
+        workflow_path=".github/workflows/reviewer-bot-sweeper-repair.yml" if request.action.startswith("repair-") else ".github/workflows/reviewer-bot-preview.yml",
+        run_id=_run_id(bot),
+        run_attempt=_run_attempt(bot),
+    )
+
+
+def derive_manual_dispatch_projection_policy(request) -> ManualDispatchProjectionPolicy:
+    action = request.action or ""
+    issue_number = request.issue_number if isinstance(request.issue_number, int) else None
+    if action == "repair-review-status-labels" and issue_number is not None and issue_number > 0:
+        return ManualDispatchProjectionPolicy(action, issue_number, False, True, "targeted_status_label_repair")
+    if action == "repair-review-status-labels":
+        return ManualDispatchProjectionPolicy(action, issue_number, True, True, "broad_status_label_repair")
+    if action in {"preview-check-overdue", "preview-status-label-projection", "preview-issue314-state-health"}:
+        return ManualDispatchProjectionPolicy(action, issue_number, False, False, "read_only_preview")
+    return ManualDispatchProjectionPolicy(action, issue_number, True, True, "normal_manual_mutation")
+
+
+def build_status_label_repair_request(bot, request) -> StatusLabelRepairRequest:
+    if request.action != "repair-review-status-labels":
+        raise RuntimeError("status_label_repair_request_blocked:unsupported_action")
+    validation_nonce = request.validation_nonce.strip()
+    evaluated_repo = _evaluated_repo(bot)
+    head_sha = _head_sha(bot)
+    evaluated_ref = _evaluated_ref(bot)
+    run_id = _run_id(bot)
+    run_attempt = _run_attempt(bot)
+    workflow_path = ".github/workflows/reviewer-bot-sweeper-repair.yml"
+    missing = []
+    for name, value in {
+        "validation_nonce": validation_nonce,
+        "evaluated_repo": evaluated_repo,
+        "head_sha": head_sha,
+        "evaluated_ref": evaluated_ref,
+        "workflow_path": workflow_path,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+    }.items():
+        if not value:
+            missing.append(name)
+    if missing:
+        raise RuntimeError("status_label_repair_request_blocked:" + ",".join(sorted(missing)))
+    return StatusLabelRepairRequest(
+        action=request.action,
+        issue_number=request.issue_number,
+        validation_nonce=validation_nonce,
+        evaluated_repo=evaluated_repo,
+        head_sha=head_sha,
+        evaluated_ref=evaluated_ref,
+        workflow_path=workflow_path,
+        run_id=run_id,
+        run_attempt=run_attempt,
+    )
+
+
+def collect_status_label_repair_targets(bot, state: dict, request: StatusLabelRepairRequest) -> tuple[int, ...]:
+    del state
+    if isinstance(request.issue_number, int) and request.issue_number > 0:
+        return (request.issue_number,)
+    return tuple(reviews.list_open_items_with_status_labels(bot))
+
+
+def run_status_label_repair(bot, state: dict, request: StatusLabelRepairRequest) -> StatusLabelRepairSummary:
+    targets = collect_status_label_repair_targets(bot, state, request)
+    before: list[StatusLabelRepairItemResult] = []
+    after: list[StatusLabelRepairItemResult] = []
+    labels_added: set[str] = set()
+    labels_removed: set[str] = set()
+    blocked = False
+    for issue_number in targets:
+        try:
+            projection = reviews.project_status_label_projection_for_item(bot, issue_number, state)
+            delta = projection.delta
+            sync_result = reviews.apply_status_label_delta(bot, issue_number, delta)
+            item_result = "changed" if sync_result.changed else "already_aligned"
+            before.append(
+                StatusLabelRepairItemResult(
+                    issue_number=issue_number,
+                    before_status_labels=delta.actual_status_labels,
+                    desired_status_labels=delta.desired_status_labels,
+                    labels_added=delta.labels_to_add,
+                    labels_removed=delta.labels_to_remove,
+                    result=item_result,
+                )
+            )
+            after.append(
+                StatusLabelRepairItemResult(
+                    issue_number=issue_number,
+                    before_status_labels=delta.desired_status_labels,
+                    desired_status_labels=delta.desired_status_labels,
+                    labels_added=sync_result.labels_added,
+                    labels_removed=sync_result.labels_removed,
+                    result=item_result,
+                )
+            )
+            labels_added.update(sync_result.labels_added)
+            labels_removed.update(sync_result.labels_removed)
+        except RuntimeError:
+            blocked = True
+            before.append(
+                StatusLabelRepairItemResult(
+                    issue_number=issue_number,
+                    before_status_labels=(),
+                    desired_status_labels=(),
+                    labels_added=(),
+                    labels_removed=(),
+                    result="blocked",
+                )
+            )
+            after.append(before[-1])
+    result = "blocked" if blocked else "changed" if labels_added or labels_removed else "already_aligned"
+    artifact = _repair_artifact_fields(request)
+    payload = StatusLabelRepairSummary(
+        schema_version=1,
+        repair_action=request.action,
+        issue_number=request.issue_number,
+        issue_numbers=targets,
+        validation_nonce=request.validation_nonce,
+        evaluated_repo=request.evaluated_repo,
+        head_sha=request.head_sha,
+        evaluated_ref=request.evaluated_ref,
+        workflow_path=request.workflow_path,
+        run_id=request.run_id,
+        run_attempt=request.run_attempt,
+        artifact_name=artifact["artifact_name"],
+        artifact_file=artifact["artifact_file"],
+        output_keys=(),
+        status_projection_epoch=state.get("status_projection_epoch") if isinstance(state.get("status_projection_epoch"), str) else None,
+        before=tuple(before),
+        after=tuple(after),
+        labels_added=tuple(sorted(labels_added)),
+        labels_removed=tuple(sorted(labels_removed)),
+        state_save_attempted=False,
+        tracked_state_mutations_attempted=False,
+        touched_projection_attempted=False,
+        target_collection_mode="issue_scoped" if isinstance(request.issue_number, int) and request.issue_number > 0 else "broad",
+        result=result,
+    )
+    output_keys = tuple(payload.to_output()["output_keys"])
+    return StatusLabelRepairSummary(**{**payload.__dict__, "output_keys": output_keys})
+
+
+def emit_status_label_repair_summary(summary: StatusLabelRepairSummary) -> None:
+    path = os.environ.get("REPAIR_SUMMARY_PATH", "").strip()
+    if not path:
+        raise RuntimeError("repair_summary_path_missing")
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary.to_output(), indent=2) + "\n", encoding="utf-8")
+
+
 def _preview_output_base(bot, state: dict, request) -> dict[str, object]:
     if request.issue_number is None or request.issue_number <= 0:
         raise RuntimeError("Preview actions require ISSUE_NUMBER to be set to a positive integer")
+    identity = _preview_identity(bot)
     return {
         "schema_version": 1,
         "preview_action": request.action,
         "issue_number": request.issue_number,
         "validation_nonce": request.validation_nonce,
-        "head_sha": bot.get_config_value("GITHUB_SHA").strip(),
-        "workflow_path": ".github/workflows/reviewer-bot-preview.yml",
+        "evaluated_repo": identity["evaluated_repo"],
+        "head_sha": identity["head_sha"],
+        "evaluated_ref": identity["evaluated_ref"],
+        "workflow_path": identity["workflow_path"],
+        "run_id": identity["run_id"],
+        "run_attempt": identity["run_attempt"],
+        "artifact_name": identity["artifact_name"],
+        "artifact_file": identity["artifact_file"],
+        "output_keys": [],
         **overdue.evaluate_overdue_review_preview(bot, state, request.issue_number),
         "lock_attempted": False,
         "state_save_attempted": False,
@@ -56,6 +406,7 @@ def _preview_output_base(bot, state: dict, request) -> dict[str, object]:
 
 
 def _emit_preview_json(payload: dict[str, object]) -> None:
+    payload["output_keys"] = sorted(payload.keys())
     print(json.dumps(payload, indent=2, sort_keys=False))
 
 
@@ -90,6 +441,32 @@ def _handle_manual_dispatch_request(bot, state: dict, request) -> bool:
     if action == "preview-check-overdue":
         _emit_preview_json(_preview_output_base(bot, state, request))
         return False
+    if action == "preview-status-label-projection":
+        if request.issue_number is None or request.issue_number <= 0:
+            raise RuntimeError("Preview actions require ISSUE_NUMBER to be set to a positive integer")
+        projection = reviews.project_status_label_projection_for_item(bot, request.issue_number, state)
+        payload = status_label_projection_output(
+            projection,
+            preview_action=request.action,
+            validation_nonce=request.validation_nonce,
+            **_preview_identity(bot),
+        )
+        payload["lock_attempted"] = False
+        payload["state_save_attempted"] = False
+        payload["tracked_state_mutations_attempted"] = False
+        payload["touched_projection_attempted"] = False
+        _emit_preview_json(payload)
+        return False
+    if action == "preview-issue314-state-health":
+        summary = issue314_state_health.classify_issue314_state_health(
+            issue314_state_health.collect_issue314_state_health_input(
+                bot,
+                state,
+                _issue314_request(bot, request),
+            )
+        )
+        _emit_preview_json(summary.to_output())
+        return False
     if action == "preview-reviewer-board":
         preflight = reviewer_board_preflight(bot)
         if not preflight.enabled:
@@ -112,9 +489,18 @@ def _handle_manual_dispatch_request(bot, state: dict, request) -> bool:
         _, changes = bot.adapters.workflow.sync_members_with_queue(state)
         return bool(changes)
     if action == "repair-review-status-labels":
-        for issue_number in reviews.list_open_items_with_status_labels(bot):
-            bot.collect_touched_item(issue_number)
+        repair_request = build_status_label_repair_request(bot, request)
+        summary = run_status_label_repair(bot, state, repair_request)
+        emit_status_label_repair_summary(summary)
         return False
+    if action == "repair-issue314-state-health":
+        summary = issue314_state_health.run_issue314_state_health_repair(
+            bot,
+            state,
+            _issue314_request(bot, request),
+        )
+        issue314_state_health.emit_issue314_state_health_repair_summary(summary)
+        return bool(summary.rows_removed_closed)
     if action == "execute-pending-privileged-command":
         source_event_key = request.privileged_source_event_key
         if not source_event_key:

--- a/scripts/reviewer_bot_lib/maintenance.py
+++ b/scripts/reviewer_bot_lib/maintenance.py
@@ -25,6 +25,7 @@ from .reviews_projection import status_label_projection_output
 
 ScheduleHandlerResult = maintenance_schedule.ScheduleHandlerResult
 SCHEDULE_LIKE_MANUAL_ACTIONS = frozenset({"check-overdue"})
+_PENDING_ISSUE314_REPAIR_SUMMARY_ATTR = "_reviewer_bot_pending_issue314_state_health_repair_summary"
 _now_iso = maintenance_privileged._now_iso
 _finalize_schedule_result = maintenance_schedule._finalize_schedule_result
 _record_maintenance_repair_marker = maintenance_schedule._record_maintenance_repair_marker
@@ -234,6 +235,14 @@ def _issue314_request(bot, request) -> issue314_state_health.Issue314StateHealth
     )
 
 
+def emit_pending_issue314_state_health_repair_summary(bot) -> None:
+    summary = getattr(bot, _PENDING_ISSUE314_REPAIR_SUMMARY_ATTR, None)
+    if summary is None:
+        return
+    issue314_state_health.emit_issue314_state_health_repair_summary(summary)
+    setattr(bot, _PENDING_ISSUE314_REPAIR_SUMMARY_ATTR, None)
+
+
 def derive_manual_dispatch_projection_policy(request) -> ManualDispatchProjectionPolicy:
     action = request.action or ""
     issue_number = request.issue_number if isinstance(request.issue_number, int) else None
@@ -296,49 +305,34 @@ def run_status_label_repair(bot, state: dict, request: StatusLabelRepairRequest)
     after: list[StatusLabelRepairItemResult] = []
     labels_added: set[str] = set()
     labels_removed: set[str] = set()
-    blocked = False
     for issue_number in targets:
-        try:
-            projection = reviews.project_status_label_projection_for_item(bot, issue_number, state)
-            delta = projection.delta
-            sync_result = reviews.apply_status_label_delta(bot, issue_number, delta)
-            item_result = "changed" if sync_result.changed else "already_aligned"
-            before.append(
-                StatusLabelRepairItemResult(
-                    issue_number=issue_number,
-                    before_status_labels=delta.actual_status_labels,
-                    desired_status_labels=delta.desired_status_labels,
-                    labels_added=delta.labels_to_add,
-                    labels_removed=delta.labels_to_remove,
-                    result=item_result,
-                )
+        projection = reviews.project_status_label_projection_for_item(bot, issue_number, state)
+        delta = projection.delta
+        sync_result = reviews.apply_status_label_delta(bot, issue_number, delta)
+        item_result = "changed" if sync_result.changed else "already_aligned"
+        before.append(
+            StatusLabelRepairItemResult(
+                issue_number=issue_number,
+                before_status_labels=delta.actual_status_labels,
+                desired_status_labels=delta.desired_status_labels,
+                labels_added=delta.labels_to_add,
+                labels_removed=delta.labels_to_remove,
+                result=item_result,
             )
-            after.append(
-                StatusLabelRepairItemResult(
-                    issue_number=issue_number,
-                    before_status_labels=delta.desired_status_labels,
-                    desired_status_labels=delta.desired_status_labels,
-                    labels_added=sync_result.labels_added,
-                    labels_removed=sync_result.labels_removed,
-                    result=item_result,
-                )
+        )
+        after.append(
+            StatusLabelRepairItemResult(
+                issue_number=issue_number,
+                before_status_labels=delta.desired_status_labels,
+                desired_status_labels=delta.desired_status_labels,
+                labels_added=sync_result.labels_added,
+                labels_removed=sync_result.labels_removed,
+                result=item_result,
             )
-            labels_added.update(sync_result.labels_added)
-            labels_removed.update(sync_result.labels_removed)
-        except RuntimeError:
-            blocked = True
-            before.append(
-                StatusLabelRepairItemResult(
-                    issue_number=issue_number,
-                    before_status_labels=(),
-                    desired_status_labels=(),
-                    labels_added=(),
-                    labels_removed=(),
-                    result="blocked",
-                )
-            )
-            after.append(before[-1])
-    result = "blocked" if blocked else "changed" if labels_added or labels_removed else "already_aligned"
+        )
+        labels_added.update(sync_result.labels_added)
+        labels_removed.update(sync_result.labels_removed)
+    result = "changed" if labels_added or labels_removed else "already_aligned"
     artifact = _repair_artifact_fields(request)
     payload = StatusLabelRepairSummary(
         schema_version=1,
@@ -499,7 +493,7 @@ def _handle_manual_dispatch_request(bot, state: dict, request) -> bool:
             state,
             _issue314_request(bot, request),
         )
-        issue314_state_health.emit_issue314_state_health_repair_summary(summary)
+        setattr(bot, _PENDING_ISSUE314_REPAIR_SUMMARY_ATTR, summary)
         return bool(summary.rows_removed_closed)
     if action == "execute-pending-privileged-command":
         source_event_key = request.privileged_source_event_key

--- a/scripts/reviewer_bot_lib/reviews.py
+++ b/scripts/reviewer_bot_lib/reviews.py
@@ -8,15 +8,21 @@ from urllib.parse import quote
 
 from scripts.reviewer_bot_core import live_review_support
 
-from . import review_state
+from . import assignment_flow, overdue, review_state
 from .config import (
     MANDATORY_TRIAGE_APPROVER_LABEL,
     MANDATORY_TRIAGE_ESCALATION_TEMPLATE,
     MANDATORY_TRIAGE_SATISFIED_TEMPLATE,
+    STATUS_LABEL_CONFIG,
     STATUS_LABELS,
 )
 from .reviews_projection import (
-    desired_labels_from_response_state,
+    StatusLabelProjectionInput,
+    StatusLabelProjectionResult,
+    StatusLabelSyncResult,
+    actual_status_labels_from_snapshot,
+    derive_status_label_projection,
+    status_label_delta,
 )
 
 
@@ -311,6 +317,86 @@ def compute_reviewer_response_state(
     )
 
 
+def project_status_label_projection_for_item(
+    bot,
+    issue_number: int,
+    state: dict,
+    *,
+    issue_snapshot: dict | None = None,
+) -> StatusLabelProjectionResult:
+    if issue_snapshot is None:
+        issue_snapshot = bot.github.get_issue_or_pr_snapshot(issue_number)
+    if not isinstance(issue_snapshot, dict):
+        raise RuntimeError("status_label_projection_blocked:live_read_unavailable")
+    issue_state = str(issue_snapshot.get("state", "")).lower()
+    actual_status_labels = actual_status_labels_from_snapshot(issue_snapshot)
+    review_data = review_state.ensure_review_entry(state, issue_number)
+    if issue_state == "closed":
+        from scripts.reviewer_bot_core import reviewer_response_policy
+
+        decision = reviewer_response_policy.to_reviewer_response_decision(
+            {"response_state": "closed", "reason": None}
+        )
+        return derive_status_label_projection(
+            StatusLabelProjectionInput(
+                issue_number=issue_number,
+                issue_state=issue_state,
+                actual_labels=actual_status_labels,
+                reviewer_response=decision,
+                reviewer_authority_outcome="closed",
+                freshness_runtime_epoch=state.get("freshness_runtime_epoch") if isinstance(state.get("freshness_runtime_epoch"), str) else None,
+                status_projection_epoch=state.get("status_projection_epoch") if isinstance(state.get("status_projection_epoch"), str) else None,
+            )
+        )
+    if review_data is None:
+        from scripts.reviewer_bot_core import reviewer_response_policy
+
+        decision = reviewer_response_policy.to_reviewer_response_decision(
+            {"response_state": "untracked", "reason": "no_review_entry"}
+        )
+        return derive_status_label_projection(
+            StatusLabelProjectionInput(
+                issue_number=issue_number,
+                issue_state=issue_state,
+                actual_labels=actual_status_labels,
+                reviewer_response=decision,
+                reviewer_authority_outcome="no_tracked_reviewer",
+                freshness_runtime_epoch=state.get("freshness_runtime_epoch") if isinstance(state.get("freshness_runtime_epoch"), str) else None,
+                status_projection_epoch=state.get("status_projection_epoch") if isinstance(state.get("status_projection_epoch"), str) else None,
+            )
+        )
+    is_pull_request = isinstance(issue_snapshot.get("pull_request"), dict)
+    authority = assignment_flow.resolve_reviewer_authority(
+        bot,
+        issue_number,
+        review_data,
+        is_pull_request=is_pull_request,
+    )
+    authority_status = str(authority.get("authority_status") or "unknown")
+    if authority_status == "live_read_unavailable":
+        raise RuntimeError("status_label_projection_blocked:live_read_unavailable")
+    response_state = compute_reviewer_response_state(bot, issue_number, review_data, issue_snapshot=issue_snapshot)
+    response_state = dict(response_state)
+    response_state["reviewer_authority_outcome"] = authority_status
+    effective_response, _cadence, _reminder_scan = overdue._effective_response_with_cadence(
+        bot,
+        issue_number,
+        review_data,
+        response_state,
+    )
+    return derive_status_label_projection(
+        StatusLabelProjectionInput(
+            issue_number=issue_number,
+            issue_state=issue_state,
+            actual_labels=actual_status_labels,
+            reviewer_response=effective_response,
+            reviewer_authority_outcome=authority_status,
+            freshness_runtime_epoch=state.get("freshness_runtime_epoch") if isinstance(state.get("freshness_runtime_epoch"), str) else None,
+            status_projection_epoch=state.get("status_projection_epoch") if isinstance(state.get("status_projection_epoch"), str) else None,
+        )
+    )
+
+
 def project_status_labels_for_item(
     bot,
     issue_number: int,
@@ -318,47 +404,61 @@ def project_status_labels_for_item(
     *,
     issue_snapshot: dict | None = None,
 ) -> tuple[set[str] | None, dict[str, str | None]]:
-    if issue_snapshot is None:
-        issue_snapshot = bot.github.get_issue_or_pr_snapshot(issue_number)
-    if not isinstance(issue_snapshot, dict):
-        return None, {"state": "projection_failed", "reason": "issue_snapshot_unavailable"}
-    if str(issue_snapshot.get("state", "")).lower() == "closed":
-        return set(), {"state": "closed", "reason": None}
-
-    review_data = review_state.ensure_review_entry(state, issue_number)
-    if review_data is None:
-        return set(), {"state": "untracked", "reason": "no_review_entry"}
-    current_reviewer = review_data.get("current_reviewer")
-    if not isinstance(current_reviewer, str) or not current_reviewer.strip():
-        return set(), {"state": "untracked", "reason": "no_current_reviewer"}
-
-    response_state = compute_reviewer_response_state(bot, issue_number, review_data, issue_snapshot=issue_snapshot)
-    state_name = response_state.get("state")
-    reason = response_state.get("reason")
-    return desired_labels_from_response_state(str(state_name), None if reason is None else str(reason))
+    result = project_status_label_projection_for_item(
+        bot,
+        issue_number,
+        state,
+        issue_snapshot=issue_snapshot,
+    )
+    return set(result.delta.desired_status_labels), {
+        "state": result.response_state,
+        "reason": result.suppression_reason,
+    }
 
 
-def sync_status_labels(bot, issue_number: int, desired_labels: set[str], actual_labels: Iterable[str]) -> bool:
+def apply_status_label_delta(bot, issue_number: int, delta) -> StatusLabelSyncResult:
     from . import github_api
 
-    actual_status_labels = {label for label in actual_labels if label in STATUS_LABELS}
-    to_add = desired_labels - actual_status_labels
-    to_remove = actual_status_labels - desired_labels
+    actual_status_labels = set(delta.actual_status_labels)
+    to_add = set(delta.labels_to_add)
+    to_remove = set(delta.labels_to_remove)
     if not to_add and not to_remove:
-        return False
-    for label in STATUS_LABELS:
-        if not bot.github.ensure_label_exists(label):
+        return StatusLabelSyncResult(
+            issue_number=issue_number,
+            before_status_labels=tuple(sorted(actual_status_labels)),
+            desired_status_labels=tuple(sorted(delta.desired_status_labels)),
+            labels_added=(),
+            labels_removed=(),
+            changed=False,
+        )
+    for label in sorted(to_add):
+        config = STATUS_LABEL_CONFIG.get(label, {})
+        if not bot.github.ensure_label_exists(
+            label,
+            color=config.get("color"),
+            description=config.get("description"),
+        ):
             raise RuntimeError(f"Unable to ensure reviewer-bot status label exists: {label}")
-    changed = False
     for label in sorted(to_remove):
         if not github_api.remove_label_with_status(bot, issue_number, label):
             raise RuntimeError(f"Unable to remove reviewer-bot status label '{label}' from #{issue_number}")
-        changed = True
     for label in sorted(to_add):
         if not github_api.add_label_with_status(bot, issue_number, label):
             raise RuntimeError(f"Unable to add reviewer-bot status label '{label}' to #{issue_number}")
-        changed = True
-    return changed
+    return StatusLabelSyncResult(
+        issue_number=issue_number,
+        before_status_labels=tuple(sorted(actual_status_labels)),
+        desired_status_labels=tuple(sorted(delta.desired_status_labels)),
+        labels_added=tuple(sorted(to_add)),
+        labels_removed=tuple(sorted(to_remove)),
+        changed=True,
+    )
+
+
+def sync_status_labels(bot, issue_number: int, desired_labels: set[str], actual_labels: Iterable[str]) -> bool:
+    actual_status_labels = tuple(sorted(label for label in actual_labels if isinstance(label, str) and label.startswith("status: ")))
+    delta = status_label_delta(actual_status_labels, tuple(sorted(desired_labels)))
+    return apply_status_label_delta(bot, issue_number, delta).changed
 
 
 def sync_status_labels_for_items(bot, state: dict, issue_numbers: Iterable[int]) -> bool:
@@ -371,15 +471,9 @@ def sync_status_labels_for_items(bot, state: dict, issue_numbers: Iterable[int])
             raise RuntimeError(f"Failed to derive reviewer-bot status labels for #{issue_number}: {reason}")
         if not isinstance(issue_snapshot, dict):
             raise RuntimeError(f"Failed to refresh issue/PR snapshot for #{issue_number}")
-        labels = issue_snapshot.get("labels", [])
-        actual_labels = set()
-        if isinstance(labels, list):
-            for label in labels:
-                if isinstance(label, dict):
-                    name = label.get("name")
-                    if isinstance(name, str):
-                        actual_labels.add(name)
-        if sync_status_labels(bot, issue_number, desired_labels, actual_labels):
+        actual_labels = actual_status_labels_from_snapshot(issue_snapshot)
+        delta = status_label_delta(actual_labels, tuple(sorted(desired_labels)))
+        if apply_status_label_delta(bot, issue_number, delta).changed:
             changed = True
     return changed
 

--- a/scripts/reviewer_bot_lib/reviews_projection.py
+++ b/scripts/reviewer_bot_lib/reviews_projection.py
@@ -1,28 +1,246 @@
-"""Pure projection helpers for reviewer-bot review state."""
+"""Pure status-label projection helpers for reviewer-bot review state."""
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+
+from scripts.reviewer_bot_core.reviewer_response_policy import ReviewerResponseDecision
 
 from .config import (
     STATUS_AWAITING_CONTRIBUTOR_RESPONSE_LABEL,
     STATUS_AWAITING_REVIEWER_RESPONSE_LABEL,
     STATUS_AWAITING_WRITE_APPROVAL_LABEL,
+    STATUS_REVIEWER_REASSIGNMENT_NEEDED_LABEL,
 )
 
 __all__ = [
+    "StatusLabelDelta",
+    "StatusLabelProjectionInput",
+    "StatusLabelProjectionResult",
+    "StatusLabelSyncResult",
+    "actual_status_labels_from_snapshot",
+    "derive_status_label_projection",
     "desired_labels_from_response_state",
+    "desired_status_labels_from_decision",
+    "status_label_delta",
+    "status_label_projection_output",
 ]
+
+_SUPPORTED_EMPTY_STATES = frozenset({"done", "closed", "untracked", "no_current_reviewer"})
+_BLOCKED_STATES = frozenset({"projection_failed", "live_read_unavailable"})
+
+
+@dataclass(frozen=True)
+class StatusLabelDelta:
+    actual_status_labels: tuple[str, ...]
+    desired_status_labels: tuple[str, ...]
+    labels_to_add: tuple[str, ...]
+    labels_to_remove: tuple[str, ...]
+
+    def to_output(self) -> dict[str, object]:
+        return {
+            "actual_status_labels": sorted(self.actual_status_labels),
+            "desired_status_labels": sorted(self.desired_status_labels),
+            "labels_to_add": sorted(self.labels_to_add),
+            "labels_to_remove": sorted(self.labels_to_remove),
+        }
+
+
+@dataclass(frozen=True)
+class StatusLabelProjectionInput:
+    issue_number: int
+    issue_state: str
+    actual_labels: tuple[str, ...]
+    reviewer_response: ReviewerResponseDecision
+    reviewer_authority_outcome: str
+    freshness_runtime_epoch: str | None
+    status_projection_epoch: str | None
+
+
+@dataclass(frozen=True)
+class StatusLabelProjectionResult:
+    issue_number: int
+    response_state: str
+    reviewer_authority_outcome: str
+    suppression_reason: str | None
+    current_scope_key: str | None
+    current_scope_basis: str | None
+    freshness_runtime_epoch: str | None
+    status_projection_epoch: str | None
+    delta: StatusLabelDelta
+    projection_metadata: dict[str, object]
+
+    def to_output(self) -> dict[str, object]:
+        return {
+            "issue_number": self.issue_number,
+            "response_state": self.response_state,
+            "reviewer_authority_outcome": self.reviewer_authority_outcome,
+            "suppression_reason": self.suppression_reason,
+            "current_scope_key": self.current_scope_key,
+            "current_scope_basis": self.current_scope_basis,
+            "freshness_runtime_epoch": self.freshness_runtime_epoch,
+            "status_projection_epoch": self.status_projection_epoch,
+            "delta": self.delta.to_output(),
+            "projection_metadata": dict(self.projection_metadata),
+        }
+
+
+@dataclass(frozen=True)
+class StatusLabelSyncResult:
+    issue_number: int
+    before_status_labels: tuple[str, ...]
+    desired_status_labels: tuple[str, ...]
+    labels_added: tuple[str, ...]
+    labels_removed: tuple[str, ...]
+    changed: bool
+
+    def to_output(self) -> dict[str, object]:
+        return {
+            "issue_number": self.issue_number,
+            "before_status_labels": sorted(self.before_status_labels),
+            "desired_status_labels": sorted(self.desired_status_labels),
+            "labels_added": sorted(self.labels_added),
+            "labels_removed": sorted(self.labels_removed),
+            "changed": self.changed,
+        }
+
+
+def _blocked(reason: str) -> RuntimeError:
+    return RuntimeError(f"status_label_projection_blocked:{reason}")
+
+
+def actual_status_labels_from_snapshot(issue_snapshot: dict) -> tuple[str, ...]:
+    labels = issue_snapshot.get("labels") if isinstance(issue_snapshot, dict) else None
+    actual: set[str] = set()
+    if isinstance(labels, list):
+        for label in labels:
+            name = label.get("name") if isinstance(label, dict) else label
+            if isinstance(name, str) and name.startswith("status: "):
+                actual.add(name)
+    return tuple(sorted(actual))
+
+
+def desired_status_labels_from_decision(decision: ReviewerResponseDecision) -> tuple[str, ...]:
+    state = getattr(decision, "response_state", None)
+    if not isinstance(state, str) or not state.strip():
+        raise _blocked("missing_response_state")
+    if state in _BLOCKED_STATES:
+        raise _blocked(state)
+    if state == "awaiting_reviewer_response":
+        return (STATUS_AWAITING_REVIEWER_RESPONSE_LABEL,)
+    if state == "awaiting_contributor_response":
+        return (STATUS_AWAITING_CONTRIBUTOR_RESPONSE_LABEL,)
+    if state == "awaiting_write_approval":
+        return (STATUS_AWAITING_WRITE_APPROVAL_LABEL,)
+    if state == "reviewer_reassignment_needed":
+        return (STATUS_REVIEWER_REASSIGNMENT_NEEDED_LABEL,)
+    if state in _SUPPORTED_EMPTY_STATES:
+        return ()
+    raise _blocked("unknown_response_state")
+
+
+def status_label_delta(
+    actual_status_labels: tuple[str, ...],
+    desired_status_labels: tuple[str, ...],
+) -> StatusLabelDelta:
+    actual = set(actual_status_labels)
+    desired = set(desired_status_labels)
+    return StatusLabelDelta(
+        actual_status_labels=tuple(sorted(actual)),
+        desired_status_labels=tuple(sorted(desired)),
+        labels_to_add=tuple(sorted(desired - actual)),
+        labels_to_remove=tuple(sorted(actual - desired)),
+    )
+
+
+def derive_status_label_projection(input: StatusLabelProjectionInput) -> StatusLabelProjectionResult:
+    issue_state = input.issue_state.strip().lower() if isinstance(input.issue_state, str) else ""
+    if issue_state not in {"open", "closed"}:
+        raise _blocked("invalid_issue_state")
+    decision = input.reviewer_response
+    desired = desired_status_labels_from_decision(decision)
+    if issue_state == "closed" and desired:
+        raise _blocked("closed_issue_with_nonterminal_response")
+    delta = status_label_delta(
+        tuple(label for label in input.actual_labels if isinstance(label, str) and label.startswith("status: ")),
+        desired,
+    )
+    scope = decision.scope
+    return StatusLabelProjectionResult(
+        issue_number=input.issue_number,
+        response_state=decision.response_state,
+        reviewer_authority_outcome=input.reviewer_authority_outcome,
+        suppression_reason=decision.suppression_reason,
+        current_scope_key=scope.scope_key if scope is not None else None,
+        current_scope_basis=scope.scope_basis if scope is not None else None,
+        freshness_runtime_epoch=input.freshness_runtime_epoch,
+        status_projection_epoch=input.status_projection_epoch,
+        delta=delta,
+        projection_metadata={
+            "source": "reviewer_response_decision",
+            "decision_output": decision.to_output(),
+        },
+    )
+
+
+def status_label_projection_output(
+    result: StatusLabelProjectionResult,
+    *,
+    preview_action: str,
+    validation_nonce: str,
+    evaluated_repo: str,
+    head_sha: str,
+    evaluated_ref: str,
+    workflow_path: str,
+    run_id: str,
+    run_attempt: str,
+    artifact_name: str,
+    artifact_file: str,
+) -> dict[str, object]:
+    delta = result.delta.to_output()
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "preview_action": preview_action,
+        "issue_number": result.issue_number,
+        "validation_nonce": validation_nonce,
+        "evaluated_repo": evaluated_repo,
+        "head_sha": head_sha,
+        "evaluated_ref": evaluated_ref,
+        "workflow_path": workflow_path,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "artifact_name": artifact_name,
+        "artifact_file": artifact_file,
+        "output_keys": [],
+        "freshness_runtime_epoch": result.freshness_runtime_epoch,
+        "status_projection_epoch": result.status_projection_epoch,
+        "response_state": result.response_state,
+        "reviewer_authority_outcome": result.reviewer_authority_outcome,
+        "suppression_reason": result.suppression_reason,
+        "current_scope_key": result.current_scope_key,
+        "current_scope_basis": result.current_scope_basis,
+        "actual_status_labels": delta["actual_status_labels"],
+        "desired_status_labels": delta["desired_status_labels"],
+        "labels_to_add": delta["labels_to_add"],
+        "labels_to_remove": delta["labels_to_remove"],
+        "projection_metadata": dict(result.projection_metadata),
+    }
+    payload["output_keys"] = sorted(payload.keys())
+    return payload
 
 
 def desired_labels_from_response_state(
     state_name: str,
     reason: str | None,
 ) -> tuple[set[str] | None, dict[str, str | None]]:
-    if state_name == "projection_failed":
-        return None, {"state": state_name, "reason": reason}
-    if state_name == "awaiting_reviewer_response":
-        return {STATUS_AWAITING_REVIEWER_RESPONSE_LABEL}, {"state": state_name, "reason": reason}
-    if state_name == "awaiting_contributor_response":
-        return {STATUS_AWAITING_CONTRIBUTOR_RESPONSE_LABEL}, {"state": state_name, "reason": reason}
-    if state_name == "awaiting_write_approval":
-        return {STATUS_AWAITING_WRITE_APPROVAL_LABEL}, {"state": state_name, "reason": reason}
-    return set(), {"state": state_name, "reason": reason}
+    from scripts.reviewer_bot_core.reviewer_response_policy import (
+        to_reviewer_response_decision,
+    )
+
+    try:
+        desired = desired_status_labels_from_decision(
+            to_reviewer_response_decision({"response_state": state_name, "reason": reason})
+        )
+    except RuntimeError:
+        raise
+    return set(desired), {"state": state_name, "reason": reason}

--- a/tests/contract/reviewer_bot/test_preview_workflow_contracts.py
+++ b/tests/contract/reviewer_bot/test_preview_workflow_contracts.py
@@ -20,7 +20,12 @@ def test_preview_workflow_exposes_exact_dispatch_inputs_and_actions():
     workflow_dispatch = on_block["workflow_dispatch"]
     assert sorted(workflow_dispatch["inputs"]) == ["action", "issue_number", "validation_nonce"]
     action_input = workflow_dispatch["inputs"]["action"]
-    assert action_input["options"] == ["preview-check-overdue", "preview-reviewer-board"]
+    assert action_input["options"] == [
+        "preview-check-overdue",
+        "preview-status-label-projection",
+        "preview-issue314-state-health",
+        "preview-reviewer-board",
+    ]
     assert workflow_dispatch["inputs"]["issue_number"]["required"] is True
     assert workflow_dispatch["inputs"]["issue_number"]["type"] == "string"
     assert workflow_dispatch["inputs"]["validation_nonce"]["required"] is True
@@ -47,6 +52,11 @@ def test_preview_workflow_run_name_and_env_contract_are_frozen():
     assert "MANUAL_ACTION: ${{ github.event.inputs.action }}" in text
     assert "ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}" in text
     assert "VALIDATION_NONCE: ${{ github.event.inputs.validation_nonce }}" in text
+    assert "EVALUATED_REPO: ${{ github.repository }}" in text
+    assert "HEAD_SHA: ${{ github.sha }}" in text
+    assert "EVALUATED_REF: ${{ github.sha }}" in text
+    assert "GITHUB_RUN_ID: ${{ github.run_id }}" in text
+    assert "GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}" in text
     assert "WORKFLOW_RUN_ID: ${{ github.run_id }}" in text
     assert "WORKFLOW_NAME: ${{ github.workflow }}" in text
     assert "WORKFLOW_JOB_NAME: ${{ github.job }}" in text

--- a/tests/contract/reviewer_bot/test_workflow_artifact_contracts.py
+++ b/tests/contract/reviewer_bot/test_workflow_artifact_contracts.py
@@ -9,7 +9,15 @@ import yaml
 
 pytestmark = pytest.mark.contract
 
-from scripts.reviewer_bot_lib import reconcile_payloads
+from scripts.reviewer_bot_core.reviewer_response_policy import (
+    to_reviewer_response_decision,
+)
+from scripts.reviewer_bot_lib import (
+    issue314_state_health,
+    maintenance,
+    reconcile_payloads,
+    reviews_projection,
+)
 
 
 def _load_fixture_payload(relative_path: str) -> dict:
@@ -339,3 +347,158 @@ def test_validate_workflow_run_artifact_identity_requires_successful_conclusion(
 
     with pytest.raises(RuntimeError, match="did not conclude successfully"):
         reconcile_payloads.validate_workflow_run_artifact_identity(bot, payload)
+
+
+def test_status_projection_preview_output_carries_standard_artifact_identity():
+    decision = to_reviewer_response_decision(
+        {
+            "issue_number": 264,
+            "response_state": "reviewer_reassignment_needed",
+            "current_scope_key": "scope",
+            "current_scope_basis": "reminder_cadence_exhausted",
+            "suppression_reason": "legacy_duplicate_reminders_exhausted",
+        }
+    )
+    projection = reviews_projection.derive_status_label_projection(
+        reviews_projection.StatusLabelProjectionInput(
+            issue_number=264,
+            issue_state="open",
+            actual_labels=("status: awaiting reviewer response",),
+            reviewer_response=decision,
+            reviewer_authority_outcome="tracked_reviewer_confirmed",
+            freshness_runtime_epoch="freshness_v15",
+            status_projection_epoch="status_projection_v2",
+        )
+    )
+
+    payload = reviews_projection.status_label_projection_output(
+        projection,
+        preview_action="preview-status-label-projection",
+        validation_nonce="nonce",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id="1",
+        run_attempt="1",
+        artifact_name="reviewer-bot-preview-output-1-attempt-1",
+        artifact_file="preview-output.json",
+    )
+
+    for key in [
+        "schema_version",
+        "preview_action",
+        "issue_number",
+        "validation_nonce",
+        "workflow_path",
+        "evaluated_repo",
+        "head_sha",
+        "evaluated_ref",
+        "run_id",
+        "run_attempt",
+        "artifact_name",
+        "artifact_file",
+        "output_keys",
+    ]:
+        assert key in payload
+    assert payload["output_keys"] == sorted(payload.keys())
+
+
+def test_status_label_repair_summary_carries_standard_artifact_identity():
+    summary = maintenance.StatusLabelRepairSummary(
+        schema_version=1,
+        repair_action="repair-review-status-labels",
+        issue_number=264,
+        issue_numbers=(264,),
+        validation_nonce="nonce",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-sweeper-repair.yml",
+        run_id="2",
+        run_attempt="1",
+        artifact_name="reviewer-bot-repair-output-2-attempt-1",
+        artifact_file="repair-summary.json",
+        output_keys=(),
+        status_projection_epoch="status_projection_v2",
+        before=(),
+        after=(),
+        labels_added=(),
+        labels_removed=(),
+        state_save_attempted=False,
+        tracked_state_mutations_attempted=False,
+        touched_projection_attempted=False,
+        target_collection_mode="issue_scoped",
+        result="already_aligned",
+    )
+    payload = summary.to_output()
+
+    assert payload["repair_action"] == "repair-review-status-labels"
+    assert payload["artifact_name"] == "reviewer-bot-repair-output-2-attempt-1"
+    assert payload["artifact_file"] == "repair-summary.json"
+    assert payload["output_keys"] == sorted(payload.keys())
+
+
+def test_issue314_preview_and_repair_outputs_carry_standard_artifact_identity():
+    preview = issue314_state_health.Issue314StateHealthSummary(
+        schema_version=1,
+        preview_action="preview-issue314-state-health",
+        state_issue_number=314,
+        issue_number=314,
+        validation_nonce="nonce",
+        active_review_row_count=0,
+        active_rows_inspected=(),
+        row_inventory=(),
+        row_health_summary={},
+        status_projection_summary={},
+        rows_repairable=(),
+        rows_operator_action_required=(),
+        rows_blocked=(),
+        pr264_no_ping_status="pass",
+        lock_attempted=False,
+        state_save_attempted=False,
+        tracked_state_mutations_attempted=False,
+        touched_projection_attempted=False,
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id="3",
+        run_attempt="1",
+        artifact_name="reviewer-bot-preview-output-3-attempt-1",
+        artifact_file="preview-output.json",
+        output_keys=(),
+    ).to_output()
+    repair = issue314_state_health.Issue314StateHealthRepairSummary(
+        schema_version=1,
+        repair_action="repair-issue314-state-health",
+        state_issue_number=314,
+        issue_number=314,
+        validation_nonce="nonce",
+        target_collection_mode="global_issue314_state_health",
+        active_rows_inspected=(),
+        rows_repaired=(),
+        rows_removed_closed=(),
+        rows_operator_action_required=(),
+        rows_blocked=(),
+        status_labels_changed=(),
+        reviewer_facing_reminder_posts_attempted=0,
+        manual_issue314_edit_status="not_attempted",
+        state_store_mutation_mode="not_required",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-sweeper-repair.yml",
+        run_id="4",
+        run_attempt="1",
+        artifact_name="reviewer-bot-repair-output-4-attempt-1",
+        artifact_file="issue314-state-health-repair-summary.json",
+        output_keys=(),
+        result="already_healthy",
+    ).to_output()
+
+    assert preview["preview_action"] == "preview-issue314-state-health"
+    assert preview["output_keys"] == sorted(preview.keys())
+    assert repair["repair_action"] == "repair-issue314-state-health"
+    assert repair["target_collection_mode"] == "global_issue314_state_health"
+    assert repair["output_keys"] == sorted(repair.keys())

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -430,6 +430,34 @@ def test_workflow_summaries_and_runbook_references_exist():
     assert "docs/reviewer-bot-review-freshness-operator-runbook.md" in reconcile
 
 
+def test_sweeper_repair_workflow_exposes_nonce_identity_and_repair_artifacts():
+    workflow_path = ".github/workflows/reviewer-bot-sweeper-repair.yml"
+    text = Path(workflow_path).read_text(encoding="utf-8")
+    workflow = yaml.safe_load(text)
+    on_block = workflow.get("on", workflow.get(True))
+    inputs = on_block["workflow_dispatch"]["inputs"]
+
+    assert workflow["run-name"] == "repair ${{ github.event.inputs.action }} issue ${{ github.event.inputs.issue_number }} nonce ${{ github.event.inputs.validation_nonce }}"
+    assert inputs["action"]["options"] == [
+        "sync-members",
+        "show-state",
+        "check-overdue",
+        "repair-review-status-labels",
+        "repair-issue314-state-health",
+    ]
+    assert inputs["validation_nonce"]["type"] == "string"
+    assert "VALIDATION_NONCE: ${{ github.event.inputs.validation_nonce }}" in text
+    assert "EVALUATED_REPO: ${{ github.repository }}" in text
+    assert "HEAD_SHA: ${{ github.sha }}" in text
+    assert "EVALUATED_REF: ${{ github.sha }}" in text
+    assert "GITHUB_RUN_ID: ${{ github.run_id }}" in text
+    assert "GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}" in text
+    assert "REPAIR_SUMMARY_PATH: ${{ runner.temp }}/reviewer-bot-repair-output-${{ github.run_id }}-attempt-${{ github.run_attempt }}/repair-summary.json" in text
+    assert "ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH: ${{ runner.temp }}/reviewer-bot-repair-output-${{ github.run_id }}-attempt-${{ github.run_attempt }}/issue314-state-health-repair-summary.json" in text
+    assert "actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808" in text
+    assert "if-no-files-found: error" in text
+
+
 def test_reconcile_workflow_selects_at_most_one_recursive_json_payload():
     workflow_text = Path(".github/workflows/reviewer-bot-reconcile.yml").read_text(encoding="utf-8")
 

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -438,6 +438,12 @@ def test_sweeper_repair_workflow_exposes_nonce_identity_and_repair_artifacts():
     inputs = on_block["workflow_dispatch"]["inputs"]
 
     assert workflow["run-name"] == "repair ${{ github.event.inputs.action }} issue ${{ github.event.inputs.issue_number }} nonce ${{ github.event.inputs.validation_nonce }}"
+    upload_step = next(
+        step
+        for step in workflow["jobs"]["reviewer-bot-sweeper-repair"]["steps"]
+        if step["name"] == "Upload repair artifact"
+    )
+    assert upload_step["if"] == "${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.action == 'repair-review-status-labels' || github.event.inputs.action == 'repair-issue314-state-health') }}"
     assert inputs["action"]["options"] == [
         "sync-members",
         "show-state",

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -446,6 +446,7 @@ def test_sweeper_repair_workflow_exposes_nonce_identity_and_repair_artifacts():
         "repair-issue314-state-health",
     ]
     assert inputs["validation_nonce"]["type"] == "string"
+    assert inputs["validation_nonce"]["required"] is True
     assert "VALIDATION_NONCE: ${{ github.event.inputs.validation_nonce }}" in text
     assert "EVALUATED_REPO: ${{ github.repository }}" in text
     assert "HEAD_SHA: ${{ github.sha }}" in text

--- a/tests/integration/reviewer_bot/test_app_execution.py
+++ b/tests/integration/reviewer_bot/test_app_execution.py
@@ -732,7 +732,7 @@ def test_bootstrapped_runtime_pr_metadata_closed_executes_real_status_label_proj
     assert runtime.ACTIVE_LEASE_CONTEXT is None
 
 
-def test_bootstrapped_runtime_workflow_dispatch_repair_status_labels_uses_real_projection_path(monkeypatch):
+def test_bootstrapped_runtime_workflow_dispatch_repair_status_labels_uses_real_projection_path(monkeypatch, tmp_path):
     state = make_state()
     runtime, label_ops = _configure_bootstrapped_runtime_with_real_status_projection(
         monkeypatch, state, issue_state="open"
@@ -741,11 +741,17 @@ def test_bootstrapped_runtime_workflow_dispatch_repair_status_labels_uses_real_p
     monkeypatch.setenv("EVENT_NAME", "workflow_dispatch")
     monkeypatch.setenv("EVENT_ACTION", "")
     monkeypatch.setenv("MANUAL_ACTION", "repair-review-status-labels")
+    monkeypatch.setenv("VALIDATION_NONCE", "repair-nonce")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "rustfoundation/safety-critical-rust-coding-guidelines")
+    monkeypatch.setenv("GITHUB_RUN_ID", "9001")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "1")
+    monkeypatch.setenv("GITHUB_SHA", "workflow-head")
+    monkeypatch.setenv("REPAIR_SUMMARY_PATH", str(tmp_path / "repair-summary.json"))
 
     result = reviewer_bot.execute_run(reviewer_bot.build_event_context(runtime), runtime)
 
     assert result.exit_code == 0
-    assert result.state_changed is True
+    assert result.state_changed is False
     assert label_ops == [("remove", STATUS_AWAITING_REVIEWER_RESPONSE_LABEL)]
     assert runtime.ACTIVE_LEASE_CONTEXT is None
 

--- a/tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py
+++ b/tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py
@@ -122,3 +122,58 @@ def test_execute_run_preview_issue314_state_health_is_read_only_and_inspects_act
     assert payload["artifact_name"] == "reviewer-bot-preview-output-999-attempt-4"
     assert payload["artifact_file"] == "preview-output.json"
     assert payload["output_keys"] == sorted(payload.keys())
+
+
+def test_execute_run_preview_issue314_state_health_blocks_unavailable_live_rows(
+    monkeypatch,
+    capsys,
+):
+    harness = AppHarness(monkeypatch)
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="preview-issue314-state-health",
+        ISSUE_NUMBER=314,
+        VALIDATION_NONCE="nonce-issue314-preview",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="1000",
+        GITHUB_RUN_ATTEMPT="1",
+        STATE_ISSUE_NUMBER=314,
+    )
+    state = make_state()
+    make_tracked_review_state(
+        state,
+        264,
+        reviewer="iglesias",
+        assigned_at="2026-02-10T17:20:07Z",
+        active_cycle_started_at="2026-02-10T17:20:07Z",
+    )
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/264",
+        status_code=502,
+        payload={"message": "bad gateway"},
+    ).add_request(
+        "GET",
+        "issues/264/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[],
+    )
+    harness.runtime.github.stub(routes)
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_lock(acquire=lambda: (_ for _ in ()).throw(AssertionError("preview should not acquire lock")))
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("preview should not save state")))
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("preview should not sync labels")))
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["active_rows_inspected"] == [264]
+    assert payload["rows_blocked"] == [264]
+    assert payload["row_inventory"][0]["blockers"] == [
+        "live_snapshot_unavailable",
+        "reviewer_response_unavailable",
+        "status_projection_unavailable",
+    ]

--- a/tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py
+++ b/tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py
@@ -1,0 +1,124 @@
+import json
+
+import pytest
+
+from tests.fixtures.app_harness import AppHarness
+from tests.fixtures.reviewer_bot import (
+    make_state,
+    make_tracked_review_state,
+    pull_request_payload,
+    review_payload,
+)
+from tests.fixtures.reviewer_bot_builders import accept_reviewer_review
+from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
+
+pytestmark = pytest.mark.integration
+
+
+def test_execute_run_preview_issue314_state_health_is_read_only_and_inspects_active_rows(
+    monkeypatch,
+    capsys,
+):
+    harness = AppHarness(monkeypatch)
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="preview-issue314-state-health",
+        ISSUE_NUMBER=314,
+        VALIDATION_NONCE="nonce-issue314-preview",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="999",
+        GITHUB_RUN_ATTEMPT="4",
+        STATE_ISSUE_NUMBER=314,
+    )
+
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        264,
+        reviewer="iglesias",
+        assigned_at="2026-02-10T17:20:07Z",
+        active_cycle_started_at="2026-02-10T17:20:07Z",
+    )
+    accept_reviewer_review(
+        review,
+        semantic_key="pull_request_review:77",
+        timestamp="2026-03-18T01:09:05Z",
+        actor="iglesias",
+        reviewed_head_sha="head-old",
+    )
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/264",
+        status_code=200,
+        payload={
+            "number": 264,
+            "state": "open",
+            "pull_request": {},
+            "labels": [{"name": "status: awaiting reviewer response"}],
+        },
+    ).add_request(
+        "GET",
+        "pulls/264",
+        status_code=200,
+        payload={
+            **pull_request_payload(264, head_sha="head-live", author="manhatsu"),
+            "requested_reviewers": [],
+        },
+    ).add_pull_request_reviews(
+        264,
+        [
+            review_payload(
+                501,
+                state="APPROVED",
+                submitted_at="2026-03-18T12:10:42Z",
+                commit_id="head-live",
+                author="plaindocs",
+            )
+        ],
+    ).add_request(
+        "GET",
+        "issues/264/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[
+            {
+                "id": 9001,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-13T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\ntransition period",
+            },
+            {
+                "id": 9002,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-14T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\ntransition period",
+            },
+        ],
+    )
+    harness.runtime.github.stub(routes)
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="push": "granted"
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_lock(acquire=lambda: (_ for _ in ()).throw(AssertionError("preview should not acquire lock")))
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("preview should not save state")))
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("preview should not sync labels")))
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["preview_action"] == "preview-issue314-state-health"
+    assert payload["state_issue_number"] == 314
+    assert payload["issue_number"] == 314
+    assert payload["active_review_row_count"] == 1
+    assert payload["active_rows_inspected"] == [264]
+    assert payload["rows_operator_action_required"] == [264]
+    assert payload["rows_blocked"] == []
+    assert payload["pr264_no_ping_status"] == "pass"
+    assert payload["lock_attempted"] is False
+    assert payload["state_save_attempted"] is False
+    assert payload["tracked_state_mutations_attempted"] is False
+    assert payload["touched_projection_attempted"] is False
+    assert payload["artifact_name"] == "reviewer-bot-preview-output-999-attempt-4"
+    assert payload["artifact_file"] == "preview-output.json"
+    assert payload["output_keys"] == sorted(payload.keys())

--- a/tests/integration/reviewer_bot/test_app_preview_overdue.py
+++ b/tests/integration/reviewer_bot/test_app_preview_overdue.py
@@ -114,7 +114,7 @@ def test_execute_run_preview_check_overdue_uses_frozen_pr264_operational_project
     assert payload["reviewer_authority_outcome"] == "tracked_reviewer_confirmed"
     assert payload["suppression_reason"] == "legacy_duplicate_reminders_exhausted"
     assert payload["current_scope_key"] == "reviewer=iglesias|head=head-live|cycle=2026-02-10T17:20:07Z|anchor=2026-02-10T17:20:07Z"
-    assert payload["current_scope_basis"] == "active_cycle_started_at"
+    assert payload["current_scope_basis"] == "reminder_cadence_exhausted"
     assert payload["would_post_warning"] is False
     assert payload["would_post_transition"] is False
     assert payload["lock_attempted"] is False

--- a/tests/integration/reviewer_bot/test_app_preview_overdue.py
+++ b/tests/integration/reviewer_bot/test_app_preview_overdue.py
@@ -27,6 +27,9 @@ def test_execute_run_preview_check_overdue_uses_frozen_pr264_operational_project
         ISSUE_NUMBER=264,
         VALIDATION_NONCE="nonce-pr264",
         GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="777",
+        GITHUB_RUN_ATTEMPT="2",
     )
 
     state = make_state()
@@ -94,25 +97,30 @@ def test_execute_run_preview_check_overdue_uses_frozen_pr264_operational_project
 
     assert result.exit_code == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload == {
-        "schema_version": 1,
-        "preview_action": "preview-check-overdue",
-        "issue_number": 264,
-        "validation_nonce": "nonce-pr264",
-        "head_sha": "workflow-head",
-        "workflow_path": ".github/workflows/reviewer-bot-preview.yml",
-        "response_state": "reviewer_reassignment_needed",
-        "reviewer_authority_outcome": "tracked_reviewer_confirmed",
-        "suppression_reason": "legacy_duplicate_reminders_exhausted",
-        "current_scope_key": "reviewer=iglesias|head=head-live|cycle=2026-02-10T17:20:07Z|anchor=2026-02-10T17:20:07Z",
-        "current_scope_basis": "active_cycle_started_at",
-        "would_post_warning": False,
-        "would_post_transition": False,
-        "lock_attempted": False,
-        "state_save_attempted": False,
-        "tracked_state_mutations_attempted": False,
-        "touched_projection_attempted": False,
-    }
+    assert payload["schema_version"] == 1
+    assert payload["preview_action"] == "preview-check-overdue"
+    assert payload["issue_number"] == 264
+    assert payload["validation_nonce"] == "nonce-pr264"
+    assert payload["evaluated_repo"] == "rustfoundation/safety-critical-rust-coding-guidelines"
+    assert payload["head_sha"] == "workflow-head"
+    assert payload["evaluated_ref"] == "workflow-head"
+    assert payload["workflow_path"] == ".github/workflows/reviewer-bot-preview.yml"
+    assert payload["run_id"] == "777"
+    assert payload["run_attempt"] == "2"
+    assert payload["artifact_name"] == "reviewer-bot-preview-output-777-attempt-2"
+    assert payload["artifact_file"] == "preview-output.json"
+    assert payload["output_keys"] == sorted(payload.keys())
+    assert payload["response_state"] == "reviewer_reassignment_needed"
+    assert payload["reviewer_authority_outcome"] == "tracked_reviewer_confirmed"
+    assert payload["suppression_reason"] == "legacy_duplicate_reminders_exhausted"
+    assert payload["current_scope_key"] == "reviewer=iglesias|head=head-live|cycle=2026-02-10T17:20:07Z|anchor=2026-02-10T17:20:07Z"
+    assert payload["current_scope_basis"] == "active_cycle_started_at"
+    assert payload["would_post_warning"] is False
+    assert payload["would_post_transition"] is False
+    assert payload["lock_attempted"] is False
+    assert payload["state_save_attempted"] is False
+    assert payload["tracked_state_mutations_attempted"] is False
+    assert payload["touched_projection_attempted"] is False
 
 
 def test_execute_run_preview_check_overdue_backfills_claim_cycle_from_assignment_guidance(monkeypatch, capsys):

--- a/tests/integration/reviewer_bot/test_app_preview_status_label_projection.py
+++ b/tests/integration/reviewer_bot/test_app_preview_status_label_projection.py
@@ -1,0 +1,122 @@
+import json
+
+import pytest
+
+from tests.fixtures.app_harness import AppHarness
+from tests.fixtures.reviewer_bot import (
+    make_state,
+    make_tracked_review_state,
+    pull_request_payload,
+    review_payload,
+)
+from tests.fixtures.reviewer_bot_builders import accept_reviewer_review
+from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
+
+pytestmark = pytest.mark.integration
+
+
+def test_execute_run_preview_status_label_projection_is_read_only_pr264_contract(monkeypatch, capsys):
+    harness = AppHarness(monkeypatch)
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="preview-status-label-projection",
+        ISSUE_NUMBER=264,
+        VALIDATION_NONCE="nonce-pr264-projection",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="777",
+        GITHUB_RUN_ATTEMPT="2",
+    )
+
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        264,
+        reviewer="iglesias",
+        assigned_at="2026-02-10T17:20:07Z",
+        active_cycle_started_at="2026-02-10T17:20:07Z",
+    )
+    accept_reviewer_review(
+        review,
+        semantic_key="pull_request_review:77",
+        timestamp="2026-03-18T01:09:05Z",
+        actor="iglesias",
+        reviewed_head_sha="head-old",
+    )
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/264",
+        status_code=200,
+        payload={
+            "number": 264,
+            "state": "open",
+            "pull_request": {},
+            "labels": [{"name": "status: awaiting reviewer response"}],
+        },
+    ).add_request(
+        "GET",
+        "pulls/264",
+        status_code=200,
+        payload={
+            **pull_request_payload(264, head_sha="head-live", author="manhatsu"),
+            "requested_reviewers": [],
+        },
+    ).add_pull_request_reviews(
+        264,
+        [
+            review_payload(
+                501,
+                state="APPROVED",
+                submitted_at="2026-03-18T12:10:42Z",
+                commit_id="head-live",
+                author="plaindocs",
+            )
+        ],
+    ).add_request(
+        "GET",
+        "issues/264/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[
+            {
+                "id": 9001,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-13T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\ntransition period",
+            },
+            {
+                "id": 9002,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-14T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\ntransition period",
+            },
+        ],
+    )
+    harness.runtime.github.stub(routes)
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_lock(acquire=lambda: (_ for _ in ()).throw(AssertionError("preview should not acquire lock")))
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("preview should not save state")))
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("preview should not sync labels")))
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="push": "granted"
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["preview_action"] == "preview-status-label-projection"
+    assert payload["response_state"] == "reviewer_reassignment_needed"
+    assert payload["reviewer_authority_outcome"] == "tracked_reviewer_confirmed"
+    assert payload["suppression_reason"] == "legacy_duplicate_reminders_exhausted"
+    assert payload["current_scope_basis"] == "active_cycle_started_at"
+    assert payload["actual_status_labels"] == ["status: awaiting reviewer response"]
+    assert payload["desired_status_labels"] == ["status: reviewer reassignment needed"]
+    assert payload["labels_to_add"] == ["status: reviewer reassignment needed"]
+    assert payload["labels_to_remove"] == ["status: awaiting reviewer response"]
+    assert payload["projection_metadata"]["source"] == "reviewer_response_decision"
+    assert payload["lock_attempted"] is False
+    assert payload["state_save_attempted"] is False
+    assert payload["tracked_state_mutations_attempted"] is False
+    assert payload["touched_projection_attempted"] is False
+    assert payload["artifact_name"] == "reviewer-bot-preview-output-777-attempt-2"
+    assert payload["artifact_file"] == "preview-output.json"
+    assert payload["output_keys"] == sorted(payload.keys())

--- a/tests/integration/reviewer_bot/test_app_preview_status_label_projection.py
+++ b/tests/integration/reviewer_bot/test_app_preview_status_label_projection.py
@@ -107,7 +107,7 @@ def test_execute_run_preview_status_label_projection_is_read_only_pr264_contract
     assert payload["response_state"] == "reviewer_reassignment_needed"
     assert payload["reviewer_authority_outcome"] == "tracked_reviewer_confirmed"
     assert payload["suppression_reason"] == "legacy_duplicate_reminders_exhausted"
-    assert payload["current_scope_basis"] == "active_cycle_started_at"
+    assert payload["current_scope_basis"] == "reminder_cadence_exhausted"
     assert payload["actual_status_labels"] == ["status: awaiting reviewer response"]
     assert payload["desired_status_labels"] == ["status: reviewer reassignment needed"]
     assert payload["labels_to_add"] == ["status: reviewer reassignment needed"]

--- a/tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py
+++ b/tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from scripts.reviewer_bot_lib import app
 from tests.fixtures.app_harness import AppHarness
 from tests.fixtures.reviewer_bot import make_state, make_tracked_review_state
 from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
@@ -31,6 +32,7 @@ def test_execute_run_repair_issue314_state_health_removes_closed_rows_through_st
     monkeypatch.setenv("ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH", str(summary_path))
 
     state = make_state()
+    state["status_projection_epoch"] = "stale_projection_epoch"
     make_tracked_review_state(
         state,
         42,
@@ -59,6 +61,11 @@ def test_execute_run_repair_issue314_state_health_removes_closed_rows_through_st
     harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
     harness.stub_save_state(lambda current: saved.append(json.loads(json.dumps(current))) or True)
     harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("issue314 repair should not broad-sync labels")))
+    monkeypatch.setattr(
+        app,
+        "collect_status_projection_repair_items",
+        lambda bot, state: (_ for _ in ()).throw(AssertionError("issue314 repair broadened through epoch repair")),
+    )
 
     result = harness.run_execute()
 
@@ -77,6 +84,7 @@ def test_execute_run_repair_issue314_state_health_removes_closed_rows_through_st
     assert payload["output_keys"] == sorted(payload.keys())
     assert saved
     assert "42" not in saved[-1]["active_reviews"]
+    assert saved[-1]["status_projection_epoch"] == "stale_projection_epoch"
 
 
 def test_execute_run_repair_issue314_state_health_emits_summary_only_after_state_save(

--- a/tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py
+++ b/tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+
+from tests.fixtures.app_harness import AppHarness
+from tests.fixtures.reviewer_bot import make_state, make_tracked_review_state
+from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
+
+pytestmark = pytest.mark.integration
+
+
+def test_execute_run_repair_issue314_state_health_removes_closed_rows_through_state_store(
+    monkeypatch,
+    tmp_path,
+):
+    harness = AppHarness(monkeypatch)
+    summary_path = tmp_path / "repair" / "issue314-state-health-repair-summary.json"
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="repair-issue314-state-health",
+        ISSUE_NUMBER=314,
+        VALIDATION_NONCE="nonce-issue314-repair",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="1001",
+        GITHUB_RUN_ATTEMPT="5",
+        STATE_ISSUE_NUMBER=314,
+    )
+    harness.stub_lock()
+    monkeypatch.setenv("ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH", str(summary_path))
+
+    state = make_state()
+    make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-02-10T17:20:07Z",
+        active_cycle_started_at="2026-02-10T17:20:07Z",
+    )
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/42",
+        status_code=200,
+        payload={
+            "number": 42,
+            "state": "closed",
+            "pull_request": {},
+            "labels": [{"name": "status: awaiting reviewer response"}],
+        },
+    ).add_request(
+        "GET",
+        "issues/42/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[],
+    )
+    harness.runtime.github.stub(routes)
+    saved = []
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_save_state(lambda current: saved.append(json.loads(json.dumps(current))) or True)
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("issue314 repair should not broad-sync labels")))
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert payload["repair_action"] == "repair-issue314-state-health"
+    assert payload["state_issue_number"] == 314
+    assert payload["issue_number"] == 314
+    assert payload["target_collection_mode"] == "global_issue314_state_health"
+    assert payload["active_rows_inspected"] == [42]
+    assert payload["rows_removed_closed"] == [42]
+    assert payload["reviewer_facing_reminder_posts_attempted"] == 0
+    assert payload["manual_issue314_edit_status"] == "not_attempted"
+    assert payload["artifact_name"] == "reviewer-bot-repair-output-1001-attempt-5"
+    assert payload["artifact_file"] == "issue314-state-health-repair-summary.json"
+    assert payload["output_keys"] == sorted(payload.keys())
+    assert saved
+    assert "42" not in saved[-1]["active_reviews"]

--- a/tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py
+++ b/tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py
@@ -77,3 +77,80 @@ def test_execute_run_repair_issue314_state_health_removes_closed_rows_through_st
     assert payload["output_keys"] == sorted(payload.keys())
     assert saved
     assert "42" not in saved[-1]["active_reviews"]
+
+
+def test_execute_run_repair_issue314_state_health_emits_summary_only_after_state_save(
+    monkeypatch,
+    tmp_path,
+):
+    harness = AppHarness(monkeypatch)
+    summary_path = tmp_path / "repair" / "issue314-state-health-repair-summary.json"
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="repair-issue314-state-health",
+        ISSUE_NUMBER=314,
+        VALIDATION_NONCE="nonce-issue314-repair",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="1002",
+        GITHUB_RUN_ATTEMPT="1",
+        STATE_ISSUE_NUMBER=314,
+    )
+    harness.stub_lock()
+    monkeypatch.setenv("ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH", str(summary_path))
+
+    state = make_state()
+    make_tracked_review_state(
+        state,
+        42,
+        reviewer="alice",
+        assigned_at="2026-02-10T17:20:07Z",
+        active_cycle_started_at="2026-02-10T17:20:07Z",
+    )
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/42",
+        status_code=200,
+        payload={"number": 42, "state": "closed", "pull_request": {}, "labels": []},
+    ).add_request(
+        "GET",
+        "issues/42/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[],
+    )
+    harness.runtime.github.stub(routes)
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_save_state(lambda current: False)
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("issue314 repair should not broad-sync labels")))
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 1
+    assert not summary_path.exists()
+
+
+def test_execute_run_repair_issue314_state_health_requires_identity(monkeypatch, tmp_path):
+    harness = AppHarness(monkeypatch)
+    summary_path = tmp_path / "repair" / "issue314-state-health-repair-summary.json"
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="repair-issue314-state-health",
+        ISSUE_NUMBER=314,
+        VALIDATION_NONCE="",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="1003",
+        GITHUB_RUN_ATTEMPT="1",
+        STATE_ISSUE_NUMBER=314,
+    )
+    harness.stub_lock()
+    monkeypatch.setenv("ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH", str(summary_path))
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: make_state())
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("identity-blocked repair should not save state")))
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 1
+    assert not summary_path.exists()

--- a/tests/integration/reviewer_bot/test_app_repair_status_labels.py
+++ b/tests/integration/reviewer_bot/test_app_repair_status_labels.py
@@ -1,0 +1,142 @@
+import json
+
+import pytest
+
+from scripts.reviewer_bot_lib import app
+from tests.fixtures.app_harness import AppHarness
+from tests.fixtures.reviewer_bot import (
+    make_state,
+    make_tracked_review_state,
+    pull_request_payload,
+    review_payload,
+)
+from tests.fixtures.reviewer_bot_builders import accept_reviewer_review
+from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
+
+pytestmark = pytest.mark.integration
+
+
+def test_execute_run_targeted_status_label_repair_does_not_broaden_epoch_repair(
+    monkeypatch,
+    tmp_path,
+):
+    harness = AppHarness(monkeypatch)
+    repair_summary_path = tmp_path / "repair" / "repair-summary.json"
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="repair-review-status-labels",
+        ISSUE_NUMBER=264,
+        VALIDATION_NONCE="nonce-pr264-repair",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="888",
+        GITHUB_RUN_ATTEMPT="3",
+    )
+    harness.stub_lock()
+    monkeypatch.setenv("REPAIR_SUMMARY_PATH", str(repair_summary_path))
+
+    state = make_state(epoch="freshness_v15")
+    state["status_projection_epoch"] = "stale_projection_epoch"
+    review = make_tracked_review_state(
+        state,
+        264,
+        reviewer="iglesias",
+        assigned_at="2026-02-10T17:20:07Z",
+        active_cycle_started_at="2026-02-10T17:20:07Z",
+    )
+    accept_reviewer_review(
+        review,
+        semantic_key="pull_request_review:77",
+        timestamp="2026-03-18T01:09:05Z",
+        actor="iglesias",
+        reviewed_head_sha="head-old",
+    )
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/264",
+        status_code=200,
+        payload={
+            "number": 264,
+            "state": "open",
+            "pull_request": {},
+            "labels": [{"name": "status: awaiting reviewer response"}],
+        },
+    ).add_request(
+        "GET",
+        "pulls/264",
+        status_code=200,
+        payload={
+            **pull_request_payload(264, head_sha="head-live", author="manhatsu"),
+            "requested_reviewers": [],
+        },
+    ).add_pull_request_reviews(
+        264,
+        [
+            review_payload(
+                501,
+                state="APPROVED",
+                submitted_at="2026-03-18T12:10:42Z",
+                commit_id="head-live",
+                author="plaindocs",
+            )
+        ],
+    ).add_request(
+        "GET",
+        "issues/264/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[
+            {
+                "id": 9001,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-13T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\ntransition period",
+            },
+            {
+                "id": 9002,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-14T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\ntransition period",
+            },
+        ],
+    ).add_request(
+        "POST",
+        "labels",
+        status_code=422,
+        payload={"message": "already_exists"},
+    ).add_request(
+        "DELETE",
+        "issues/264/labels/status%3A%20awaiting%20reviewer%20response",
+        status_code=204,
+        payload=None,
+    ).add_request(
+        "POST",
+        "issues/264/labels",
+        status_code=200,
+        payload={"labels": ["status: reviewer reassignment needed"]},
+    )
+    harness.runtime.github.stub(routes)
+    harness.runtime.github.get_user_permission_status = lambda username, required_permission="push": "granted"
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("targeted repair should not save epoch state")))
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("targeted repair should not enter broad sync")))
+    monkeypatch.setattr(
+        app,
+        "collect_status_projection_repair_items",
+        lambda bot, state: (_ for _ in ()).throw(AssertionError("targeted repair broadened")),
+    )
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    payload = json.loads(repair_summary_path.read_text(encoding="utf-8"))
+    assert payload["repair_action"] == "repair-review-status-labels"
+    assert payload["issue_number"] == 264
+    assert payload["issue_numbers"] == [264]
+    assert payload["target_collection_mode"] == "issue_scoped"
+    assert payload["labels_added"] == ["status: reviewer reassignment needed"]
+    assert payload["labels_removed"] == ["status: awaiting reviewer response"]
+    assert payload["artifact_name"] == "reviewer-bot-repair-output-888-attempt-3"
+    assert payload["artifact_file"] == "repair-summary.json"
+    assert payload["output_keys"] == sorted(payload.keys())
+    assert state["status_projection_epoch"] == "stale_projection_epoch"

--- a/tests/integration/reviewer_bot/test_app_repair_status_labels.py
+++ b/tests/integration/reviewer_bot/test_app_repair_status_labels.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from scripts.reviewer_bot_lib import app
+from scripts.reviewer_bot_lib import app, maintenance
 from tests.fixtures.app_harness import AppHarness
 from tests.fixtures.reviewer_bot import (
     make_state,
@@ -140,3 +140,38 @@ def test_execute_run_targeted_status_label_repair_does_not_broaden_epoch_repair(
     assert payload["artifact_file"] == "repair-summary.json"
     assert payload["output_keys"] == sorted(payload.keys())
     assert state["status_projection_epoch"] == "stale_projection_epoch"
+
+
+def test_execute_run_targeted_status_label_repair_fails_closed_without_summary(
+    monkeypatch,
+    tmp_path,
+):
+    harness = AppHarness(monkeypatch)
+    repair_summary_path = tmp_path / "repair" / "repair-summary.json"
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="repair-review-status-labels",
+        ISSUE_NUMBER=264,
+        VALIDATION_NONCE="nonce-pr264-repair",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="889",
+        GITHUB_RUN_ATTEMPT="1",
+    )
+    harness.stub_lock()
+    monkeypatch.setenv("REPAIR_SUMMARY_PATH", str(repair_summary_path))
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: make_state())
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("blocked repair should not save state")))
+    monkeypatch.setattr(
+        maintenance.reviews,
+        "project_status_label_projection_for_item",
+        lambda bot, issue_number, state: (_ for _ in ()).throw(
+            RuntimeError("status_label_projection_blocked:projection_failed")
+        ),
+    )
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 1
+    assert not repair_summary_path.exists()

--- a/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
+++ b/tests/integration/reviewer_bot/test_app_reviewer_board_preview.py
@@ -180,6 +180,9 @@ def test_execute_run_preview_reviewer_board_keeps_pr264_alternate_approval_proje
         ISSUE_NUMBER=264,
         VALIDATION_NONCE="board-preview-pr264",
         GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="1004",
+        GITHUB_RUN_ATTEMPT="1",
     )
     monkeypatch.setattr(harness.runtime, "_reviewer_board_project_metadata", None, raising=False)
 
@@ -233,24 +236,29 @@ def test_execute_run_preview_reviewer_board_keeps_pr264_alternate_approval_proje
 
     assert result.exit_code == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload == {
-        "schema_version": 1,
-        "preview_action": "preview-reviewer-board",
-        "issue_number": 264,
-        "validation_nonce": "board-preview-pr264",
-        "head_sha": "workflow-head",
-        "workflow_path": ".github/workflows/reviewer-bot-preview.yml",
-        "response_state": "reviewer_reassignment_needed",
-        "reviewer_authority_outcome": "tracked_reviewer_confirmed",
-        "suppression_reason": "transition_notice_sent",
-        "current_scope_key": "reviewer=iglesias|head=head-live|cycle=2026-02-10T17:20:07Z|anchor=2026-02-10T17:20:07Z",
-        "current_scope_basis": "active_cycle_started_at",
-        "would_post_warning": False,
-        "would_post_transition": False,
-        "lock_attempted": False,
-        "state_save_attempted": False,
-        "tracked_state_mutations_attempted": False,
-        "touched_projection_attempted": False,
-        "board_attention": "Transition Notice Sent",
-        "board_waiting_since": "2026-02-10",
-    }
+    assert payload["schema_version"] == 1
+    assert payload["preview_action"] == "preview-reviewer-board"
+    assert payload["issue_number"] == 264
+    assert payload["validation_nonce"] == "board-preview-pr264"
+    assert payload["evaluated_repo"] == "rustfoundation/safety-critical-rust-coding-guidelines"
+    assert payload["head_sha"] == "workflow-head"
+    assert payload["evaluated_ref"] == "workflow-head"
+    assert payload["workflow_path"] == ".github/workflows/reviewer-bot-preview.yml"
+    assert payload["run_id"] == "1004"
+    assert payload["run_attempt"] == "1"
+    assert payload["artifact_name"] == "reviewer-bot-preview-output-1004-attempt-1"
+    assert payload["artifact_file"] == "preview-output.json"
+    assert payload["response_state"] == "reviewer_reassignment_needed"
+    assert payload["reviewer_authority_outcome"] == "tracked_reviewer_confirmed"
+    assert payload["suppression_reason"] == "transition_notice_sent"
+    assert payload["current_scope_key"] == "reviewer=iglesias|head=head-live|cycle=2026-02-10T17:20:07Z|anchor=2026-02-10T17:20:07Z"
+    assert payload["current_scope_basis"] == "reminder_cadence_exhausted"
+    assert payload["would_post_warning"] is False
+    assert payload["would_post_transition"] is False
+    assert payload["lock_attempted"] is False
+    assert payload["state_save_attempted"] is False
+    assert payload["tracked_state_mutations_attempted"] is False
+    assert payload["touched_projection_attempted"] is False
+    assert payload["board_attention"] == "Transition Notice Sent"
+    assert payload["board_waiting_since"] == "2026-02-10"
+    assert payload["output_keys"] == sorted(payload.keys())

--- a/tests/unit/reviewer_bot/test_app_event_intent.py
+++ b/tests/unit/reviewer_bot/test_app_event_intent.py
@@ -37,6 +37,19 @@ def test_classify_event_intent_preview_check_overdue_is_non_mutating(monkeypatch
     assert intent == runtime.EVENT_INTENT_NON_MUTATING_READONLY
 
 
+@pytest.mark.parametrize(
+    "manual_action",
+    ["preview-status-label-projection", "preview-issue314-state-health"],
+)
+def test_classify_event_intent_projection_previews_are_non_mutating(monkeypatch, manual_action):
+    runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.set_config_value("MANUAL_ACTION", manual_action)
+
+    intent = app.classify_event_intent(runtime, "workflow_dispatch", "")
+
+    assert intent == runtime.EVENT_INTENT_NON_MUTATING_READONLY
+
+
 def test_classify_event_intent_same_repo_review_is_read_only(monkeypatch):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     intent = app.classify_event_intent(runtime, "pull_request_review", "submitted")

--- a/tests/unit/reviewer_bot/test_issue314_state_health.py
+++ b/tests/unit/reviewer_bot/test_issue314_state_health.py
@@ -1,0 +1,203 @@
+import json
+
+import pytest
+
+from scripts.reviewer_bot_core.reviewer_response_policy import (
+    to_reviewer_response_decision,
+)
+from scripts.reviewer_bot_lib import issue314_state_health, reviews_projection
+from scripts.reviewer_bot_lib.reminder_comments import scan_reviewer_reminder_comments
+
+
+def _projection(issue_number: int, actual_labels: tuple[str, ...], state: str):
+    decision = to_reviewer_response_decision(
+        {
+            "issue_number": issue_number,
+            "current_reviewer": "iglesias",
+            "response_state": state,
+            "suppression_reason": "legacy_duplicate_reminders_exhausted"
+            if state == "reviewer_reassignment_needed"
+            else None,
+            "current_scope_key": "scope",
+            "current_scope_basis": "reminder_cadence_exhausted",
+        }
+    )
+    return decision, reviews_projection.derive_status_label_projection(
+        reviews_projection.StatusLabelProjectionInput(
+            issue_number=issue_number,
+            issue_state="open",
+            actual_labels=actual_labels,
+            reviewer_response=decision,
+            reviewer_authority_outcome="tracked_reviewer_confirmed",
+            freshness_runtime_epoch="freshness_v15",
+            status_projection_epoch="status_projection_v2",
+        )
+    )
+
+
+def test_issue314_classifier_marks_pr264_stale_label_as_operator_action_without_ping_risk():
+    decision, projection = _projection(
+        264,
+        ("status: awaiting reviewer response",),
+        "reviewer_reassignment_needed",
+    )
+    scan = scan_reviewer_reminder_comments(
+        [
+            {
+                "id": 1,
+                "created_at": "2026-04-13T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "user": {"login": "github-actions[bot]"},
+            },
+            {
+                "id": 2,
+                "created_at": "2026-04-14T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "user": {"login": "github-actions[bot]"},
+            },
+        ]
+    )
+    input = issue314_state_health.Issue314StateHealthClassificationInput(
+        state_issue_number=314,
+        validation_nonce="nonce",
+        active_review_rows=(
+            {
+                "issue_number": 264,
+                "review_data": {
+                    "current_reviewer": "iglesias",
+                    "active_head_sha": "7d8864fa0c00b5bf9da20dd66047f039a049fd8b",
+                },
+            },
+        ),
+        live_snapshots={
+            264: {
+                "number": 264,
+                "state": "open",
+                "pull_request": {},
+                "labels": [{"name": "status: awaiting reviewer response"}],
+            }
+        },
+        reviewer_responses={264: decision},
+        status_projections={264: projection},
+        reminder_scans={264: scan},
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id="1",
+        run_attempt="1",
+    )
+
+    summary = issue314_state_health.classify_issue314_state_health(input)
+    payload = summary.to_output()
+
+    assert payload["preview_action"] == "preview-issue314-state-health"
+    assert payload["issue_number"] == 314
+    assert payload["rows_operator_action_required"] == [264]
+    assert payload["rows_blocked"] == []
+    assert payload["pr264_no_ping_status"] == "pass"
+    row = payload["row_inventory"][0]
+    assert row["health_classification"] == "operator_action_required"
+    assert row["status_label_risk"] == "operator_visible_stale"
+    assert row["automated_reminder_risk"] is False
+    assert payload["output_keys"] == sorted(payload.keys())
+
+
+def test_issue314_classifier_blocks_rows_with_automated_reminder_risk():
+    decision, projection = _projection(42, (), "awaiting_reviewer_response")
+    input = issue314_state_health.Issue314StateHealthClassificationInput(
+        state_issue_number=314,
+        validation_nonce="nonce",
+        active_review_rows=({"issue_number": 42, "review_data": {"current_reviewer": "alice"}},),
+        live_snapshots={42: {"number": 42, "state": "open", "pull_request": {}, "labels": []}},
+        reviewer_responses={42: decision},
+        status_projections={42: projection},
+        reminder_scans={42: scan_reviewer_reminder_comments([])},
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id="1",
+        run_attempt="1",
+    )
+
+    summary = issue314_state_health.classify_issue314_state_health(input)
+
+    assert summary.rows_blocked == (42,)
+    assert summary.row_inventory[0].automated_reminder_risk is True
+    assert summary.row_inventory[0].status_label_risk == "blocked_unknown"
+
+
+def test_issue314_repair_summary_writer_requires_artifact_path(monkeypatch):
+    monkeypatch.delenv("ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH", raising=False)
+    summary = issue314_state_health.Issue314StateHealthRepairSummary(
+        schema_version=1,
+        repair_action="repair-issue314-state-health",
+        state_issue_number=314,
+        issue_number=314,
+        validation_nonce="nonce",
+        target_collection_mode="global_issue314_state_health",
+        active_rows_inspected=(264,),
+        rows_repaired=(),
+        rows_removed_closed=(),
+        rows_operator_action_required=(264,),
+        rows_blocked=(),
+        status_labels_changed=(),
+        reviewer_facing_reminder_posts_attempted=0,
+        manual_issue314_edit_status="not_attempted",
+        state_store_mutation_mode="not_required",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-sweeper-repair.yml",
+        run_id="1",
+        run_attempt="1",
+        artifact_name="reviewer-bot-repair-output-1-attempt-1",
+        artifact_file="issue314-state-health-repair-summary.json",
+        output_keys=(),
+        result="already_healthy",
+    )
+
+    with pytest.raises(RuntimeError, match="issue314_state_health_repair_summary_path_missing"):
+        issue314_state_health.emit_issue314_state_health_repair_summary(summary)
+
+
+def test_issue314_repair_summary_writer_emits_identity_fields(monkeypatch, tmp_path):
+    summary = issue314_state_health.Issue314StateHealthRepairSummary(
+        schema_version=1,
+        repair_action="repair-issue314-state-health",
+        state_issue_number=314,
+        issue_number=314,
+        validation_nonce="nonce",
+        target_collection_mode="global_issue314_state_health",
+        active_rows_inspected=(42, 264),
+        rows_repaired=(42,),
+        rows_removed_closed=(),
+        rows_operator_action_required=(264,),
+        rows_blocked=(),
+        status_labels_changed=(42,),
+        reviewer_facing_reminder_posts_attempted=0,
+        manual_issue314_edit_status="not_attempted",
+        state_store_mutation_mode="not_required",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-sweeper-repair.yml",
+        run_id="1",
+        run_attempt="2",
+        artifact_name="reviewer-bot-repair-output-1-attempt-2",
+        artifact_file="issue314-state-health-repair-summary.json",
+        output_keys=(),
+        result="changed",
+    )
+    path = tmp_path / "repair" / "issue314-state-health-repair-summary.json"
+    monkeypatch.setenv("ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH", str(path))
+
+    issue314_state_health.emit_issue314_state_health_repair_summary(summary)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["target_collection_mode"] == "global_issue314_state_health"
+    assert payload["reviewer_facing_reminder_posts_attempted"] == 0
+    assert payload["manual_issue314_edit_status"] == "not_attempted"
+    assert payload["artifact_file"] == "issue314-state-health-repair-summary.json"
+    assert payload["output_keys"] == sorted(payload.keys())

--- a/tests/unit/reviewer_bot/test_issue314_state_health.py
+++ b/tests/unit/reviewer_bot/test_issue314_state_health.py
@@ -35,6 +35,38 @@ def _projection(issue_number: int, actual_labels: tuple[str, ...], state: str):
     )
 
 
+def _repair_summary(**overrides):
+    values = {
+        "schema_version": 1,
+        "repair_action": "repair-issue314-state-health",
+        "state_issue_number": 314,
+        "issue_number": 314,
+        "validation_nonce": "nonce",
+        "target_collection_mode": "global_issue314_state_health",
+        "active_rows_inspected": (42,),
+        "rows_repaired": (),
+        "rows_removed_closed": (),
+        "rows_operator_action_required": (),
+        "rows_blocked": (),
+        "status_labels_changed": (),
+        "reviewer_facing_reminder_posts_attempted": 0,
+        "manual_issue314_edit_status": "not_attempted",
+        "state_store_mutation_mode": "not_required",
+        "evaluated_repo": "rustfoundation/safety-critical-rust-coding-guidelines",
+        "head_sha": "head",
+        "evaluated_ref": "head",
+        "workflow_path": ".github/workflows/reviewer-bot-sweeper-repair.yml",
+        "run_id": "1",
+        "run_attempt": "1",
+        "artifact_name": "reviewer-bot-repair-output-1-attempt-1",
+        "artifact_file": "issue314-state-health-repair-summary.json",
+        "output_keys": (),
+        "result": "already_healthy",
+    }
+    values.update(overrides)
+    return issue314_state_health.Issue314StateHealthRepairSummary(**values)
+
+
 def test_issue314_classifier_marks_pr264_stale_label_as_operator_action_without_ping_risk():
     decision, projection = _projection(
         264,
@@ -160,6 +192,29 @@ def test_issue314_repair_summary_writer_requires_artifact_path(monkeypatch):
 
     with pytest.raises(RuntimeError, match="issue314_state_health_repair_summary_path_missing"):
         issue314_state_health.emit_issue314_state_health_repair_summary(summary)
+
+
+def test_issue314_summary_requires_identity_fields():
+    summary = _repair_summary(validation_nonce="")
+
+    with pytest.raises(RuntimeError, match="issue314_state_health_identity_blocked:missing:validation_nonce"):
+        summary.to_output()
+
+
+def test_issue314_summary_rejects_broad_or_manual_repair_as_success():
+    with pytest.raises(RuntimeError, match="target_collection_mode"):
+        _repair_summary(target_collection_mode="broad").to_output()
+
+    with pytest.raises(RuntimeError, match="manual_issue314_edit"):
+        _repair_summary(manual_issue314_edit_status="attempted").to_output()
+
+
+def test_issue314_summary_rejects_blocked_or_final_label_only_success():
+    with pytest.raises(RuntimeError, match="blocked_rows_success"):
+        _repair_summary(rows_blocked=(42,), result="changed").to_output()
+
+    with pytest.raises(RuntimeError, match="final_label_only_status"):
+        _repair_summary(status_labels_changed=(42,), rows_repaired=(), result="changed").to_output()
 
 
 def test_issue314_repair_summary_writer_emits_identity_fields(monkeypatch, tmp_path):

--- a/tests/unit/reviewer_bot/test_maintenance.py
+++ b/tests/unit/reviewer_bot/test_maintenance.py
@@ -235,6 +235,16 @@ def test_broad_status_label_repair_collection_is_explicit(monkeypatch):
     assert maintenance.collect_status_label_repair_targets(bot, make_state(), request) == (42, 264)
 
 
+def test_issue314_state_health_repair_policy_does_not_broaden_epoch_repair():
+    policy = maintenance.derive_manual_dispatch_projection_policy(
+        SimpleNamespace(action="repair-issue314-state-health", issue_number=314)
+    )
+
+    assert policy.allow_epoch_repair_expansion is False
+    assert policy.allow_status_label_sync is True
+    assert policy.reason == "issue314_state_health_repair"
+
+
 def test_status_label_repair_summary_writes_machine_readable_artifact(monkeypatch, tmp_path):
     summary = maintenance.StatusLabelRepairSummary(
         schema_version=1,

--- a/tests/unit/reviewer_bot/test_maintenance.py
+++ b/tests/unit/reviewer_bot/test_maintenance.py
@@ -1,3 +1,6 @@
+import json
+from types import SimpleNamespace
+
 import pytest
 
 from scripts.reviewer_bot_lib import (
@@ -183,6 +186,93 @@ def test_manual_dispatch_result_routes_check_overdue_through_structured_schedule
     monkeypatch.setattr(maintenance, "handle_scheduled_check_result", lambda bot, state: expected)
 
     assert maintenance.handle_manual_dispatch_result(bot, state) == expected
+
+
+def test_targeted_status_label_repair_policy_and_collection_do_not_broaden(monkeypatch):
+    bot = FakeReviewerBotRuntime(monkeypatch)
+    state = make_state(epoch="freshness_v15")
+    request = maintenance.StatusLabelRepairRequest(
+        action="repair-review-status-labels",
+        issue_number=264,
+        validation_nonce="nonce",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-sweeper-repair.yml",
+        run_id="1",
+        run_attempt="1",
+    )
+    monkeypatch.setattr(
+        maintenance.reviews,
+        "list_open_items_with_status_labels",
+        lambda bot: (_ for _ in ()).throw(AssertionError("targeted repair broadened")),
+    )
+    policy = maintenance.derive_manual_dispatch_projection_policy(
+        SimpleNamespace(action="repair-review-status-labels", issue_number=264)
+    )
+
+    assert policy.allow_epoch_repair_expansion is False
+    assert policy.allow_status_label_sync is True
+    assert policy.reason == "targeted_status_label_repair"
+    assert maintenance.collect_status_label_repair_targets(bot, state, request) == (264,)
+
+
+def test_broad_status_label_repair_collection_is_explicit(monkeypatch):
+    bot = FakeReviewerBotRuntime(monkeypatch)
+    request = maintenance.StatusLabelRepairRequest(
+        action="repair-review-status-labels",
+        issue_number=None,
+        validation_nonce="nonce",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-sweeper-repair.yml",
+        run_id="1",
+        run_attempt="1",
+    )
+    monkeypatch.setattr(maintenance.reviews, "list_open_items_with_status_labels", lambda bot: [42, 264])
+
+    assert maintenance.collect_status_label_repair_targets(bot, make_state(), request) == (42, 264)
+
+
+def test_status_label_repair_summary_writes_machine_readable_artifact(monkeypatch, tmp_path):
+    summary = maintenance.StatusLabelRepairSummary(
+        schema_version=1,
+        repair_action="repair-review-status-labels",
+        issue_number=264,
+        issue_numbers=(264,),
+        validation_nonce="nonce",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-sweeper-repair.yml",
+        run_id="1",
+        run_attempt="1",
+        artifact_name="reviewer-bot-repair-output-1-attempt-1",
+        artifact_file="repair-summary.json",
+        output_keys=(),
+        status_projection_epoch="status_projection_v2",
+        before=(),
+        after=(),
+        labels_added=("status: reviewer reassignment needed",),
+        labels_removed=("status: awaiting reviewer response",),
+        state_save_attempted=False,
+        tracked_state_mutations_attempted=False,
+        touched_projection_attempted=False,
+        target_collection_mode="issue_scoped",
+        result="changed",
+    )
+    path = tmp_path / "repair-output" / "repair-summary.json"
+    monkeypatch.setenv("REPAIR_SUMMARY_PATH", str(path))
+
+    maintenance.emit_status_label_repair_summary(summary)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["repair_action"] == "repair-review-status-labels"
+    assert payload["issue_number"] == 264
+    assert payload["issue_numbers"] == [264]
+    assert payload["target_collection_mode"] == "issue_scoped"
+    assert payload["output_keys"] == sorted(payload.keys())
 
 
 def test_scheduled_check_collects_touched_item_for_warning_diagnostic_mutation(monkeypatch):

--- a/tests/unit/reviewer_bot/test_project_board.py
+++ b/tests/unit/reviewer_bot/test_project_board.py
@@ -26,11 +26,12 @@ from tests.fixtures.reviewer_bot import (
     review_payload,
     valid_reviewer_board_metadata,
 )
-from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
+from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi, github_result
 
 
 def _runtime(monkeypatch, routes=None):
     runtime = FakeReviewerBotRuntime(monkeypatch)
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: github_result(200, [])
     if routes is not None:
         runtime.github.stub(routes)
     return runtime

--- a/tests/unit/reviewer_bot/test_reviewer_response_policy.py
+++ b/tests/unit/reviewer_bot/test_reviewer_response_policy.py
@@ -25,7 +25,13 @@ def test_legacy_response_dict_normalizes_to_typed_decision():
 
 
 def test_cadence_overlay_projects_reassignment_needed_once():
-    base = to_reviewer_response_decision({"response_state": "awaiting_reviewer_response"})
+    base = to_reviewer_response_decision(
+        {
+            "response_state": "awaiting_reviewer_response",
+            "current_scope_key": "reviewer=iglesias|head=head-a|cycle=none|anchor=assigned",
+            "current_scope_basis": "assigned_at",
+        }
+    )
     cadence = ReminderCadenceDecision(
         issue_number=264,
         reviewer="iglesias",
@@ -45,3 +51,5 @@ def test_cadence_overlay_projects_reassignment_needed_once():
     assert decision.response_state == "reviewer_reassignment_needed"
     assert decision.suppresses_overdue_reminder is True
     assert decision.reason == "legacy_duplicate_reminders_exhausted"
+    assert decision.scope.scope_basis == "reminder_cadence_exhausted"
+    assert base.scope.scope_basis == "assigned_at"

--- a/tests/unit/reviewer_bot/test_reviews_live_fetch.py
+++ b/tests/unit/reviewer_bot/test_reviews_live_fetch.py
@@ -23,6 +23,7 @@ from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi, github_result
 def _runtime(monkeypatch, routes=None):
     runtime = FakeReviewerBotRuntime(monkeypatch)
     runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot(issue_number, state="open", is_pull_request=True)
+    runtime.github.get_issue_assignees_result = lambda issue_number, is_pull_request=None: github_result(200, [])
     runtime.github.get_user_permission_status = lambda username, required_permission="push": "granted"
     if routes is not None:
         runtime.github.stub(routes)

--- a/tests/unit/reviewer_bot/test_reviews_live_fetch.py
+++ b/tests/unit/reviewer_bot/test_reviews_live_fetch.py
@@ -411,6 +411,23 @@ def test_compute_reviewer_response_state_reports_permission_unavailable(monkeypa
 
     assert response_state["state"] == "projection_failed"
     assert response_state["reason"] == "live_review_state_unknown"
+    assert response_state["write_approval_authority"] == {
+        "issue_number": 42,
+        "head_sha": "head-1",
+        "assigned_reviewer": "alice",
+        "assigned_review_id": 10,
+        "assigned_review_state": "APPROVED",
+        "assigned_round_complete": True,
+        "write_approval_state": "blocked_unavailable_authority",
+        "write_approval_source": "github_permission_read_unavailable",
+        "approving_reviewer": "alice",
+        "approving_review_id": 10,
+        "permission_source": "github_permission_read",
+        "dismissal_supersession_status": "blocked_untrusted",
+        "response_state": "projection_failed",
+        "diagnostic_reason": "permission_unavailable",
+        "can_project_final_state": False,
+    }
 
 
 def test_trigger_mandatory_approver_escalation_sets_required_label_and_ping(monkeypatch):

--- a/tests/unit/reviewer_bot/test_reviews_projection.py
+++ b/tests/unit/reviewer_bot/test_reviews_projection.py
@@ -355,6 +355,51 @@ def test_status_projection_maps_reassignment_needed_and_exposes_decision_output(
     assert payload["output_keys"] == sorted(payload.keys())
 
 
+def test_status_projection_preserves_write_approval_authority_decision_output():
+    authority = {
+        "issue_number": 264,
+        "head_sha": "head-a",
+        "assigned_reviewer": "iglesias",
+        "assigned_review_id": 10,
+        "assigned_review_state": "APPROVED",
+        "assigned_round_complete": True,
+        "write_approval_state": "visibly_missing_write_approval",
+        "write_approval_source": "none_visible_after_trusted_reads",
+        "approving_reviewer": None,
+        "approving_review_id": None,
+        "permission_source": "github_permission_read",
+        "dismissal_supersession_status": "pass_not_dismissed_or_superseded",
+        "response_state": "awaiting_write_approval",
+        "diagnostic_reason": None,
+        "can_project_final_state": True,
+    }
+    decision = to_reviewer_response_decision(
+        {
+            "issue_number": 264,
+            "response_state": "awaiting_write_approval",
+            "current_scope_key": "scope-approval",
+            "current_scope_basis": "assigned_at",
+            "write_approval_authority": authority,
+        }
+    )
+
+    result = reviews_projection.derive_status_label_projection(
+        reviews_projection.StatusLabelProjectionInput(
+            issue_number=264,
+            issue_state="open",
+            actual_labels=(),
+            reviewer_response=decision,
+            reviewer_authority_outcome="tracked_reviewer_confirmed",
+            freshness_runtime_epoch="freshness_v15",
+            status_projection_epoch="status_projection_v2",
+        )
+    )
+
+    decision_output = result.projection_metadata["decision_output"]
+    assert decision_output["write_approval_authority"] == authority
+    assert result.delta.desired_status_labels == ("status: awaiting write approval",)
+
+
 @pytest.mark.parametrize("state_name", ["projection_failed", "live_read_unavailable", "unknown"])
 def test_status_projection_fail_closed_states_never_clear_existing_labels(state_name):
     decision = to_reviewer_response_decision({"response_state": state_name})

--- a/tests/unit/reviewer_bot/test_reviews_projection.py
+++ b/tests/unit/reviewer_bot/test_reviews_projection.py
@@ -2,8 +2,13 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from scripts.reviewer_bot_core import approval_policy, live_review_support
-from scripts.reviewer_bot_lib import reviews
+from scripts.reviewer_bot_core.reviewer_response_policy import (
+    to_reviewer_response_decision,
+)
+from scripts.reviewer_bot_lib import github_api, reviews, reviews_projection
 from scripts.reviewer_bot_lib.config import GitHubApiResult
 from tests.fixtures.reviewer_bot import (
     make_state,
@@ -302,3 +307,93 @@ def test_h1a_reviewer_response_matrix_fixture_exists_and_stays_reviewer_response
         "projection_failed_pull_request_head_unavailable",
         "projection_failed_live_review_state_unknown",
     ]
+
+
+def test_status_projection_maps_reassignment_needed_and_exposes_decision_output():
+    decision = to_reviewer_response_decision(
+        {
+            "issue_number": 264,
+            "current_reviewer": "iglesias",
+            "response_state": "reviewer_reassignment_needed",
+            "suppression_reason": "legacy_duplicate_reminders_exhausted",
+            "current_scope_key": "scope-1",
+            "current_scope_basis": "reminder_cadence_exhausted",
+        }
+    )
+
+    result = reviews_projection.derive_status_label_projection(
+        reviews_projection.StatusLabelProjectionInput(
+            issue_number=264,
+            issue_state="open",
+            actual_labels=("status: awaiting reviewer response",),
+            reviewer_response=decision,
+            reviewer_authority_outcome="tracked_reviewer_confirmed",
+            freshness_runtime_epoch="freshness_v15",
+            status_projection_epoch="status_projection_v2",
+        )
+    )
+    payload = reviews_projection.status_label_projection_output(
+        result,
+        preview_action="preview-status-label-projection",
+        validation_nonce="nonce",
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id="1",
+        run_attempt="2",
+        artifact_name="reviewer-bot-preview-output-1-attempt-2",
+        artifact_file="preview-output.json",
+    )
+
+    assert result.delta.desired_status_labels == ("status: reviewer reassignment needed",)
+    assert result.delta.labels_to_add == ("status: reviewer reassignment needed",)
+    assert result.delta.labels_to_remove == ("status: awaiting reviewer response",)
+    assert result.projection_metadata["source"] == "reviewer_response_decision"
+    assert result.projection_metadata["decision_output"] == decision.to_output()
+    assert payload["desired_status_labels"] == ["status: reviewer reassignment needed"]
+    assert payload["output_keys"] == sorted(payload.keys())
+
+
+@pytest.mark.parametrize("state_name", ["projection_failed", "live_read_unavailable", "unknown"])
+def test_status_projection_fail_closed_states_never_clear_existing_labels(state_name):
+    decision = to_reviewer_response_decision({"response_state": state_name})
+
+    with pytest.raises(RuntimeError, match="status_label_projection_blocked"):
+        reviews_projection.derive_status_label_projection(
+            reviews_projection.StatusLabelProjectionInput(
+                issue_number=42,
+                issue_state="open",
+                actual_labels=("status: awaiting reviewer response",),
+                reviewer_response=decision,
+                reviewer_authority_outcome="tracked_reviewer_confirmed",
+                freshness_runtime_epoch=None,
+                status_projection_epoch=None,
+            )
+        )
+
+
+def test_apply_status_label_delta_is_mutation_boundary(monkeypatch):
+    calls = []
+    bot = _bot()
+    bot.github.ensure_label_exists = lambda label, **kwargs: calls.append(("ensure", label, kwargs)) or True
+    monkeypatch.setattr(github_api, "add_label_with_status", lambda bot, issue_number, label: calls.append(("add", issue_number, label)) or True)
+    monkeypatch.setattr(github_api, "remove_label_with_status", lambda bot, issue_number, label: calls.append(("remove", issue_number, label)) or True)
+    delta = reviews_projection.status_label_delta(
+        ("status: awaiting reviewer response",),
+        ("status: reviewer reassignment needed",),
+    )
+
+    result = reviews.apply_status_label_delta(bot, 264, delta)
+
+    assert result.to_output() == {
+        "issue_number": 264,
+        "before_status_labels": ["status: awaiting reviewer response"],
+        "desired_status_labels": ["status: reviewer reassignment needed"],
+        "labels_added": ["status: reviewer reassignment needed"],
+        "labels_removed": ["status: awaiting reviewer response"],
+        "changed": True,
+    }
+    assert calls[0][0:2] == ("ensure", "status: reviewer reassignment needed")
+    assert ("remove", 264, "status: awaiting reviewer response") in calls
+    assert ("add", 264, "status: reviewer reassignment needed") in calls


### PR DESCRIPTION
## Summary
- add issue-scoped status-label projection preview for reviewer-bot incident closure
- make status-label repair issue-scoped and nonce-auditable before live PR 264 repair
- preserve poisoned-state regression proof so preview silence cannot hide stale labels
