### PR TITLE
fix: ignore diagnostic PR comments in reviewer response

### DIFF
--- a/scripts/reviewer_bot_core/reviewer_response_policy.py
+++ b/scripts/reviewer_bot_core/reviewer_response_policy.py
@@ -742,6 +742,9 @@ def derive_reviewer_response_state(
             reason="pull_request_head_unavailable",
             scope_fields={"current_scope_key": None, "current_scope_basis": None},
         )
+    # Plain PR issue/review comments are diagnostic-only in v65. Explicit
+    # command handoff is represented separately by current_cycle_reviewer_handoff.
+    reviewer_comment = None
 
     reviewer_handoff = _current_cycle_reviewer_handoff_record(
         review_data,
@@ -824,7 +827,7 @@ def derive_reviewer_response_state(
     if reviewer_handoff is not None and latest_reviewer_response is reviewer_handoff:
         return _decorate_response(
             state="awaiting_contributor_response",
-            reason="accepted_same_scope_reviewer_activity",
+            reason="reviewer_feedback_handoff",
             scope_fields=_current_scope_fields(review_data, current_reviewer, current_head, contributor_handoff),
             anchor_timestamp=reviewer_handoff.get("timestamp"),
             current_head_sha=current_head,
@@ -860,7 +863,7 @@ def derive_reviewer_response_state(
             response_anchor = reviewer_comment if isinstance(reviewer_comment, dict) else reviewer_handoff
             return _decorate_response(
                 state="awaiting_contributor_response",
-                reason="accepted_same_scope_reviewer_activity",
+                reason="reviewer_feedback_handoff",
                 scope_fields=_current_scope_fields(review_data, current_reviewer, current_head, contributor_handoff),
                 anchor_timestamp=response_anchor.get("timestamp") if isinstance(response_anchor.get("timestamp"), str) else None,
                 current_head_sha=current_head,
@@ -989,6 +992,10 @@ def compute_reviewer_response_state(
     stored_reviewer_review = reviewer_review
     contributor_comment = review_data.get("contributor_comment", {}).get("accepted")
     had_reviewer_review = isinstance(reviewer_review, dict)
+    if is_pr:
+        # Plain PR issue/review comments are diagnostic-only in v65. Explicit
+        # command handoff is represented separately by current_cycle_reviewer_handoff.
+        reviewer_comment = None
 
     if not is_pr:
         return derive_reviewer_response_state(

--- a/scripts/reviewer_bot_lib/issue314_state_health.py
+++ b/scripts/reviewer_bot_lib/issue314_state_health.py
@@ -486,10 +486,17 @@ def _row_from_input(input: Issue314StateHealthClassificationInput, row: dict[str
                 reason = "row_can_still_trigger_reviewer_reminder"
                 blockers.append(reason)
             elif has_drift and issue_number == 264:
-                health = "operator_action_required"
-                repair = "not_attempted"
-                status_risk = "operator_visible_stale"
-                reason = "pr264_status_label_repair_deferred_to_issue_scoped_live_repair"
+                if projection.response_state != "reviewer_reassignment_needed":
+                    health = "blocked"
+                    repair = "blocked"
+                    status_risk = "blocked_unknown"
+                    reason = "pr264_projection_handoff_response_state_mismatch"
+                    blockers.append(reason)
+                else:
+                    health = "operator_action_required"
+                    repair = "not_attempted"
+                    status_risk = "operator_visible_stale"
+                    reason = "pr264_status_label_repair_deferred_to_issue_scoped_live_repair"
             elif has_drift:
                 health = "repairable"
                 repair = "not_attempted"

--- a/scripts/reviewer_bot_lib/reminder_comments.py
+++ b/scripts/reviewer_bot_lib/reminder_comments.py
@@ -77,7 +77,11 @@ def _matched_shape(first_line: str, body: str) -> str | None:
     if first_line.startswith(f"<!-- {TRANSITION_NOTICE_MARKER_PREFIX} "):
         return "markerized_transition_notice"
     normalized = body.lower()
-    if "**review reminder**" in normalized and "transition period" in normalized:
+    if "**review reminder**" in normalized and (
+        "transition period" in normalized
+        or "transitioned from producer to observer" in normalized
+        or "if no action is taken" in normalized
+    ):
         return "legacy_unmarked_warning"
     if "**transition period ended**" in normalized:
         return "legacy_unmarked_transition_notice"

--- a/tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py
+++ b/tests/integration/reviewer_bot/test_app_preview_issue314_state_health.py
@@ -9,7 +9,11 @@ from tests.fixtures.reviewer_bot import (
     pull_request_payload,
     review_payload,
 )
-from tests.fixtures.reviewer_bot_builders import accept_reviewer_review
+from tests.fixtures.reviewer_bot_builders import (
+    accept_contributor_revision,
+    accept_reviewer_comment,
+    accept_reviewer_review,
+)
 from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
 
 pytestmark = pytest.mark.integration
@@ -38,8 +42,8 @@ def test_execute_run_preview_issue314_state_health_is_read_only_and_inspects_act
         state,
         264,
         reviewer="iglesias",
-        assigned_at="2026-02-10T17:20:07Z",
-        active_cycle_started_at="2026-02-10T17:20:07Z",
+        assigned_at="2026-02-26T04:58:03.401345+00:00",
+        active_cycle_started_at="2026-02-26T04:58:03.401345+00:00",
     )
     accept_reviewer_review(
         review,
@@ -47,6 +51,19 @@ def test_execute_run_preview_issue314_state_health_is_read_only_and_inspects_act
         timestamp="2026-03-18T01:09:05Z",
         actor="iglesias",
         reviewed_head_sha="head-old",
+    )
+    accept_contributor_revision(
+        review,
+        semantic_key="pull_request_sync:264:head-live",
+        timestamp="2026-03-18T12:09:36.450502+00:00",
+        actor="manhatsu",
+        head_sha="head-live",
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:4240237244",
+        timestamp="2026-04-13T23:23:25Z",
+        actor="iglesias",
     )
     routes = RouteGitHubApi().add_request(
         "GET",
@@ -83,16 +100,26 @@ def test_execute_run_preview_issue314_state_health_is_read_only_and_inspects_act
         status_code=200,
         payload=[
             {
-                "id": 9001,
-                "user": {"login": "github-actions[bot]"},
-                "created_at": "2026-04-13T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "id": 4240237244,
+                "user": {"login": "iglesias"},
+                "created_at": "2026-04-13T23:23:25Z",
+                "body": "LGTM",
             },
             {
-                "id": 9002,
+                "id": 4240517367,
                 "user": {"login": "github-actions[bot]"},
                 "created_at": "2026-04-14T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, it's been more than 14 days since you were assigned to review this.\n\n"
+                "If no action is taken within 14 days, you may be transitioned from Producer to Observer status.",
+            },
+            {
+                "id": 4240520000,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-14T00:52:09Z",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, this review has already received its final transition notice.\n\n"
+                "If no action is taken, the reviewer may be transitioned from Producer to Observer status.",
             },
         ],
     )

--- a/tests/integration/reviewer_bot/test_app_preview_overdue.py
+++ b/tests/integration/reviewer_bot/test_app_preview_overdue.py
@@ -12,7 +12,11 @@ from tests.fixtures.reviewer_bot import (
     pull_request_payload,
     review_payload,
 )
-from tests.fixtures.reviewer_bot_builders import accept_reviewer_review
+from tests.fixtures.reviewer_bot_builders import (
+    accept_contributor_revision,
+    accept_reviewer_comment,
+    accept_reviewer_review,
+)
 from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
 
 pytestmark = pytest.mark.integration
@@ -37,8 +41,8 @@ def test_execute_run_preview_check_overdue_uses_frozen_pr264_operational_project
         state,
         264,
         reviewer="iglesias",
-        assigned_at="2026-02-10T17:20:07Z",
-        active_cycle_started_at="2026-02-10T17:20:07Z",
+        assigned_at="2026-02-26T04:58:03.401345+00:00",
+        active_cycle_started_at="2026-02-26T04:58:03.401345+00:00",
     )
     accept_reviewer_review(
         review,
@@ -46,6 +50,19 @@ def test_execute_run_preview_check_overdue_uses_frozen_pr264_operational_project
         timestamp="2026-03-18T01:09:05Z",
         actor="iglesias",
         reviewed_head_sha="head-old",
+    )
+    accept_contributor_revision(
+        review,
+        semantic_key="pull_request_sync:264:head-live",
+        timestamp="2026-03-18T12:09:36.450502+00:00",
+        actor="manhatsu",
+        head_sha="head-live",
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:4240237244",
+        timestamp="2026-04-13T23:23:25Z",
+        actor="iglesias",
     )
 
     routes = RouteGitHubApi().add_request(
@@ -71,16 +88,26 @@ def test_execute_run_preview_check_overdue_uses_frozen_pr264_operational_project
         status_code=200,
         payload=[
             {
-                "id": 9001,
-                "user": {"login": "github-actions[bot]"},
-                "created_at": "2026-04-13T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "id": 4240237244,
+                "user": {"login": "iglesias"},
+                "created_at": "2026-04-13T23:23:25Z",
+                "body": "LGTM",
             },
             {
-                "id": 9002,
+                "id": 4240517367,
                 "user": {"login": "github-actions[bot]"},
                 "created_at": "2026-04-14T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, it's been more than 14 days since you were assigned to review this.\n\n"
+                "If no action is taken within 14 days, you may be transitioned from Producer to Observer status.",
+            },
+            {
+                "id": 4240520000,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-14T00:52:09Z",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, this review has already received its final transition notice.\n\n"
+                "If no action is taken, the reviewer may be transitioned from Producer to Observer status.",
             },
         ],
     )
@@ -113,7 +140,7 @@ def test_execute_run_preview_check_overdue_uses_frozen_pr264_operational_project
     assert payload["response_state"] == "reviewer_reassignment_needed"
     assert payload["reviewer_authority_outcome"] == "tracked_reviewer_confirmed"
     assert payload["suppression_reason"] == "legacy_duplicate_reminders_exhausted"
-    assert payload["current_scope_key"] == "reviewer=iglesias|head=head-live|cycle=2026-02-10T17:20:07Z|anchor=2026-02-10T17:20:07Z"
+    assert payload["current_scope_key"] == "reviewer=iglesias|head=head-live|cycle=2026-02-26T04:58:03.401345+00:00|anchor=2026-03-18T12:09:36.450502+00:00"
     assert payload["current_scope_basis"] == "reminder_cadence_exhausted"
     assert payload["would_post_warning"] is False
     assert payload["would_post_transition"] is False

--- a/tests/integration/reviewer_bot/test_app_preview_status_label_projection.py
+++ b/tests/integration/reviewer_bot/test_app_preview_status_label_projection.py
@@ -9,7 +9,11 @@ from tests.fixtures.reviewer_bot import (
     pull_request_payload,
     review_payload,
 )
-from tests.fixtures.reviewer_bot_builders import accept_reviewer_review
+from tests.fixtures.reviewer_bot_builders import (
+    accept_contributor_revision,
+    accept_reviewer_comment,
+    accept_reviewer_review,
+)
 from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
 
 pytestmark = pytest.mark.integration
@@ -34,8 +38,8 @@ def test_execute_run_preview_status_label_projection_is_read_only_pr264_contract
         state,
         264,
         reviewer="iglesias",
-        assigned_at="2026-02-10T17:20:07Z",
-        active_cycle_started_at="2026-02-10T17:20:07Z",
+        assigned_at="2026-02-26T04:58:03.401345+00:00",
+        active_cycle_started_at="2026-02-26T04:58:03.401345+00:00",
     )
     accept_reviewer_review(
         review,
@@ -43,6 +47,19 @@ def test_execute_run_preview_status_label_projection_is_read_only_pr264_contract
         timestamp="2026-03-18T01:09:05Z",
         actor="iglesias",
         reviewed_head_sha="head-old",
+    )
+    accept_contributor_revision(
+        review,
+        semantic_key="pull_request_sync:264:head-live",
+        timestamp="2026-03-18T12:09:36.450502+00:00",
+        actor="manhatsu",
+        head_sha="head-live",
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:4240237244",
+        timestamp="2026-04-13T23:23:25Z",
+        actor="iglesias",
     )
     routes = RouteGitHubApi().add_request(
         "GET",
@@ -79,16 +96,26 @@ def test_execute_run_preview_status_label_projection_is_read_only_pr264_contract
         status_code=200,
         payload=[
             {
-                "id": 9001,
-                "user": {"login": "github-actions[bot]"},
-                "created_at": "2026-04-13T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "id": 4240237244,
+                "user": {"login": "iglesias"},
+                "created_at": "2026-04-13T23:23:25Z",
+                "body": "LGTM",
             },
             {
-                "id": 9002,
+                "id": 4240517367,
                 "user": {"login": "github-actions[bot]"},
                 "created_at": "2026-04-14T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, it's been more than 14 days since you were assigned to review this.\n\n"
+                "If no action is taken within 14 days, you may be transitioned from Producer to Observer status.",
+            },
+            {
+                "id": 4240520000,
+                "user": {"login": "github-actions[bot]"},
+                "created_at": "2026-04-14T00:52:09Z",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, this review has already received its final transition notice.\n\n"
+                "If no action is taken, the reviewer may be transitioned from Producer to Observer status.",
             },
         ],
     )

--- a/tests/integration/reviewer_bot/test_pr264_incident_replay_card.py
+++ b/tests/integration/reviewer_bot/test_pr264_incident_replay_card.py
@@ -7,9 +7,13 @@ from scripts.reviewer_bot_lib import maintenance
 from scripts.reviewer_bot_lib import overdue as overdue_lib
 from tests.fixtures.reconcile_harness import ReconcileHarness, issue_comment_payload
 from tests.fixtures.reviewer_bot import (
+    accept_contributor_revision,
+    accept_reviewer_comment,
+    accept_reviewer_review,
     make_state,
     make_tracked_review_state,
     pull_request_payload,
+    review_payload,
 )
 from tests.fixtures.reviewer_bot_fakes import RouteGitHubApi
 
@@ -22,8 +26,8 @@ def test_pr264_canonical_replay_card_keeps_plain_lgtm_diagnostic_only(monkeypatc
         state,
         264,
         reviewer="iglesias",
-        assigned_at="2026-02-10T17:20:07Z",
-        active_cycle_started_at="2026-02-10T17:20:07Z",
+        assigned_at="2026-02-26T04:58:03.401345+00:00",
+        active_cycle_started_at="2026-02-26T04:58:03.401345+00:00",
     )
     harness = ReconcileHarness(
         monkeypatch,
@@ -62,6 +66,51 @@ def test_pr264_canonical_replay_card_keeps_plain_lgtm_diagnostic_only(monkeypatc
     assert all(call.method == "GET" for call in harness.github.request_calls)
     assert harness.github.api_calls == []
 
+    accept_reviewer_review(
+        review,
+        semantic_key="pull_request_review:77",
+        timestamp="2026-03-18T01:09:05Z",
+        actor="iglesias",
+        reviewed_head_sha="head-old",
+    )
+    accept_contributor_revision(
+        review,
+        semantic_key="pull_request_sync:264:head-live",
+        timestamp="2026-03-18T12:09:36.450502+00:00",
+        actor="manhatsu",
+        head_sha="head-live",
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:4240237244",
+        timestamp="2026-04-13T23:23:25Z",
+        actor="iglesias",
+    )
+    legacy_comments = [
+        {
+            "id": 4240237244,
+            "user": {"login": "iglesias"},
+            "created_at": "2026-04-13T23:23:25Z",
+            "body": "LGTM",
+        },
+        {
+            "id": 4240517367,
+            "user": {"login": "github-actions[bot]"},
+            "created_at": "2026-04-14T00:44:23Z",
+            "body": "⚠️ **Review Reminder**\n\n"
+            "Hey @iglesias, it's been more than 14 days since you were assigned to review this.\n\n"
+            "If no action is taken within 14 days, you may be transitioned from Producer to Observer status.",
+        },
+        {
+            "id": 4240520000,
+            "user": {"login": "github-actions[bot]"},
+            "created_at": "2026-04-14T00:52:09Z",
+            "body": "⚠️ **Review Reminder**\n\n"
+            "Hey @iglesias, this review has already received its final transition notice.\n\n"
+            "If no action is taken, the reviewer may be transitioned from Producer to Observer status.",
+        },
+    ]
+
     routes = RouteGitHubApi().add_request(
         "GET",
         "issues/264",
@@ -76,24 +125,17 @@ def test_pr264_canonical_replay_card_keeps_plain_lgtm_diagnostic_only(monkeypatc
             "requested_reviewers": [],
             "labels": [],
         },
-    ).add_pull_request_reviews(264, []).add_request(
+    ).add_pull_request_reviews(
+        264,
+        [
+            review_payload(77, state="COMMENTED", submitted_at="2026-03-18T01:09:05Z", commit_id="head-old", author="iglesias"),
+            review_payload(501, state="APPROVED", submitted_at="2026-03-18T12:10:42Z", commit_id="head-live", author="plaindocs"),
+        ],
+    ).add_request(
         "GET",
         "issues/264/comments?per_page=100&page=1",
         status_code=200,
-        payload=[
-            {
-                "id": 9001,
-                "user": {"login": "github-actions[bot]"},
-                "created_at": "2026-04-13T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
-            },
-            {
-                "id": 9002,
-                "user": {"login": "github-actions[bot]"},
-                "created_at": "2026-04-14T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
-            },
-        ],
+        payload=legacy_comments,
     )
     harness.runtime.github.stub(routes)
 
@@ -112,22 +154,7 @@ def test_pr264_canonical_replay_card_keeps_plain_lgtm_diagnostic_only(monkeypatc
             "current_reviewer": "iglesias",
         }
     )
-    reminder_scan = overdue_lib.scan_reviewer_reminder_comments(
-        [
-            {
-                "id": 9001,
-                "user": {"login": "github-actions[bot]"},
-                "created_at": "2026-04-13T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
-            },
-            {
-                "id": 9002,
-                "user": {"login": "github-actions[bot]"},
-                "created_at": "2026-04-14T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
-            },
-        ]
-    )
+    reminder_scan = overdue_lib.scan_reviewer_reminder_comments(legacy_comments)
     cadence = overdue_lib.derive_reminder_cadence_decision(
         response,
         receipt=None,

--- a/tests/unit/reviewer_bot/test_issue314_state_health.py
+++ b/tests/unit/reviewer_bot/test_issue314_state_health.py
@@ -83,15 +83,19 @@ def test_issue314_classifier_marks_pr264_stale_label_as_operator_action_without_
     scan = scan_reviewer_reminder_comments(
         [
             {
-                "id": 1,
-                "created_at": "2026-04-13T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "id": 4240517367,
+                "created_at": "2026-04-14T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, it's been more than 14 days since you were assigned to review this.\n\n"
+                "If no action is taken within 14 days, you may be transitioned from Producer to Observer status.",
                 "user": {"login": "github-actions[bot]"},
             },
             {
-                "id": 2,
-                "created_at": "2026-04-14T00:44:23Z",
-                "body": "⚠️ **Review Reminder**\n\ntransition period",
+                "id": 4240520000,
+                "created_at": "2026-04-14T00:52:09Z",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, this review has already received its final transition notice.\n\n"
+                "If no action is taken, the reviewer may be transitioned from Producer to Observer status.",
                 "user": {"login": "github-actions[bot]"},
             },
         ]
@@ -140,6 +144,54 @@ def test_issue314_classifier_marks_pr264_stale_label_as_operator_action_without_
     assert row["status_label_risk"] == "operator_visible_stale"
     assert row["automated_reminder_risk"] is False
     assert payload["output_keys"] == sorted(payload.keys())
+
+
+def test_issue314_classifier_blocks_pr264_handoff_when_projection_truth_is_incompatible():
+    decision, projection = _projection(
+        264,
+        ("status: awaiting reviewer response",),
+        "awaiting_contributor_response",
+    )
+    input = issue314_state_health.Issue314StateHealthClassificationInput(
+        state_issue_number=314,
+        validation_nonce="nonce",
+        active_review_rows=(
+            {
+                "issue_number": 264,
+                "review_data": {
+                    "current_reviewer": "iglesias",
+                    "active_head_sha": "7d8864fa0c00b5bf9da20dd66047f039a049fd8b",
+                },
+            },
+        ),
+        live_snapshots={
+            264: {
+                "number": 264,
+                "state": "open",
+                "pull_request": {},
+                "labels": [{"name": "status: awaiting reviewer response"}],
+            }
+        },
+        reviewer_responses={264: decision},
+        status_projections={264: projection},
+        reminder_scans={264: scan_reviewer_reminder_comments([])},
+        evaluated_repo="rustfoundation/safety-critical-rust-coding-guidelines",
+        head_sha="head",
+        evaluated_ref="head",
+        workflow_path=".github/workflows/reviewer-bot-preview.yml",
+        run_id="1",
+        run_attempt="1",
+    )
+
+    summary = issue314_state_health.classify_issue314_state_health(input)
+    payload = summary.to_output()
+
+    assert payload["rows_operator_action_required"] == []
+    assert payload["rows_blocked"] == [264]
+    row = payload["row_inventory"][0]
+    assert row["health_classification"] == "blocked"
+    assert row["classification_reason"] == "pr264_projection_handoff_response_state_mismatch"
+    assert row["blockers"] == ["pr264_projection_handoff_response_state_mismatch"]
 
 
 def test_issue314_classifier_keeps_aligned_awaiting_reviewer_response_healthy():

--- a/tests/unit/reviewer_bot/test_reminder_comments.py
+++ b/tests/unit/reviewer_bot/test_reminder_comments.py
@@ -21,6 +21,25 @@ def test_scan_classifies_legacy_unmarked_warning_with_comment_created_at():
     assert scan.records[0].created_at == "2026-04-01T00:00:00Z"
 
 
+def test_scan_classifies_pr264_legacy_warning_text_without_transition_period_phrase():
+    scan = scan_reviewer_reminder_comments(
+        [
+            {
+                "id": 4240517367,
+                "created_at": "2026-04-14T00:44:23Z",
+                "body": "⚠️ **Review Reminder**\n\n"
+                "Hey @iglesias, it's been more than 14 days since you were assigned to review this.\n\n"
+                "If no action is taken within 14 days, you may be transitioned from Producer to Observer status.",
+                "user": {"login": "github-actions[bot]"},
+            }
+        ]
+    )
+
+    assert scan.scan_status == "pass"
+    assert scan.records[0].matched_shape == "legacy_unmarked_warning"
+    assert scan.records[0].created_at == "2026-04-14T00:44:23Z"
+
+
 def test_diff_uses_comment_identity_not_latest_timestamp_only():
     before = scan_reviewer_reminder_comments([])
     after = scan_reviewer_reminder_comments(

--- a/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
+++ b/tests/unit/reviewer_bot/test_reviewer_response_equivalence.py
@@ -585,7 +585,7 @@ def test_pr_feedback_handoff_requires_current_tracked_head():
     )
 
     assert current_head_result["state"] == "awaiting_contributor_response"
-    assert current_head_result["reason"] == "accepted_same_scope_reviewer_activity"
+    assert current_head_result["reason"] == "reviewer_feedback_handoff"
     assert stale_head_result["state"] == "awaiting_reviewer_response"
     assert stale_head_result["reason"] == "no_reviewer_activity"
 
@@ -663,7 +663,7 @@ def test_pr_feedback_handoff_overrides_existing_approval_completion_without_clea
     )
 
     assert result["state"] == "awaiting_contributor_response"
-    assert result["reason"] == "accepted_same_scope_reviewer_activity"
+    assert result["reason"] == "reviewer_feedback_handoff"
     assert review["review_completed_at"] == "2026-03-17T09:30:00Z"
     assert review["current_cycle_write_approval"] == {"has_write_approval": True}
 

--- a/tests/unit/reviewer_bot/test_reviews_live_fetch.py
+++ b/tests/unit/reviewer_bot/test_reviews_live_fetch.py
@@ -4,6 +4,7 @@ from scripts.reviewer_bot_core import approval_policy
 from scripts.reviewer_bot_lib import review_state, reviews
 from scripts.reviewer_bot_lib.config import (
     STATUS_AWAITING_CONTRIBUTOR_RESPONSE_LABEL,
+    STATUS_AWAITING_REVIEWER_RESPONSE_LABEL,
 )
 from tests.fixtures.fake_runtime import FakeReviewerBotRuntime
 from tests.fixtures.reviewer_bot import (
@@ -199,7 +200,7 @@ def test_repair_missing_reviewer_review_state_backfills_live_review_payload_when
     assert review.get("transition_notice_sent_at") == before["transition_notice_sent_at"]
 
 
-def test_project_status_labels_uses_commit_id_and_comment_freshness(monkeypatch):
+def test_project_status_labels_ignores_pr_reviewer_comment_when_review_head_stale(monkeypatch):
     state = make_state()
     review = make_tracked_review_state(state, 42, reviewer="alice", active_cycle_started_at="2026-03-17T09:00:00Z")
     accept_reviewer_comment(review, semantic_key="issue_comment:1", timestamp="2026-03-17T10:00:00Z", actor="alice")
@@ -209,8 +210,65 @@ def test_project_status_labels_uses_commit_id_and_comment_freshness(monkeypatch)
 
     desired_labels, metadata = reviews.project_status_labels_for_item(runtime, 42, state)
 
-    assert desired_labels == {STATUS_AWAITING_CONTRIBUTOR_RESPONSE_LABEL}
-    assert metadata["reason"] == "accepted_same_scope_reviewer_activity"
+    assert desired_labels == {STATUS_AWAITING_REVIEWER_RESPONSE_LABEL}
+    assert metadata["reason"] == "review_head_stale"
+
+
+def test_compute_reviewer_response_state_ignores_persisted_pr264_plain_comment_poison(monkeypatch):
+    state = make_state()
+    review = make_tracked_review_state(
+        state,
+        264,
+        reviewer="iglesias",
+        assigned_at="2026-02-26T04:58:03.401345+00:00",
+        active_cycle_started_at="2026-02-26T04:58:03.401345+00:00",
+    )
+    accept_reviewer_review(
+        review,
+        semantic_key="pull_request_review:77",
+        timestamp="2026-03-18T01:09:05Z",
+        actor="iglesias",
+        reviewed_head_sha="head-old",
+        source_precedence=1,
+    )
+    accept_contributor_revision(
+        review,
+        semantic_key="pull_request_sync:264:7d8864fa0c00b5bf9da20dd66047f039a049fd8b",
+        timestamp="2026-03-18T12:09:36.450502+00:00",
+        actor="manhatsu",
+        head_sha="7d8864fa0c00b5bf9da20dd66047f039a049fd8b",
+    )
+    accept_reviewer_comment(
+        review,
+        semantic_key="issue_comment:4240237244",
+        timestamp="2026-04-13T23:23:25Z",
+        actor="iglesias",
+    )
+    routes = RouteGitHubApi().add_pull_request_snapshot(
+        264,
+        pull_request_payload(264, head_sha="7d8864fa0c00b5bf9da20dd66047f039a049fd8b", author="manhatsu"),
+    ).add_pull_request_reviews(
+        264,
+        [
+            review_payload(77, state="COMMENTED", submitted_at="2026-03-18T01:09:05Z", commit_id="head-old", author="iglesias"),
+            review_payload(
+                501,
+                state="APPROVED",
+                submitted_at="2026-03-18T12:10:42Z",
+                commit_id="7d8864fa0c00b5bf9da20dd66047f039a049fd8b",
+                author="plaindocs",
+            ),
+        ],
+    )
+    runtime = _runtime(monkeypatch, routes)
+
+    response_state = reviews.compute_reviewer_response_state(runtime, 264, review)
+
+    assert response_state["state"] == "awaiting_reviewer_response"
+    assert response_state["reason"] == "contributor_revision_newer"
+    assert response_state["reviewer_comment"] is None
+    assert response_state["anchor_timestamp"] == "2026-03-18T12:09:36.450502+00:00"
+    assert response_state["current_scope_basis"] == "contributor_revision"
 
 
 def test_compute_reviewer_response_state_reports_review_head_stale_when_current_head_has_no_matching_review(monkeypatch):
@@ -358,7 +416,10 @@ def test_project_status_labels_emits_awaiting_write_approval_only_after_completi
     accept_reviewer_review(review, semantic_key="pull_request_review:10", timestamp="2026-03-17T10:01:00Z", actor="alice", reviewed_head_sha="head-1", source_precedence=1)
     routes = RouteGitHubApi().add_pull_request_snapshot(42, pull_request_payload(42, head_sha="head-1")).add_pull_request_reviews(
         42,
-        [review_payload(10, state="APPROVED", submitted_at="2026-03-17T10:01:00Z", commit_id="head-1", author="bob")],
+        [
+            review_payload(10, state="COMMENTED", submitted_at="2026-03-17T10:01:00Z", commit_id="head-1", author="alice"),
+            review_payload(11, state="APPROVED", submitted_at="2026-03-17T10:05:00Z", commit_id="head-1", author="bob"),
+        ],
     )
     runtime = _runtime(monkeypatch, routes)
     runtime.github.get_user_permission_status = lambda username, required_permission="triage": "denied"


### PR DESCRIPTION
## Summary
- ignore persisted plain PR reviewer comments when deriving reviewer-response turn-taking, while preserving explicit `/feedback` handoff semantics
- detect the real PR #264 legacy reminder wording so cadence exhaustion can project reviewer reassignment
- block issue314 PR #264 handoff when the embedded projection truth is incompatible with reviewer reassignment

## Verification
- uv run ruff check --fix
- uv run ruff check
- uv run pytest tests/unit/reviewer_bot tests/integration/reviewer_bot -q
- uv run pytest tests/contract/reviewer_bot -q