### PR TITLE
Harden reviewer bot PR264 guardrails

### DIFF
--- a/.github/actions/reviewer-bot-source/action.yml
+++ b/.github/actions/reviewer-bot-source/action.yml
@@ -10,8 +10,31 @@ runs:
     - id: source-root
       shell: bash
       run: |
+        workspace_root="$(git -C "$GITHUB_WORKSPACE" rev-parse --show-toplevel)"
+        if [ "$workspace_root" != "$GITHUB_WORKSPACE" ]; then
+          echo "reviewer-bot source checkout root does not match GITHUB_WORKSPACE" >&2
+          exit 1
+        fi
+        checked_out_sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+        if [ -n "${GITHUB_SHA:-}" ] && [ "$checked_out_sha" != "$GITHUB_SHA" ]; then
+          echo "reviewer-bot source checkout does not match GITHUB_SHA" >&2
+          exit 1
+        fi
+        remote_url="$(git -C "$GITHUB_WORKSPACE" config --get remote.origin.url || true)"
+        case "$remote_url" in
+          *"$GITHUB_REPOSITORY"*) ;;
+          *)
+            echo "reviewer-bot source checkout remote does not match GITHUB_REPOSITORY" >&2
+            exit 1
+            ;;
+        esac
         if [ ! -f "$GITHUB_WORKSPACE/scripts/reviewer_bot.py" ]; then
           echo "reviewer-bot source checkout is missing scripts/reviewer_bot.py" >&2
+          exit 1
+        fi
+        bot_entry="$(realpath "$GITHUB_WORKSPACE/scripts/reviewer_bot.py")"
+        if [ "$bot_entry" != "$GITHUB_WORKSPACE/scripts/reviewer_bot.py" ]; then
+          echo "reviewer-bot entrypoint must be a regular file inside the trusted checkout" >&2
           exit 1
         fi
         printf 'bot-src-root=%s\n' "$GITHUB_WORKSPACE" >> "$GITHUB_OUTPUT"

--- a/scripts/reviewer_bot_lib/app.py
+++ b/scripts/reviewer_bot_lib/app.py
@@ -461,6 +461,11 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
             if manual_projection_policy is not None
             else True
         )
+        allow_status_label_sync = (
+            manual_projection_policy.allow_status_label_sync
+            if manual_projection_policy is not None
+            else True
+        )
         if (
             lock_required
             and event_name in {"schedule", "workflow_dispatch"}
@@ -560,7 +565,16 @@ def execute_run(bot: AppExecutionRuntime, context: EventContext) -> ExecutionRes
 
         maintenance.emit_pending_issue314_state_health_repair_summary(bot)
 
-        if touched_items:
+        if touched_items and not allow_status_label_sync:
+            _log(
+                bot,
+                "info",
+                "Skipping status-label sync because manual dispatch policy is read-only.",
+                manual_action=context.manual_action or "",
+                touched_items=touched_items,
+            )
+
+        if touched_items and allow_status_label_sync:
             if not lock_acquired:
                 raise RuntimeError(
                     "Status-label projection reached apply path without lease lock. "

--- a/scripts/reviewer_bot_lib/maintenance_schedule.py
+++ b/scripts/reviewer_bot_lib/maintenance_schedule.py
@@ -11,6 +11,7 @@ from .lifecycle import (
 )
 from .overdue import (
     backfill_transition_notice_if_present,
+    backfill_transition_warning_if_present,
     check_overdue_reviews,
     handle_overdue_review_warning,
 )
@@ -139,6 +140,16 @@ def _run_tracked_pr_maintenance(bot, state: dict) -> tuple[bool, list[int]]:
 
 def _run_overdue_pass(bot, state: dict) -> bool:
     changed = False
+    active_reviews = state.get("active_reviews")
+    if isinstance(active_reviews, dict):
+        for issue_key, review_data in active_reviews.items():
+            if not isinstance(review_data, dict):
+                continue
+            try:
+                issue_number = int(issue_key)
+            except ValueError:
+                continue
+            changed = backfill_transition_warning_if_present(bot, state, issue_number) or changed
     overdue_reviews = check_overdue_reviews(bot, state)
     for review in overdue_reviews:
         issue_number = review["issue_number"]

--- a/scripts/reviewer_bot_lib/overdue.py
+++ b/scripts/reviewer_bot_lib/overdue.py
@@ -729,6 +729,70 @@ def _effective_response_with_cadence(bot, issue_number: int, review_data: dict, 
     return effective_response, cadence, reminder_scan
 
 
+def backfill_transition_warning_if_present(bot, state: dict, issue_number: int) -> bool:
+    active_reviews = state.get("active_reviews") if isinstance(state, dict) else None
+    review_data = active_reviews.get(str(issue_number)) if isinstance(active_reviews, dict) else None
+    if not isinstance(review_data, dict):
+        return False
+    if not isinstance(review_data.get("current_reviewer"), str) or not review_data["current_reviewer"].strip():
+        return False
+    existing_warning = review_data.get("transition_warning_sent")
+    if isinstance(existing_warning, str) and existing_warning.strip():
+        return False
+    try:
+        issue_snapshot_result = bot.github.get_issue_or_pr_snapshot_result(issue_number)
+    except (AssertionError, AttributeError, RuntimeError):
+        return False
+    issue_snapshot = issue_snapshot_result.payload if issue_snapshot_result.ok else None
+    if not isinstance(issue_snapshot, dict):
+        return False
+    if str(issue_snapshot.get("state", "")).lower() == "closed":
+        return False
+
+    response_state = bot.adapters.review_state.compute_reviewer_response_state(
+        issue_number,
+        review_data,
+        issue_snapshot=issue_snapshot,
+    )
+    _effective_response, cadence, _reminder_scan = _effective_response_with_cadence(
+        bot,
+        issue_number,
+        review_data,
+        response_state,
+    )
+    receipt = cadence.warning_receipt
+    if receipt is None or receipt.receipt_kind != "warning":
+        return False
+    if receipt.source not in {"comment_scan", "live_comment_scan"}:
+        return False
+    if not isinstance(receipt.created_at, str) or not receipt.created_at.strip():
+        return False
+
+    changed = False
+    if review_data.get("transition_warning_sent") != receipt.created_at:
+        review_data["transition_warning_sent"] = receipt.created_at
+        changed = True
+    delivery_result = build_reminder_delivery_persistence_result(
+        issue_number=issue_number,
+        reviewer=receipt.reviewer,
+        head_sha=receipt.head_sha,
+        cycle_key=receipt.cycle_key,
+        scope_key=receipt.scope_key,
+        receipt_kind="warning",
+        comment_posted=False,
+        comment_id=receipt.comment_id,
+        comment_created_at=receipt.created_at,
+        state_save_attempted=False,
+        state_save_succeeded=False,
+        recovered_receipt=receipt,
+        diagnostic_reason="live_warning_receipt_backfill",
+    )
+    changed = _store_reminder_delivery_result(review_data, delivery_result) or changed
+    if changed:
+        bot.collect_touched_item(issue_number)
+    return changed
+
+
 def _find_existing_warning_comment(
     bot,
     issue_number: int,

--- a/scripts/reviewer_bot_lib/reconcile.py
+++ b/scripts/reviewer_bot_lib/reconcile.py
@@ -252,7 +252,28 @@ def build_command_replay_receipt(
     clear_gap_allowed: bool,
     diagnostic_reason: str | None = None,
 ) -> CommandReplayReceipt:
-    if not replay_attempted:
+    normalized_side_effects = tuple(
+        sorted(
+            {
+                str(item).strip()
+                for item in command_side_effects_attempted
+                if str(item).strip()
+            }
+        )
+    )
+    normalized_command_name = command_name.strip() if isinstance(command_name, str) and command_name.strip() else None
+    consistency_error = None
+    if replay_attempted and normalized_command_name is None:
+        consistency_error = "missing_command_name_for_replay"
+    elif not replay_attempted and normalized_side_effects:
+        consistency_error = "side_effects_without_replay"
+    elif not replay_attempted and state_save_required:
+        consistency_error = "state_save_required_without_replay"
+
+    if consistency_error is not None:
+        result = "blocked_inconsistent_replay_receipt"
+        diagnostic_reason = diagnostic_reason or consistency_error
+    elif not replay_attempted:
         result = "pass_diagnostic_only"
     elif not mark_reconciled_allowed or not clear_gap_allowed:
         result = "blocked_authority_missing"
@@ -263,9 +284,9 @@ def build_command_replay_receipt(
     return CommandReplayReceipt(
         source_event_key=source_event_key,
         issue_number=issue_number,
-        command_name=command_name,
+        command_name=normalized_command_name,
         replay_attempted=replay_attempted,
-        command_side_effects_attempted=command_side_effects_attempted,
+        command_side_effects_attempted=normalized_side_effects,
         state_save_required=state_save_required,
         state_save_succeeded=state_save_succeeded,
         mark_reconciled_allowed=mark_reconciled_allowed,

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -423,6 +423,18 @@ def test_reviewer_bot_workflows_use_shared_source_action_without_raw_extraction(
             assert "uses: ./.github/actions/reviewer-bot-source" in text
             assert "BOT_SRC_ROOT: ${{ steps.bot-source.outputs.bot-src-root }}" in text
 
+
+def test_reviewer_bot_source_action_validates_checkout_provenance():
+    action = Path(".github/actions/reviewer-bot-source/action.yml").read_text(encoding="utf-8")
+
+    assert 'git -C "$GITHUB_WORKSPACE" rev-parse --show-toplevel' in action
+    assert 'git -C "$GITHUB_WORKSPACE" rev-parse HEAD' in action
+    assert '"$checked_out_sha" != "$GITHUB_SHA"' in action
+    assert 'git -C "$GITHUB_WORKSPACE" config --get remote.origin.url' in action
+    assert '*"$GITHUB_REPOSITORY"*' in action
+    assert 'realpath "$GITHUB_WORKSPACE/scripts/reviewer_bot.py"' in action
+    assert "printf 'BOT_SRC_ROOT=%s\\n'" in action
+
 def test_workflow_summaries_and_runbook_references_exist():
     runbook = Path("docs/reviewer-bot-review-freshness-operator-runbook.md")
     assert runbook.exists()

--- a/tests/integration/reviewer_bot/test_app_execution.py
+++ b/tests/integration/reviewer_bot/test_app_execution.py
@@ -445,6 +445,30 @@ def test_execute_run_persists_projection_repair_marker_after_projection_failure(
     assert saved_states[-1]["active_reviews"]["42"]["sidecars"]["repair_markers"]["status_label_projection"]["kind"] == "projection_failure"
 
 
+def test_execute_run_manual_read_only_policy_blocks_touched_status_label_sync(monkeypatch):
+    harness = AppHarness(monkeypatch)
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="preview-status-label-projection",
+        ISSUE_NUMBER=42,
+        VALIDATION_NONCE="nonce",
+    )
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: make_state())
+
+    def fake_manual_dispatch(state):
+        harness.runtime.collect_touched_item(42)
+        return False
+
+    harness.stub_handler("handle_manual_dispatch", fake_manual_dispatch)
+    harness.stub_sync_status_labels(lambda current, issue_numbers: pytest.fail("read-only manual policy must not sync labels"))
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    assert result.state_changed is False
+
+
 def test_execute_run_returns_failure_when_lock_release_fails(monkeypatch):
     harness = AppHarness(monkeypatch)
     harness.set_event(EVENT_NAME="issue_comment", EVENT_ACTION="created")

--- a/tests/integration/reviewer_bot/test_app_schedule_bookkeeping.py
+++ b/tests/integration/reviewer_bot/test_app_schedule_bookkeeping.py
@@ -1,3 +1,7 @@
+import copy
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
 import pytest
 
 from scripts.reviewer_bot_lib import (
@@ -223,6 +227,144 @@ def test_execute_run_schedule_warning_diagnostic_mutation_projects_touched_item(
     assert result.state_changed is True
     assert saved_states
     assert synced == [[42]]
+
+
+def test_execute_run_schedule_warning_post_save_failure_recovers_from_live_comment(monkeypatch):
+    original_state = make_state()
+    review = review_state.ensure_review_entry(original_state, 42, create=True)
+    assert review is not None
+    review["current_reviewer"] = "alice"
+    review["assigned_at"] = "2026-03-17T10:00:00Z"
+    review["active_cycle_started_at"] = "2026-03-17T10:00:00Z"
+    issue_snapshot = {"number": 42, "state": "open", "pull_request": {}, "labels": []}
+    pull_request = {
+        "number": 42,
+        "state": "open",
+        "head": {"sha": "head-1"},
+        "requested_reviewers": [],
+        "user": {"login": "dana"},
+    }
+    posted_comment = {}
+
+    def configure_common(harness, state, comments):
+        harness.set_event(EVENT_NAME="schedule", EVENT_ACTION="")
+        harness.runtime.datetime = SimpleNamespace(
+            now=lambda tz=None: datetime(2026, 4, 2, tzinfo=tz or timezone.utc)
+        )
+        harness.stub_lock(acquire=lambda: None, release=lambda: True)
+        harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+        harness.stub_pass_until(lambda current: (current, []))
+        harness.stub_sync_members(lambda current: (current, []))
+        harness.runtime.github.get_issue_or_pr_snapshot = lambda issue_number: issue_snapshot
+        harness.runtime.github.get_issue_or_pr_snapshot_result = lambda issue_number: GitHubApiResult(
+            200,
+            issue_snapshot,
+            {},
+            "ok",
+            True,
+            None,
+            0,
+            None,
+        )
+        harness.runtime.github.get_issue_assignees = lambda issue_number: []
+        harness.runtime.github.list_issue_comments_result = lambda issue_number, page=1, per_page=100: GitHubApiResult(
+            200,
+            list(comments),
+            {},
+            "ok",
+            True,
+            None,
+            0,
+            None,
+        )
+        harness.runtime.github.github_api_request = lambda method, endpoint, data=None, extra_headers=None, **kwargs: GitHubApiResult(
+            200,
+            pull_request if endpoint == "pulls/42" else [],
+            {},
+            "ok",
+            True,
+            None,
+            0,
+            None,
+        )
+        monkeypatch.setattr(maintenance_schedule, "sweep_deferred_gaps", lambda bot, current: False)
+        monkeypatch.setattr(maintenance_schedule, "repair_missing_reviewer_review_state", lambda bot, issue_number, review_data: False)
+        monkeypatch.setattr(
+            maintenance_schedule,
+            "maybe_record_head_observation_repair",
+            lambda bot, issue_number, review_data: lifecycle.HeadObservationRepairResult(changed=False, outcome="unchanged"),
+        )
+
+    first_state = copy.deepcopy(original_state)
+    first = AppHarness(monkeypatch)
+    configure_common(first, first_state, [])
+
+    def post_warning(issue_number, body):
+        posted_comment.update(
+            {
+                "id": 901,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-01T00:00:00Z",
+                "body": body,
+            }
+        )
+        return GitHubApiResult(201, {"id": 901, "created_at": "2026-04-01T00:00:00Z"}, {}, "created", True, None, 0, None)
+
+    first.runtime.github.post_comment_result = post_warning
+    first.stub_save_state(lambda current: False)
+    first.stub_sync_status_labels(lambda current, issue_numbers: pytest.fail("failed save must not project labels"))
+
+    first_result = first.run_execute()
+
+    assert first_result.exit_code == 1
+    assert posted_comment["body"].startswith("<!-- reviewer-bot:transition-warning:v1 ")
+
+    recovered_state = copy.deepcopy(original_state)
+    saved_states = []
+    synced = []
+    second = AppHarness(monkeypatch)
+    configure_common(second, recovered_state, [posted_comment])
+    second.runtime.github.post_comment_result = lambda issue_number, body: pytest.fail("live warning receipt should suppress duplicate post")
+    second.stub_save_state(lambda current: saved_states.append(copy.deepcopy(current)) or True)
+    second.stub_sync_status_labels(lambda current, issue_numbers: synced.append(list(issue_numbers)) or True)
+
+    second_result = second.run_execute()
+
+    assert second_result.exit_code == 0
+    assert saved_states
+    recovered_review = saved_states[0]["active_reviews"]["42"]
+    assert recovered_review["transition_warning_sent"] == "2026-04-01T00:00:00Z"
+    receipts = recovered_review["sidecars"]["reminder_delivery_receipts"]
+    assert len(receipts) == 1
+    receipt = next(iter(receipts.values()))
+    assert receipt["result"] == "not_posted_existing_receipt"
+    assert receipt["recovered_receipt"]["source"] == "comment_scan"
+    assert synced == [[42]]
+
+
+def test_execute_run_schedule_isolated_from_reviewer_board_configuration(monkeypatch):
+    harness = AppHarness(monkeypatch)
+    harness.set_event(EVENT_NAME="schedule", EVENT_ACTION="", REVIEWER_BOARD_ENABLED="true")
+    state = make_state()
+    saved = []
+
+    harness.stub_lock(acquire=lambda: None, release=lambda: True)
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_pass_until(lambda current: (current, []))
+    harness.stub_sync_members(lambda current: (current, []))
+    monkeypatch.setattr(
+        maintenance,
+        "handle_scheduled_check_result",
+        lambda bot, current: maintenance.ScheduleHandlerResult(True, []),
+    )
+    harness.runtime.github_graphql = lambda *args, **kwargs: pytest.fail("schedule path must not touch reviewer board GraphQL")
+    harness.stub_save_state(lambda current: saved.append(copy.deepcopy(current)) or True)
+    harness.stub_sync_status_labels(lambda current, issue_numbers: True)
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    assert saved
 
 
 def test_execute_run_schedule_removes_closed_pr_rows_through_lifecycle_owner(monkeypatch):

--- a/tests/integration/reviewer_bot/test_pr264_incident_replay_card.py
+++ b/tests/integration/reviewer_bot/test_pr264_incident_replay_card.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 from scripts.reviewer_bot_core import reviewer_response_policy
@@ -47,10 +49,18 @@ def test_pr264_canonical_replay_card_keeps_plain_lgtm_diagnostic_only(monkeypatc
         author_association="CONTRIBUTOR",
     )
 
-    assert harness.run(state) is False
+    before_state = deepcopy(state)
+
+    result = harness.handle_workflow_run_event_result(state)
+
+    assert result.state_changed is False
+    assert result.touched_items == [264]
+    assert state == before_state
     assert review["reviewer_comment"].get("accepted") is None
     assert "issue_comment:210" not in review["sidecars"]["reconciled_source_events"]
     assert "issue_comment:210" not in review["sidecars"]["deferred_gaps"]
+    assert all(call.method == "GET" for call in harness.github.request_calls)
+    assert harness.github.api_calls == []
 
     routes = RouteGitHubApi().add_request(
         "GET",

--- a/tests/unit/reviewer_bot/test_reconcile_admission.py
+++ b/tests/unit/reviewer_bot/test_reconcile_admission.py
@@ -56,6 +56,41 @@ def test_command_receipt_diagnostic_only_is_not_replay_closeout_authority():
     assert receipt.replay_attempted is False
 
 
+def test_command_receipt_rejects_side_effects_without_replay_attempt():
+    receipt = build_command_replay_receipt(
+        source_event_key="issue_comment:1",
+        issue_number=264,
+        command_name=None,
+        replay_attempted=False,
+        command_side_effects_attempted=("comment_command",),
+        state_save_required=False,
+        state_save_succeeded=False,
+        mark_reconciled_allowed=True,
+        clear_gap_allowed=True,
+    )
+
+    assert receipt.result == "blocked_inconsistent_replay_receipt"
+    assert receipt.diagnostic_reason == "side_effects_without_replay"
+
+
+def test_command_receipt_rejects_replay_without_command_identity():
+    receipt = build_command_replay_receipt(
+        source_event_key="issue_comment:1",
+        issue_number=264,
+        command_name=None,
+        replay_attempted=True,
+        command_side_effects_attempted=("comment_command", "comment_command"),
+        state_save_required=True,
+        state_save_succeeded=True,
+        mark_reconciled_allowed=True,
+        clear_gap_allowed=True,
+    )
+
+    assert receipt.result == "blocked_inconsistent_replay_receipt"
+    assert receipt.command_side_effects_attempted == ("comment_command",)
+    assert receipt.diagnostic_reason == "missing_command_name_for_replay"
+
+
 def test_dismissed_review_plan_rebuilds_but_does_not_closeout_without_exact_time():
     plan = decide_review_dismissed_replay_plan(
         source_event_key="pull_request_review_dismissed:20",

--- a/tests/unit/reviewer_bot/test_review_state_machine.py
+++ b/tests/unit/reviewer_bot/test_review_state_machine.py
@@ -1,3 +1,122 @@
 """Packet verification owner for review-state-machine guardrails."""
 
-from tests.unit.reviewer_bot.test_review_state_equivalence import *  # noqa: F401,F403
+from scripts.reviewer_bot_core import review_state_machine
+from tests.fixtures.reviewer_bot import make_state
+
+
+def test_owner_ensure_review_entry_upgrades_legacy_rows_and_materializes_sidecars():
+    state = {
+        **make_state(),
+        "last_updated": "2026-03-17T09:00:00Z",
+        "active_reviews": {"42": ["alice"]},
+    }
+
+    review = review_state_machine.ensure_review_entry(state, 42)
+
+    assert review is not None
+    assert state["active_reviews"]["42"] is review
+    assert review["skipped"] == ["alice"]
+    assert review["sidecars"]["pending_privileged_commands"] == {}
+    assert review["sidecars"]["deferred_gaps"] == {}
+    assert review["sidecars"]["reconciled_source_events"] == {}
+
+
+def test_owner_accept_channel_event_dedupes_and_keeps_latest_highest_precedence_record():
+    review = {
+        "reviewer_comment": {"accepted": None, "seen_keys": []},
+    }
+
+    assert review_state_machine.accept_channel_event(
+        review,
+        "reviewer_comment",
+        semantic_key="issue_comment:100",
+        timestamp="2026-03-17T10:00:00Z",
+        actor="alice",
+        source_precedence=1,
+    ) is True
+    assert review_state_machine.accept_channel_event(
+        review,
+        "reviewer_comment",
+        semantic_key="issue_comment:100",
+        timestamp="2026-03-17T10:00:00Z",
+        actor="alice",
+        source_precedence=1,
+    ) is False
+    assert review_state_machine.accept_channel_event(
+        review,
+        "reviewer_comment",
+        semantic_key="issue_comment:101",
+        timestamp="2026-03-17T09:00:00Z",
+        actor="alice",
+        source_precedence=2,
+    ) is True
+    assert review_state_machine.accept_channel_event(
+        review,
+        "reviewer_comment",
+        semantic_key="issue_comment:102",
+        timestamp="2026-03-17T10:00:00Z",
+        actor="alice",
+        source_precedence=2,
+    ) is True
+
+    channel = review["reviewer_comment"]
+    assert channel["seen_keys"] == [
+        "issue_comment:100",
+        "issue_comment:101",
+        "issue_comment:102",
+    ]
+    assert channel["accepted"]["semantic_key"] == "issue_comment:102"
+    assert channel["accepted"]["source_precedence"] == 2
+
+
+def test_owner_contributor_activity_clears_stale_reviewer_handoff():
+    review = {
+        "current_cycle_reviewer_handoff": {
+            "timestamp": "2026-03-17T10:00:00Z",
+            "reviewer": "alice",
+        }
+    }
+
+    assert review_state_machine.accept_channel_event(
+        review,
+        "contributor_comment",
+        semantic_key="issue_comment:200",
+        timestamp="2026-03-17T10:30:00Z",
+        actor="dana",
+    ) is True
+
+    assert review["current_cycle_reviewer_handoff"] is None
+
+
+def test_owner_set_current_reviewer_resets_cycle_local_state_without_dropping_sidecars():
+    state = make_state()
+    review = review_state_machine.ensure_review_entry(state, 42, create=True)
+    assert review is not None
+    review["reviewer_comment"] = {
+        "accepted": {"semantic_key": "issue_comment:1", "timestamp": "2026-03-17T10:00:00Z"},
+        "seen_keys": ["issue_comment:1"],
+    }
+    review["current_cycle_completion"] = {"completed": True}
+    review["current_cycle_write_approval"] = {"approved": True}
+    review["current_cycle_reviewer_handoff"] = {"timestamp": "2026-03-17T10:00:00Z"}
+    review["sidecars"]["pending_privileged_commands"]["issue_comment:10"] = {"status": "pending"}
+
+    review_state_machine.set_current_reviewer(
+        state,
+        42,
+        "alice",
+        now="2026-03-18T09:00:00+00:00",
+        assignment_method="manual",
+    )
+
+    assert review["current_reviewer"] == "alice"
+    assert review["assignment_method"] == "manual"
+    assert review["reviewer_comment"] == {"accepted": None, "seen_keys": []}
+    assert review["reviewer_review"] == {"accepted": None, "seen_keys": []}
+    assert review["contributor_comment"] == {"accepted": None, "seen_keys": []}
+    assert review["current_cycle_completion"] == {}
+    assert review["current_cycle_write_approval"] == {}
+    assert review["current_cycle_reviewer_handoff"] is None
+    assert review["sidecars"]["pending_privileged_commands"] == {
+        "issue_comment:10": {"status": "pending"}
+    }


### PR DESCRIPTION
## Summary
- Replace the review-state-machine owner shim with direct owner assertions for local mutation behavior.
- Add end-to-end guardrails for PR264 LGTM replay and warning post/save failure recovery from live markerized comments.
- Enforce manual read-only status-label-sync policy, command replay receipt consistency, reviewer-board isolation, and trusted source checkout provenance.

## Verification
- uv run ruff check .
- uv run pytest tests/unit/reviewer_bot -q
- uv run pytest tests/integration/reviewer_bot -m integration -q
- uv run pytest tests/contract/reviewer_bot -m contract -q
- uv run pytest tests/unit/reviewer_bot tests/integration/reviewer_bot tests/contract/reviewer_bot -q
- COVERAGE_FILE=artifacts/coverage/.coverage uv run pytest tests/unit/reviewer_bot tests/integration/reviewer_bot --cov=scripts.reviewer_bot --cov=scripts.reviewer_bot_core --cov=scripts.reviewer_bot_lib --cov-branch --cov-report=term-missing --cov-report=json:artifacts/coverage/reviewer-bot.json
- Coverage floors: statements 82.03%, branches 65.61%