### PR TITLE
fix: avoid blocking active issue314 reviewer waits

### DIFF
--- a/scripts/reviewer_bot_lib/issue314_state_health.py
+++ b/scripts/reviewer_bot_lib/issue314_state_health.py
@@ -435,6 +435,12 @@ def _live_head_sha(snapshot: dict[str, object], projection: StatusLabelProjectio
     return None
 
 
+def _has_unsafe_automated_reminder_risk(decision: ReviewerResponseDecision) -> bool:
+    if decision.response_state == "awaiting_reviewer_response":
+        return False
+    return not decision.suppresses_overdue_reminder
+
+
 def _row_from_input(input: Issue314StateHealthClassificationInput, row: dict[str, object]) -> Issue314StateHealthRow:
     issue_number = int(row["issue_number"])
     review_data = row.get("review_data") if isinstance(row.get("review_data"), dict) else {}
@@ -469,9 +475,10 @@ def _row_from_input(input: Issue314StateHealthClassificationInput, row: dict[str
             reason = "closed_live_item_has_active_issue314_row"
         else:
             assert projection is not None
+            assert decision is not None
             delta = projection.delta
             has_drift = bool(delta.labels_to_add or delta.labels_to_remove)
-            automated_risk = projection.response_state == "awaiting_reviewer_response"
+            automated_risk = _has_unsafe_automated_reminder_risk(decision)
             if automated_risk:
                 health = "blocked"
                 repair = "blocked"

--- a/tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py
+++ b/tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py
@@ -177,3 +177,73 @@ def test_execute_run_preview_issue314_state_health_blocks_unavailable_live_rows(
         "reviewer_response_unavailable",
         "status_projection_unavailable",
     ]
+
+
+def test_execute_run_preview_issue314_state_health_keeps_aligned_awaiting_reviewer_response_healthy(
+    monkeypatch,
+    capsys,
+):
+    harness = AppHarness(monkeypatch)
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="preview-issue314-state-health",
+        ISSUE_NUMBER=314,
+        VALIDATION_NONCE="nonce-issue314-preview",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="1001",
+        GITHUB_RUN_ATTEMPT="1",
+        STATE_ISSUE_NUMBER=314,
+    )
+
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        410,
+        reviewer="cpetig",
+        assigned_at="2026-01-01T00:00:00Z",
+        active_cycle_started_at="2026-01-01T00:00:00Z",
+    )
+    review["active_head_sha"] = "head-live"
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/410",
+        status_code=200,
+        payload={
+            "number": 410,
+            "state": "open",
+            "pull_request": {},
+            "labels": [{"name": "status: awaiting reviewer response"}],
+        },
+    ).add_request(
+        "GET",
+        "pulls/410",
+        status_code=200,
+        payload={
+            **pull_request_payload(410, head_sha="head-live", author="contributor"),
+            "requested_reviewers": [{"login": "cpetig"}],
+        },
+    ).add_pull_request_reviews(410, []).add_request(
+        "GET",
+        "issues/410/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[],
+    )
+    harness.runtime.github.stub(routes)
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_lock(acquire=lambda: (_ for _ in ()).throw(AssertionError("preview should not acquire lock")))
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("preview should not save state")))
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("preview should not sync labels")))
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["active_rows_inspected"] == [410]
+    assert payload["rows_blocked"] == []
+    assert payload["rows_repairable"] == []
+    row = payload["row_inventory"][0]
+    assert row["health_classification"] == "healthy"
+    assert row["automated_reminder_risk"] is False
+    assert row["status_label_risk"] == "aligned"

--- a/tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py
+++ b/tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py
@@ -162,3 +162,81 @@ def test_execute_run_repair_issue314_state_health_requires_identity(monkeypatch,
 
     assert result.exit_code == 1
     assert not summary_path.exists()
+
+
+def test_execute_run_repair_issue314_state_health_repairs_awaiting_reviewer_label_drift(
+    monkeypatch,
+    tmp_path,
+):
+    harness = AppHarness(monkeypatch)
+    summary_path = tmp_path / "repair" / "issue314-state-health-repair-summary.json"
+    harness.set_event(
+        EVENT_NAME="workflow_dispatch",
+        EVENT_ACTION="",
+        MANUAL_ACTION="repair-issue314-state-health",
+        ISSUE_NUMBER=314,
+        VALIDATION_NONCE="nonce-issue314-repair",
+        GITHUB_SHA="workflow-head",
+        GITHUB_REPOSITORY="rustfoundation/safety-critical-rust-coding-guidelines",
+        GITHUB_RUN_ID="1004",
+        GITHUB_RUN_ATTEMPT="1",
+        STATE_ISSUE_NUMBER=314,
+    )
+    harness.stub_lock()
+    monkeypatch.setenv("ISSUE314_STATE_HEALTH_REPAIR_SUMMARY_PATH", str(summary_path))
+
+    state = make_state()
+    make_tracked_review_state(
+        state,
+        360,
+        reviewer="AlexCeleste",
+        assigned_at="2026-01-01T00:00:00Z",
+        active_cycle_started_at="2026-01-01T00:00:00Z",
+    )
+    routes = RouteGitHubApi().add_request(
+        "GET",
+        "issues/360",
+        status_code=200,
+        payload={
+            "number": 360,
+            "state": "open",
+            "labels": [
+                {"name": "status: awaiting reviewer response"},
+                {"name": "status: draft"},
+            ],
+            "assignees": [{"login": "AlexCeleste"}],
+        },
+    ).add_request(
+        "GET",
+        "issues/360/comments?per_page=100&page=1",
+        status_code=200,
+        payload=[],
+    ).add_request(
+        "DELETE",
+        "issues/360/labels/status%3A%20draft",
+        status_code=204,
+        payload=None,
+    )
+    harness.runtime.github.stub(routes)
+    harness.runtime.github.post_comment_result = lambda issue_number, body: (_ for _ in ()).throw(
+        AssertionError("issue314 repair should not post reviewer-facing reminders")
+    )
+    harness.stub_load_state(lambda *, fail_on_unavailable=False: state)
+    harness.stub_save_state(lambda current: (_ for _ in ()).throw(AssertionError("label-only issue314 repair should not save state")))
+    harness.stub_sync_status_labels(lambda current, issue_numbers: (_ for _ in ()).throw(AssertionError("issue314 repair should not broad-sync labels")))
+    monkeypatch.setattr(
+        app,
+        "collect_status_projection_repair_items",
+        lambda bot, state: (_ for _ in ()).throw(AssertionError("issue314 repair broadened through epoch repair")),
+    )
+
+    result = harness.run_execute()
+
+    assert result.exit_code == 0
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert payload["active_rows_inspected"] == [360]
+    assert payload["rows_repaired"] == [360]
+    assert payload["rows_blocked"] == []
+    assert payload["status_labels_changed"] == [360]
+    assert payload["reviewer_facing_reminder_posts_attempted"] == 0
+    assert payload["result"] == "changed"

--- a/tests/unit/reviewer_bot/test_issue314_state_health.py
+++ b/tests/unit/reviewer_bot/test_issue314_state_health.py
@@ -9,19 +9,26 @@ from scripts.reviewer_bot_lib import issue314_state_health, reviews_projection
 from scripts.reviewer_bot_lib.reminder_comments import scan_reviewer_reminder_comments
 
 
-def _projection(issue_number: int, actual_labels: tuple[str, ...], state: str):
-    decision = to_reviewer_response_decision(
-        {
-            "issue_number": issue_number,
-            "current_reviewer": "iglesias",
-            "response_state": state,
-            "suppression_reason": "legacy_duplicate_reminders_exhausted"
-            if state == "reviewer_reassignment_needed"
-            else None,
-            "current_scope_key": "scope",
-            "current_scope_basis": "reminder_cadence_exhausted",
-        }
-    )
+def _projection(
+    issue_number: int,
+    actual_labels: tuple[str, ...],
+    state: str,
+    *,
+    suppresses_overdue_reminder: bool | None = None,
+):
+    decision_payload = {
+        "issue_number": issue_number,
+        "current_reviewer": "iglesias",
+        "response_state": state,
+        "suppression_reason": "legacy_duplicate_reminders_exhausted"
+        if state == "reviewer_reassignment_needed"
+        else None,
+        "current_scope_key": "scope",
+        "current_scope_basis": "reminder_cadence_exhausted",
+    }
+    if suppresses_overdue_reminder is not None:
+        decision_payload["suppresses_overdue_reminder"] = suppresses_overdue_reminder
+    decision = to_reviewer_response_decision(decision_payload)
     return decision, reviews_projection.derive_status_label_projection(
         reviews_projection.StatusLabelProjectionInput(
             issue_number=issue_number,
@@ -135,13 +142,105 @@ def test_issue314_classifier_marks_pr264_stale_label_as_operator_action_without_
     assert payload["output_keys"] == sorted(payload.keys())
 
 
-def test_issue314_classifier_blocks_rows_with_automated_reminder_risk():
-    decision, projection = _projection(42, (), "awaiting_reviewer_response")
+def test_issue314_classifier_keeps_aligned_awaiting_reviewer_response_healthy():
+    decision, projection = _projection(
+        42,
+        ("status: awaiting reviewer response",),
+        "awaiting_reviewer_response",
+    )
     input = issue314_state_health.Issue314StateHealthClassificationInput(
         state_issue_number=314,
         validation_nonce="nonce",
         active_review_rows=({"issue_number": 42, "review_data": {"current_reviewer": "alice"}},),
-        live_snapshots={42: {"number": 42, "state": "open", "pull_request": {}, "labels": []}},
+        live_snapshots={
+            42: {
+                "number": 42,
+                "state": "open",
+                "pull_request": {},
+                "labels": [{"name": "status: awaiting reviewer response"}],
+            }
+        },
+        reviewer_responses={42: decision},
+        status_projections={42: projection},
+        reminder_scans={42: scan_reviewer_reminder_comments([])},
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id="1",
+        run_attempt="1",
+    )
+
+    summary = issue314_state_health.classify_issue314_state_health(input)
+
+    assert summary.rows_blocked == ()
+    assert summary.rows_repairable == ()
+    row = summary.row_inventory[0]
+    assert row.health_classification == "healthy"
+    assert row.automated_reminder_risk is False
+    assert row.status_label_risk == "aligned"
+
+
+def test_issue314_classifier_marks_awaiting_reviewer_response_label_drift_repairable():
+    decision, projection = _projection(
+        360,
+        ("status: awaiting reviewer response", "status: draft"),
+        "awaiting_reviewer_response",
+    )
+    input = issue314_state_health.Issue314StateHealthClassificationInput(
+        state_issue_number=314,
+        validation_nonce="nonce",
+        active_review_rows=({"issue_number": 360, "review_data": {"current_reviewer": "alice"}},),
+        live_snapshots={
+            360: {
+                "number": 360,
+                "state": "open",
+                "labels": [
+                    {"name": "status: awaiting reviewer response"},
+                    {"name": "status: draft"},
+                ],
+            }
+        },
+        reviewer_responses={360: decision},
+        status_projections={360: projection},
+        reminder_scans={360: scan_reviewer_reminder_comments([])},
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id="1",
+        run_attempt="1",
+    )
+
+    summary = issue314_state_health.classify_issue314_state_health(input)
+
+    assert summary.rows_blocked == ()
+    assert summary.rows_repairable == (360,)
+    row = summary.row_inventory[0]
+    assert row.health_classification == "repairable"
+    assert row.automated_reminder_risk is False
+    assert row.status_label_risk == "repairable_drift"
+
+
+def test_issue314_classifier_blocks_contradictory_non_remindable_response():
+    decision, projection = _projection(
+        42,
+        ("status: reviewer reassignment needed",),
+        "reviewer_reassignment_needed",
+        suppresses_overdue_reminder=False,
+    )
+    input = issue314_state_health.Issue314StateHealthClassificationInput(
+        state_issue_number=314,
+        validation_nonce="nonce",
+        active_review_rows=({"issue_number": 42, "review_data": {"current_reviewer": "alice"}},),
+        live_snapshots={
+            42: {
+                "number": 42,
+                "state": "open",
+                "pull_request": {},
+                "labels": [{"name": "status: reviewer reassignment needed"}],
+            }
+        },
         reviewer_responses={42: decision},
         status_projections={42: projection},
         reminder_scans={42: scan_reviewer_reminder_comments([])},


### PR DESCRIPTION
## Summary
- Classify legitimate `awaiting_reviewer_response` issue314 rows as healthy or repairable instead of blocked.
- Preserve fail-closed behavior for contradictory reminder-suppression evidence.
- Add unit and integration coverage for Window 8 preview and repair behavior.

## Tests
- `uv run ruff check --fix`
- `uv run pytest tests/unit/reviewer_bot/test_issue314_state_health.py`
- `uv run pytest tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py tests/integration/reviewer_bot/test_app_repair_issue314_state_health.py`
- `uv run pytest tests/contract/reviewer_bot/test_workflow_artifact_contracts.py tests/contract/reviewer_bot/test_workflow_files.py`
- `uv run pytest tests/unit/reviewer_bot tests/integration/reviewer_bot tests/contract/reviewer_bot`