### PR TITLE
docs: refine pointer conversion guidance

### DIFF
--- a/src/appendices/standards-matrices/cert-c-2016-mapping.rst
+++ b/src/appendices/standards-matrices/cert-c-2016-mapping.rst
@@ -1,10 +1,12 @@
 Rust Cross Reference with CERT-C 2016
 =======================================
 
-The following tables provide a cross reference between the CERT-C 2025 guidelines and their applicability to Rust. The
+The following tables provide a cross reference between the CERT C 2016 guidelines and their applicability to Rust. The
 first table covers guidelines that are applicable to Rust in general, while the second table covers additional
 guidelines that are applicable in the presence of unsafe code. The third table lists guidelines that are not applicable
 to Rust.
+
+The mappings use the shared :ref:`standards-matrix-coverage`.
 
 
 Table 1 – Guidelines applicable to Rust in general (safe Rust, no unsafe code present)

--- a/src/appendices/standards-matrices/index.rst
+++ b/src/appendices/standards-matrices/index.rst
@@ -6,6 +6,20 @@
 Standards Matrices
 ==================
 
+.. _standards-matrix-coverage:
+
+Coverage Semantics
+------------------
+
+Standards matrices provide traceability between external standards and the Safety-Critical Rust Coding Guidelines;
+a populated mapping records a relationship, but does not by itself claim equivalent or complete coverage.
+A linked Safety-Critical Rust guideline may cover all or part of the corresponding external guideline. When coverage
+is partial, the comment shall identify the covered behavior and material gaps.
+
+A blank Safety-Critical Rust rule cell means that no mapping is currently recorded. It does not mean that the external
+guideline is inapplicable to Rust. Inapplicability shall be stated explicitly with a reason. Categories from the
+external standard and the Safety-Critical Rust Coding Guidelines are reported independently and need not match.
+
 .. toctree::
    :maxdepth: 1
 

--- a/src/appendices/standards-matrices/misra-c-2025-mapping.rst
+++ b/src/appendices/standards-matrices/misra-c-2025-mapping.rst
@@ -439,9 +439,10 @@ In addition to the rules from Table 1, these are the additional guidelines that 
      - includes both safe ``as`` and unsafe ``transmute`` operations
    * - R.11.1
      - Required
-     -
-     -
-     - includes both safe ``as`` and unsafe ``transmute`` operations
+     - :need:`gui_ADHABsmK9FXz`, :need:`gui_gghCZVhoRV8Z`
+     - Advisory, Required
+     - partial mapping: covers function-pointer-to-integer ``as`` and direct numeric-to-function-pointer
+       ``transmute`` operations only; other conversions involving function pointers remain uncovered
    * - R.11.2
      - Required
      -
@@ -1032,4 +1033,3 @@ Footnotes
 .. rubric:: Footnotes
 
 .. _MISRA C\:2025 Addendum 6: https://misra.org.uk/app/uploads/2025/03/MISRA-C-2025-ADD6.pdf
-

--- a/src/appendices/standards-matrices/misra-c-2025-mapping.rst
+++ b/src/appendices/standards-matrices/misra-c-2025-mapping.rst
@@ -6,6 +6,8 @@ first table covers guidelines that are applicable to Rust in general, while the 
 guidelines that are applicable in the presence of unsafe code. The third table lists guidelines that are not applicable
 to Rust.
 
+The mappings use the shared :ref:`standards-matrix-coverage`.
+
 The origin of this assessment can be found at `MISRA C:2025 Addendum 6`_.
 
 

--- a/src/coding-guidelines/expressions/gui_ADHABsmK9FXz.rst
+++ b/src/coding-guidelines/expressions/gui_ADHABsmK9FXz.rst
@@ -27,6 +27,9 @@ The 'as' operator should not be used with numeric operands
    **Exception:** ``as`` may be used with ``usize`` as the right operand and an expression of raw pointer
    type as the left operand.
 
+   An ``as`` cast from a numeric value to a raw pointer type is outside the scope of this guideline; it is
+   prohibited by the guideline `A numeric value shall not be converted to a pointer`.
+
    .. rationale::
       :id: rat_v56bjjcveLxQ
       :status: draft
@@ -45,13 +48,8 @@ The 'as' operator should not be used with numeric operands
       truncated when the destination integer type is too small. The ``usize`` type is guaranteed to be wide enough
       to hold the address value.
 
-      The inverse conversion is not symmetrical. Interpreting an integer as a machine address does not, by itself,
-      establish that the resulting pointer designates a valid object of the right type, is properly aligned, or has
-      provenance permitting a later memory access. The FLS classifies `access through a pointer without provenance
-      permitting that access <https://rust-lang.github.io/fls/values.html#fls_c3DaCLQEBpYQ>`_ as undefined behavior.
-
-      Neither ``as`` nor :std:`std::mem::transmute` validates those conditions. ``transmute`` makes an unsafe
-      conversion explicit, but it does not by itself establish that the resulting pointer may be dereferenced.
+      The exception permits extracting an address only. Converting a numeric value back to a raw pointer is governed
+      by the guideline `A numeric value shall not be converted to a pointer`.
 
    .. non_compliant_example::
       :id: non_compl_ex_hzGUYoMnK59w
@@ -60,10 +58,6 @@ The 'as' operator should not be used with numeric operands
       ``as`` used here can change the value range or lose precision.
       Even when it doesn't, nothing enforces the correct behaviour or communicates whether
       we intend to allow lossy conversions, or only expect valid conversions.
-
-      The integer-to-pointer casts are also noncompliant uses of ``as``. Replacing them with
-      ``transmute`` would make the conversion unsafe and explicit, but would not by itself
-      establish that the resulting pointer has provenance permitting memory access.
 
       .. rust-example::
 
@@ -84,11 +78,6 @@ The 'as' operator should not be used with numeric operands
            let _a1 = p1 as usize;        // compliant by exception
            let _a2 = p1 as u16;          // non-compliant - may lose address range
            let _a3 = p1 as u64;          // non-compliant - use usize to indicate intent
-
-           let a1 = p1 as usize;
-           let _p2 = a1 as * const u32;  // non-compliant - numeric-to-pointer cast
-           let a2 = p1 as u16;
-           let _p3 = a2 as * const u32;  // non-compliant (and most likely not in a valid address range)
          }
          #
          # fn main() {}
@@ -102,8 +91,7 @@ The 'as' operator should not be used with numeric operands
       Valid conversions that risk losing value, where doing so would be an error, can
       communicate this and include an error check, with ``try_into`` or ``try_from``.
       Bit reinterpretation through ``transmute`` is a different operation from numeric
-      value conversion and is not a general replacement for an integer-to-pointer cast.
-      Every ``transmute`` must independently satisfy its safety requirements.
+      value conversion. Every ``transmute`` must independently satisfy its safety requirements.
 
       .. rust-example::
          :miri:

--- a/src/coding-guidelines/expressions/gui_ADHABsmK9FXz.rst
+++ b/src/coding-guidelines/expressions/gui_ADHABsmK9FXz.rst
@@ -41,13 +41,17 @@ The 'as' operator should not be used with numeric operands
       value, and which are intended to be fallible. The latter cannot be used from const functions, indicating
       that these should avoid using fallible conversions.
 
-      A pointer-to-address cast does not lose value, but will be truncated unless the destination type is large
-      enough to hold the address value. The ``usize`` type is guaranteed to be wide enough for this purpose.
+      A pointer-to-address cast produces an integer that represents the pointer's machine address. The address is
+      truncated when the destination integer type is too small. The ``usize`` type is guaranteed to be wide enough
+      to hold the address value.
 
-      A pointer-to-address cast is not symmetrical because the resulting pointer may not point to a valid object,
-      may not point to an object of the right type, or may not be properly aligned.
-      If a conversion in this direction is needed, :std:`std::mem::transmute` will communicate the intent to perform
-      an unsafe operation.
+      The inverse conversion is not symmetrical. Interpreting an integer as a machine address does not, by itself,
+      establish that the resulting pointer designates a valid object of the right type, is properly aligned, or has
+      provenance permitting a later memory access. The FLS classifies `access through a pointer without provenance
+      permitting that access <https://rust-lang.github.io/fls/values.html#fls_c3DaCLQEBpYQ>`_ as undefined behavior.
+
+      Neither ``as`` nor :std:`std::mem::transmute` validates those conditions. ``transmute`` makes an unsafe
+      conversion explicit, but it does not by itself establish that the resulting pointer may be dereferenced.
 
    .. non_compliant_example::
       :id: non_compl_ex_hzGUYoMnK59w
@@ -56,6 +60,10 @@ The 'as' operator should not be used with numeric operands
       ``as`` used here can change the value range or lose precision.
       Even when it doesn't, nothing enforces the correct behaviour or communicates whether
       we intend to allow lossy conversions, or only expect valid conversions.
+
+      The integer-to-pointer casts are also noncompliant uses of ``as``. Replacing them with
+      ``transmute`` would make the conversion unsafe and explicit, but would not by itself
+      establish that the resulting pointer has provenance permitting memory access.
 
       .. rust-example::
 
@@ -78,7 +86,7 @@ The 'as' operator should not be used with numeric operands
            let _a3 = p1 as u64;          // non-compliant - use usize to indicate intent
 
            let a1 = p1 as usize;
-           let _p2 = a1 as * const u32;  // non-compliant - prefer transmute
+           let _p2 = a1 as * const u32;  // non-compliant - numeric-to-pointer cast
            let a2 = p1 as u16;
            let _p3 = a2 as * const u32;  // non-compliant (and most likely not in a valid address range)
          }
@@ -93,7 +101,9 @@ The 'as' operator should not be used with numeric operands
       better with ``into()`` or ``from()``.
       Valid conversions that risk losing value, where doing so would be an error, can
       communicate this and include an error check, with ``try_into`` or ``try_from``.
-      Other forms of conversion may find ``transmute`` better communicates their intent.
+      Bit reinterpretation through ``transmute`` is a different operation from numeric
+      value conversion and is not a general replacement for an integer-to-pointer cast.
+      Every ``transmute`` must independently satisfy its safety requirements.
 
       .. rust-example::
          :miri:
@@ -114,23 +124,11 @@ The 'as' operator should not be used with numeric operands
 
            let h: u32 = 0;
            let p1: * const u32 = &h;
-           let a1 = p1 as usize;     // (compliant)
+           let _address = p1 as usize; // compliant by exception
 
            unsafe {
-             let _a2: usize = std::mem::transmute(p1);  // OK
-             let _a3: u64   = std::mem::transmute(p1);  // OK, size is checked
-             // let a3: u16   = std::mem::transmute(p1);  // invalid, different sizes
-
-             #[allow(integer_to_ptr_transmutes)]
-             let _p2: * const u32 = std::mem::transmute(a1); // OK
-             #[allow(integer_to_ptr_transmutes)]
-             let _p3: * const u32 = std::mem::transmute(a1); // OK
-           }
-
-           unsafe {
-             // does something entirely different,
-             // reinterpreting the bits of z as the IEEE bit pattern of a double
-             // precision object, rather than converting the integer value
+             // Reinterpret the bits of z as an IEEE double-precision value.
+             // This is not a numeric value conversion.
              #[allow(unnecessary_transmutes)]
              let _f1: f64 = std::mem::transmute(_z);
            }

--- a/src/coding-guidelines/expressions/gui_PM8Vpf7lZ51U.rst
+++ b/src/coding-guidelines/expressions/gui_PM8Vpf7lZ51U.rst
@@ -22,6 +22,12 @@ An integer shall not be converted to a pointer
    :std:`std::mem::transmute` shall not be used with any numeric type (including floating point types)
    as the argument to the ``Src`` parameter, and any pointer type as the argument to the ``Dst`` parameter.
 
+   In this guideline, "any pointer type" includes raw pointer types, reference types, and function
+   pointer types. This is intentionally broader than the FLS definition of `pointer type
+   <https://rust-lang.github.io/fls/types-and-traits.html#fls_3qI8FXMsyk0f>`_, which excludes
+   function pointer types: creating a function pointer from a numeric value via
+   :std:`std::mem::transmute` carries at least the same risk as creating a data pointer.
+
    .. rationale::
       :id: rat_YqhEiWTj9z6L
       :status: draft
@@ -30,6 +36,16 @@ An integer shall not be converted to a pointer
       including an address that does not point to a valid object, an address that points to an
       object of the wrong type, or an address that is not properly aligned. Use of such a pointer
       to access memory will result in undefined behavior.
+
+      Satisfying those address, type, and alignment conditions is not sufficient to establish that
+      memory access is permitted. A `well-formed pointer may carry no provenance
+      <https://rust-lang.github.io/fls/values.html#fls_ffh8mAkebORJ>`_, and `accessing memory through a pointer
+      without provenance permitting the access <https://rust-lang.github.io/fls/values.html#fls_c3DaCLQEBpYQ>`_
+      is undefined behavior.
+
+      The FLS does not specify the provenance result of every numeric-to-pointer conversion. This
+      guideline therefore imposes a conservative subset restriction instead of treating a matching
+      numeric address or pointer representation as proof that the result may be dereferenced.
 
       The ``as`` operator also does not check that the size of the source operand is the same as
       the size of a pointer, which may lead to unexpected results if the address computation was

--- a/src/coding-guidelines/expressions/gui_PM8Vpf7lZ51U.rst
+++ b/src/coding-guidelines/expressions/gui_PM8Vpf7lZ51U.rst
@@ -23,10 +23,7 @@ An integer shall not be converted to a pointer
    as the argument to the ``Src`` parameter, and any pointer type as the argument to the ``Dst`` parameter.
 
    In this guideline, "any pointer type" includes raw pointer types, reference types, and function
-   pointer types. This is intentionally broader than the FLS definition of `pointer type
-   <https://rust-lang.github.io/fls/types-and-traits.html#fls_3qI8FXMsyk0f>`_, which excludes
-   function pointer types: creating a function pointer from a numeric value via
-   :std:`std::mem::transmute` carries at least the same risk as creating a data pointer.
+   pointer types.
 
    .. rationale::
       :id: rat_YqhEiWTj9z6L
@@ -53,6 +50,11 @@ An integer shall not be converted to a pointer
 
       While ``as`` can notionally be used to create a null pointer, the functions
       :std:`core::ptr::null` and :std:`core::ptr::null_mut` are the more idiomatic way to do this.
+
+      This guideline's use of "any pointer type" is intentionally broader than the FLS definition of
+      `pointer type <https://rust-lang.github.io/fls/types-and-traits.html#fls_3qI8FXMsyk0f>`_, which
+      excludes function pointer types. Creating a function pointer from a numeric value via
+      :std:`std::mem::transmute` carries at least the same risk as creating a data pointer.
 
    .. non_compliant_example::
       :id: non_compl_ex_0ydPk7VENSrA

--- a/src/coding-guidelines/expressions/gui_PM8Vpf7lZ51U.rst
+++ b/src/coding-guidelines/expressions/gui_PM8Vpf7lZ51U.rst
@@ -3,10 +3,10 @@
 
 .. default-domain:: coding-guidelines
 
-An integer shall not be converted to a pointer
-==============================================
+A numeric value shall not be converted to a pointer
+===================================================
 
-.. guideline:: An integer shall not be converted to a pointer
+.. guideline:: A numeric value shall not be converted to a pointer
    :id: gui_PM8Vpf7lZ51U
    :category: <TODO>
    :status: draft
@@ -22,8 +22,10 @@ An integer shall not be converted to a pointer
    :std:`std::mem::transmute` shall not be used with any numeric type (including floating point types)
    as the argument to the ``Src`` parameter, and any pointer type as the argument to the ``Dst`` parameter.
 
-   In this guideline, "any pointer type" includes raw pointer types, reference types, and function
-   pointer types.
+   In this guideline, "any pointer type" means a raw pointer type or a reference type, matching the
+   FLS definition of pointer type :cite:`gui_PM8Vpf7lZ51U:FLS-POINTER-TYPES`.
+   Direct transmutation of a numeric value to a function pointer is prohibited by the guideline
+   `A numeric value shall not be transmuted to a function pointer`.
 
    .. rationale::
       :id: rat_YqhEiWTj9z6L
@@ -35,10 +37,10 @@ An integer shall not be converted to a pointer
       to access memory will result in undefined behavior.
 
       Satisfying those address, type, and alignment conditions is not sufficient to establish that
-      memory access is permitted. A `well-formed pointer may carry no provenance
-      <https://rust-lang.github.io/fls/values.html#fls_ffh8mAkebORJ>`_, and `accessing memory through a pointer
-      without provenance permitting the access <https://rust-lang.github.io/fls/values.html#fls_c3DaCLQEBpYQ>`_
-      is undefined behavior.
+      memory access is permitted. A well-formed pointer may carry no provenance
+      :cite:`gui_PM8Vpf7lZ51U:FLS-WELL-FORMED-POINTER`, and accessing memory through a pointer without
+      provenance permitting the access is undefined behavior
+      :cite:`gui_PM8Vpf7lZ51U:FLS-POINTER-ACCESS-PROVENANCE`.
 
       The FLS does not specify the provenance result of every numeric-to-pointer conversion. This
       guideline therefore imposes a conservative subset restriction instead of treating a matching
@@ -51,42 +53,20 @@ An integer shall not be converted to a pointer
       While ``as`` can notionally be used to create a null pointer, the functions
       :std:`core::ptr::null` and :std:`core::ptr::null_mut` are the more idiomatic way to do this.
 
-      This guideline's use of "any pointer type" is intentionally broader than the FLS definition of
-      `pointer type <https://rust-lang.github.io/fls/types-and-traits.html#fls_3qI8FXMsyk0f>`_, which
-      excludes function pointer types. Creating a function pointer from a numeric value via
-      :std:`std::mem::transmute` carries at least the same risk as creating a data pointer.
-
    .. non_compliant_example::
       :id: non_compl_ex_0ydPk7VENSrA
       :status: draft
 
-      Any use of ``as`` or ``transmute`` to create a pointer from an arithmetic address value
-      is non-compliant:
+      Reconstructing a pointer from a numeric address is noncompliant even when the address was
+      obtained from a valid pointer:
 
       .. rust-example::
         :miri:
 
         #[allow(dead_code)]
-        fn f1(x: u16, y: i32, z: u64, w: usize) {
-          let _p1 = x as * const u32;  // not compliant
-          let _p2 = y as * const u32;  // not compliant
-          let _p3 = z as * const u32;  // not compliant
-          let _p4 = w as * const u32;  // not compliant despite being the right size
-
-          let _f: f64 = 10.0;
-          // let p5 = f as * const u32;  // not valid
-
-          unsafe {
-            // let p5: * const u32 = std::mem::transmute(x);  // not valid
-            // let p6: * const u32 = std::mem::transmute(y);  // not valid
-
-            #[allow(integer_to_ptr_transmutes)]
-            let _p7: * const u32 = std::mem::transmute(z); // not compliant
-            #[allow(integer_to_ptr_transmutes)]
-            let _p8: * const u32 = std::mem::transmute(w); // not compliant
-
-            let _p9: * const u32 = std::mem::transmute(_f); // not compliant, and very strange
-          }
+        fn f1(value: &u32) {
+          let address = value as * const u32 as usize;
+          let _pointer = address as * const u32; // non-compliant
         }
         #
         # fn main() {}
@@ -95,4 +75,29 @@ An integer shall not be converted to a pointer
       :id: compl_ex_oneKuF52yzrx
       :status: draft
 
-      There is no compliant example of this operation.
+      Preserve a pointer as a pointer instead of converting it through a numeric value:
+
+      .. rust-example::
+
+         #[allow(dead_code)]
+         fn f2(value: &u32) {
+           let _pointer: * const u32 = value;
+         }
+         #
+         # fn main() {}
+
+   .. bibliography::
+      :id: bib_PM8Vpf7lZ51U
+      :status: draft
+
+      .. list-table::
+         :header-rows: 0
+         :widths: auto
+         :class: bibliography-table
+
+         * - :bibentry:`gui_PM8Vpf7lZ51U:FLS-POINTER-TYPES`
+           - The Rust FLS. "Types and Traits - Indirection Types." https://rust-lang.github.io/fls/types-and-traits.html#fls_3qI8FXMsyk0f
+         * - :bibentry:`gui_PM8Vpf7lZ51U:FLS-WELL-FORMED-POINTER`
+           - The Rust FLS. "Values - Pointer Types." https://rust-lang.github.io/fls/values.html#fls_ffh8mAkebORJ
+         * - :bibentry:`gui_PM8Vpf7lZ51U:FLS-POINTER-ACCESS-PROVENANCE`
+           - The Rust FLS. "Values - Pointer Types." https://rust-lang.github.io/fls/values.html#fls_c3DaCLQEBpYQ

--- a/src/coding-guidelines/expressions/gui_gghCZVhoRV8Z.rst
+++ b/src/coding-guidelines/expressions/gui_gghCZVhoRV8Z.rst
@@ -1,0 +1,86 @@
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+   SPDX-FileCopyrightText: The Coding Guidelines Subcommittee Contributors
+
+.. default-domain:: coding-guidelines
+
+A numeric value shall not be transmuted to a function pointer
+=============================================================
+
+.. guideline:: A numeric value shall not be transmuted to a function pointer
+   :id: gui_gghCZVhoRV8Z
+   :category: required
+   :status: draft
+   :release: <TODO>
+   :fls: fls_52thmi9hnoks
+   :decidability: decidable
+   :scope: module
+   :tags: subset, undefined-behavior
+
+   :std:`std::mem::transmute` shall not be used with any numeric type (including floating point types)
+   as the argument to the ``Src`` parameter, and any function pointer type as the argument to the
+   ``Dst`` parameter.
+
+   .. rationale::
+      :id: rat_71j2Ud06kthz
+      :status: draft
+
+      An all-zero numeric representation can produce a null function pointer and violate the function-pointer
+      validity invariant at construction :cite:`gui_gghCZVhoRV8Z:FLS-FUNCTION-POINTER-TYPES`. A nonzero
+      representation does not violate that invariant merely because it came from a numeric value, but non-nullness
+      alone does not establish that it designates a function callable through the destination function pointer type.
+
+      In particular, the FLS defines calling a function with an ABI other than the ABI with which it was defined as
+      undefined behavior :cite:`gui_gghCZVhoRV8Z:FLS-CALL-EXPRESSIONS`. A numeric value cannot establish that the
+      address designates a function callable through the destination function pointer type. This guideline therefore
+      imposes a conservative subset restriction on direct numeric-to-function-pointer transmutation.
+
+      The ``as`` operator cannot directly convert a numeric value to a function pointer. Direct numeric-to-raw-pointer
+      ``as`` casts and numeric-to-pointer :std:`std::mem::transmute` operations are prohibited by the guideline
+      `A numeric value shall not be converted to a pointer`.
+
+   .. non_compliant_example::
+      :id: non_compl_ex_jg56Jyx1KbkE
+      :status: draft
+
+      Directly transmuting a numeric value to a function pointer is noncompliant, even if the resulting pointer is
+      never called:
+
+      .. rust-example::
+         :miri:
+
+         #[allow(dead_code)]
+         fn f1(address: usize) {
+           unsafe {
+             let _function = std::mem::transmute::<usize, fn()>(address); // non-compliant
+           }
+         }
+         #
+         # fn main() {}
+
+   .. compliant_example::
+      :id: compl_ex_8S7Xw4sUk6kP
+      :status: draft
+
+      Obtain a function pointer from a function item instead of fabricating one from a numeric value:
+
+      .. rust-example::
+
+         fn target() {}
+
+         fn main() {
+           let _handler: fn() = target;
+         }
+
+   .. bibliography::
+      :id: bib_gghCZVhoRV8Z
+      :status: draft
+
+      .. list-table::
+         :header-rows: 0
+         :widths: auto
+         :class: bibliography-table
+
+         * - :bibentry:`gui_gghCZVhoRV8Z:FLS-FUNCTION-POINTER-TYPES`
+           - The Rust FLS. "Types and Traits - Indirection Types - Function Pointer Types." https://rust-lang.github.io/fls/types-and-traits.html#fls_52thmi9hnoks
+         * - :bibentry:`gui_gghCZVhoRV8Z:FLS-CALL-EXPRESSIONS`
+           - The Rust FLS. "Expressions - Call Expressions." https://rust-lang.github.io/fls/expressions.html#fls_5yeq4oah58dl

--- a/src/coding-guidelines/expressions/gui_iv9yCMHRgpE0.rst
+++ b/src/coding-guidelines/expressions/gui_iv9yCMHRgpE0.rst
@@ -26,6 +26,16 @@ An integer shall not be converted to an invalid pointer
       The mapping between pointers and integers must be consistent with the addressing structure of the
       execution environment. Issues may arise, for example, on architectures that have a segmented memory model.
 
+      Constructing a pointer from an integer and accessing memory through that pointer are distinct operations.
+      A `well-formed pointer may carry no provenance
+      <https://rust-lang.github.io/fls/values.html#fls_ffh8mAkebORJ>`_ despite having a plausible machine address.
+      Before the pointer is used to read or write memory, it must have `provenance permitting that access
+      <https://rust-lang.github.io/fls/values.html#fls_c3DaCLQEBpYQ>`_ in addition to satisfying the alignment,
+      type, and representation conditions above.
+
+      This guideline constrains the result of the conversion. It does not claim that constructing or storing an
+      integer-derived pointer, without accessing memory through it, is by itself undefined behavior.
+
    .. non_compliant_example::
       :id: non_compl_ex_CkytKjRQezfQ
       :status: draft
@@ -34,6 +44,11 @@ An integer shall not be converted to an invalid pointer
       The manipulated address may have discarded part of the original address space, and the flag may
       silently interfere with the address value. On platforms where pointers are 64-bits this may have
       particularly unexpected results.
+
+      The example constructs the resulting pointer but does not access memory through it. It is noncompliant
+      because the address manipulation does not demonstrate that the result meets this guideline's alignment,
+      type, and representation requirements. Any later memory access would additionally require provenance
+      permitting that access.
 
       .. rust-example::
 
@@ -53,7 +68,8 @@ An integer shall not be converted to an invalid pointer
 
       This compliant solution uses a struct to provide storage for both the pointer and the flag value.
       This solution is portable to machines of different word sizes, both smaller and larger than 32 bits,
-      working even when pointers cannot be represented in any integer type.
+      working even when pointers cannot be represented in any integer type. Keeping the pointer as a pointer
+      also preserves its provenance instead of reconstructing it from a numeric address.
 
       .. rust-example::
 

--- a/src/coding-guidelines/expressions/gui_iv9yCMHRgpE0.rst
+++ b/src/coding-guidelines/expressions/gui_iv9yCMHRgpE0.rst
@@ -3,10 +3,10 @@
 
 .. default-domain:: coding-guidelines
 
-An integer shall not be converted to an invalid pointer
-=======================================================
+A numeric value shall not be converted to an invalid pointer
+============================================================
 
-.. guideline:: An integer shall not be converted to an invalid pointer
+.. guideline:: A numeric value shall not be converted to an invalid pointer
    :id: gui_iv9yCMHRgpE0
    :category: <TODO>
    :status: draft
@@ -27,14 +27,17 @@ An integer shall not be converted to an invalid pointer
       execution environment. Issues may arise, for example, on architectures that have a segmented memory model.
 
       Constructing a pointer from an integer and accessing memory through that pointer are distinct operations.
-      A `well-formed pointer may carry no provenance
-      <https://rust-lang.github.io/fls/values.html#fls_ffh8mAkebORJ>`_ despite having a plausible machine address.
-      Before the pointer is used to read or write memory, it must have `provenance permitting that access
-      <https://rust-lang.github.io/fls/values.html#fls_c3DaCLQEBpYQ>`_ in addition to satisfying the alignment,
-      type, and representation conditions above.
+      A well-formed pointer may carry no provenance :cite:`gui_iv9yCMHRgpE0:FLS-WELL-FORMED-POINTER`
+      despite having a plausible machine address. Before the pointer is used to read or write memory, it must
+      have provenance permitting that access :cite:`gui_iv9yCMHRgpE0:FLS-POINTER-ACCESS-PROVENANCE` in
+      addition to satisfying the alignment, type, and representation conditions above.
 
       This guideline constrains the result of the conversion. It does not claim that constructing or storing an
       integer-derived pointer, without accessing memory through it, is by itself undefined behavior.
+
+      This guideline remains binding when code operates under an approved deviation from the guideline
+      `A numeric value shall not be converted to a pointer`: a deviation permits performing the
+      conversion, but does not permit the conversion to produce an invalid pointer.
 
    .. non_compliant_example::
       :id: non_compl_ex_CkytKjRQezfQ
@@ -45,6 +48,9 @@ An integer shall not be converted to an invalid pointer
       silently interfere with the address value. On platforms where pointers are 64-bits this may have
       particularly unexpected results.
 
+      Assume the numeric-to-pointer conversion below is covered by an approved deviation from the guideline
+      `A numeric value shall not be converted to a pointer`.
+
       The example constructs the resulting pointer but does not access memory through it. It is noncompliant
       because, for some inputs or platforms where its layout assumptions do not hold, the masked and shifted
       address can yield a pointer that is incorrectly aligned, does not point to an entity of the referenced
@@ -54,10 +60,10 @@ An integer shall not be converted to an invalid pointer
       .. rust-example::
 
         #[allow(dead_code)]
-        fn f1(flag: u32, ptr: * const u32) {
+        fn f1(flag: usize, ptr: * const u32) {
           /* ... */
           let mut rep = ptr as usize;
-          rep = (rep & 0x7fffff) | ((flag as usize) << 23);
+          rep = (rep & 0x7fffff) | (flag << 23);
           let _p2 = rep as * const u32;
         }
         #
@@ -90,3 +96,17 @@ An integer shall not be converted to an invalid pointer
         }
         #
         # fn main() {}
+
+   .. bibliography::
+      :id: bib_iv9yCMHRgpE0
+      :status: draft
+
+      .. list-table::
+         :header-rows: 0
+         :widths: auto
+         :class: bibliography-table
+
+         * - :bibentry:`gui_iv9yCMHRgpE0:FLS-WELL-FORMED-POINTER`
+           - The Rust FLS. "Values - Pointer Types." https://rust-lang.github.io/fls/values.html#fls_ffh8mAkebORJ
+         * - :bibentry:`gui_iv9yCMHRgpE0:FLS-POINTER-ACCESS-PROVENANCE`
+           - The Rust FLS. "Values - Pointer Types." https://rust-lang.github.io/fls/values.html#fls_c3DaCLQEBpYQ

--- a/src/coding-guidelines/expressions/gui_iv9yCMHRgpE0.rst
+++ b/src/coding-guidelines/expressions/gui_iv9yCMHRgpE0.rst
@@ -46,9 +46,10 @@ An integer shall not be converted to an invalid pointer
       particularly unexpected results.
 
       The example constructs the resulting pointer but does not access memory through it. It is noncompliant
-      because the address manipulation does not demonstrate that the result meets this guideline's alignment,
-      type, and representation requirements. Any later memory access would additionally require provenance
-      permitting that access.
+      because, for some inputs or platforms where its layout assumptions do not hold, the masked and shifted
+      address can yield a pointer that is incorrectly aligned, does not point to an entity of the referenced
+      type, or has an invalid representation. Such a result violates this guideline. Any later memory access
+      would additionally require provenance permitting that access.
 
       .. rust-example::
 


### PR DESCRIPTION
## Summary
- clarify numeric-to-pointer guidance using the current FLS provenance rules
- remove overlapping rule ownership and isolate each noncompliant example
- add a focused rule for direct numeric-to-function-pointer `transmute`
- define shared matrix coverage semantics and record partial MISRA C R.11.1 coverage

Follow-up to #1225; the FLS lock update landed in #1228.

## Checks
- `./make.py`
- FLS audit: no remaining changes
- 79 Rust examples and 14 Miri checks passed