### PR TITLE
Add draft guideline for avoiding unused macros

### DIFF
--- a/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
+++ b/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
@@ -49,7 +49,7 @@ Avoid unused macros
             }
 
             fn main() {
-              self::used_macro!()
+              self::used_macro!{}
             }
 
 .. bibliography::

--- a/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
+++ b/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
@@ -28,6 +28,7 @@ Avoid unused macros
         .. rust-example::
             :no_run:
 
+            #[allow(unused_macros)]
             macro_rules! never_used {
                 () => {};
             }

--- a/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
+++ b/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
@@ -26,6 +26,7 @@ Avoid unused macros
         The macro `never_used` is not used.
 
         .. rust-example::
+            :no_run:
 
             macro_rules! never_used {
                 () => {};
@@ -43,13 +44,14 @@ Avoid unused macros
 
         .. rust-example::
 
-            #[macro_export]
             macro_rules! used_macro {
-                () => {};
+            ($t:expr) => {
+                println!("MACRO TEXT: {}", $t);
+                }
             }
 
             fn main() {
-              self::used_macro!{}
+            used_macro!("I am used, therefore I am.");
             }
 
 .. bibliography::

--- a/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
+++ b/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
@@ -7,7 +7,7 @@ Avoid unused macros
     :status: draft
     :release: unclear
     :fls: fls_83182bfa9uqb
-    :decidability: decideable
+    :decidability: decidable
     :scope: system
     :tags: maintainability
 

--- a/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
+++ b/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
@@ -1,0 +1,68 @@
+Avoid unused macros
+===================
+
+.. guideline:: Avoid Unused Macros
+    :id: gui_GQm4lfJ4zYUD
+    :category: advisory
+    :status: draft
+    :release: unclear
+    :fls: fls_83182bfa9uqb
+    :decidability: decideable
+    :scope: system
+    :tags: maintainability
+
+    Avoid defining macros that are never used.
+
+    .. rationale::
+        :id: rat_h36jR1v3hTnx
+        :status: draft
+
+        Ensuring that all code is used reduces potential mistakes in unfinished code.
+
+    .. non_compliant_example::
+        :id: non_compl_ex_1dv2kGST217Z
+        :status: draft
+
+        The macro `never_used` is not used.
+
+        .. rust-example::
+
+            macro_rules! never_used {
+                () => {};
+            }
+
+            fn main() {
+            }
+
+
+    .. compliant_example::
+        :id: compl_ex_gtdFrUPXYBG2
+        :status: draft
+
+        The `used_macro` is exported and used.
+
+        .. rust-example::
+
+            #[macro_export]
+            macro_rules! used_macro {
+                () => {};
+            }
+
+            fn main() {
+              self::used_macro!()
+            }
+
+.. bibliography::
+      :id: bib_STH4njMLYuZ
+      :status: draft
+
+      .. list-table::
+         :header-rows: 0
+         :widths: auto
+         :class: bibliography-table
+
+         * - :bibentry:`gui_GQm4lfJ4zYUD:RUSTC-LINT`
+           - Rust C lints. "UNUSED_MACROS" https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.UNUSED_MACROS.html
+
+         * - :bibentry:`gui_GQm4lfJ4zYUD:MISRA-C`
+           - MISRA C. "Rule 2.5" https://misra.org.uk/product/misra-c2025/

--- a/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
+++ b/src/coding-guidelines/macros/gui_GQm4lfJ4zYUD.rst
@@ -52,7 +52,7 @@ Avoid unused macros
             }
 
             fn main() {
-            used_macro!("I am used, therefore I am.");
+                used_macro!("I am used, therefore I am.");
             }
 
 .. bibliography::


### PR DESCRIPTION
This is a super simple guideline that states that you shouldn't define macros you don't use.

I'm also using it to test the [local workflow](https://github.com/Safety-Critical-Rust-Consortium/safety-critical-rust-coding-guidelines/blob/main/README.md), will open an issue after.